### PR TITLE
feat: decouple frontend from backend with REST API + WebSocket layer

### DIFF
--- a/app/oid_dialog.py
+++ b/app/oid_dialog.py
@@ -138,7 +138,7 @@ class OidDialog:
     
     @staticmethod
     def extract_oid(url: str) -> str:
-        pattern = r"^https://app\.overlays\.uno/control/([a-zA-Z0-9-]*)\??"
+        pattern = r"^https://app\.overlays\.uno/control/([a-zA-Z0-9_\-/.]+?)(?:\?.*)?$"
         match = re.match(pattern, url)
         if match:
             return match.group(1)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -365,3 +365,45 @@ def test_custom_overlay_is_visible_fallback(mock_load, backend, mock_requests_se
     conf.oid = "C-test_overlay"
     assert backend.is_visible() is True
     mock_requests_session.put.assert_not_called()
+
+
+def test_validate_custom_overlay_oid_is_valid(backend, mock_requests_session, conf):
+    """Tests that a C- prefixed custom overlay OID validates as VALID."""
+    conf.oid = "C-test_overlay"
+    result = backend.validate_and_store_model_for_oid("C-test_overlay")
+    assert result == State.OIDStatus.VALID
+
+
+def test_validate_custom_overlay_oid_with_style_is_valid(backend, mock_requests_session, conf):
+    """Tests that a custom overlay OID with style suffix validates as VALID."""
+    conf.oid = "C-test_overlay/line"
+    result = backend.validate_and_store_model_for_oid("C-test_overlay/line")
+    assert result == State.OIDStatus.VALID
+
+
+def test_extract_oid_preserves_underscores_in_uno_url():
+    """Tests that extract_oid correctly captures OIDs with underscores from Uno URLs."""
+    from app.oid_dialog import OidDialog
+    assert OidDialog.extract_oid("https://app.overlays.uno/control/abc_123") == "abc_123"
+
+
+def test_extract_oid_preserves_custom_overlay_oid():
+    """Tests that extract_oid returns custom overlay OIDs unchanged."""
+    from app.oid_dialog import OidDialog
+    assert OidDialog.extract_oid("C-mybroadcast") == "C-mybroadcast"
+    assert OidDialog.extract_oid("C-mybroadcast/line") == "C-mybroadcast/line"
+
+
+def test_extract_oid_handles_query_params():
+    """Tests that extract_oid strips query params from Uno URLs."""
+    from app.oid_dialog import OidDialog
+    assert OidDialog.extract_oid("https://app.overlays.uno/control/abc123?token=x") == "abc123"
+
+
+def test_api_schema_accepts_custom_overlay_oid():
+    """Tests that the API InitRequest schema accepts custom overlay OID formats."""
+    from app.api.schemas import InitRequest
+    req = InitRequest(oid="C-mybroadcast")
+    assert req.oid == "C-mybroadcast"
+    req2 = InitRequest(oid="C-mybroadcast/line")
+    assert req2.oid == "C-mybroadcast/line"


### PR DESCRIPTION
Introduce a new `app/api/` package that exposes all game actions as REST
endpoints and provides a WebSocket hub for real-time state updates. This
allows building alternative frontends with pure JavaScript frameworks
(React, Vue, Svelte, etc.) while the existing NiceGUI frontend continues
to work unchanged.

New modules:
- `app/api/routes.py` — REST + WS endpoints under /api/v1/
- `app/api/schemas.py` — Pydantic request/response models
- `app/api/game_service.py` — shared service layer (used by both NiceGUI and API)
- `app/api/session_manager.py` — thread-safe game session management
- `app/api/ws_hub.py` — WebSocket broadcast hub for real-time updates
- `app/api/dependencies.py` — auth (Bearer token) + session DI

Modified:
- `main.py` — mount API router
- `app/gui.py` — route actions through GameService, broadcast via WS hub
- `app/startup.py` — register sessions in SessionManager
- `app/authentication.py` — add check_api_key() + allow /api/ routes

Documentation:
- New `FRONTEND_DEVELOPMENT.md` — complete guide for building JS frontends
- Updated README, DEVELOPER_GUIDE, AGENTS with API layer info

https://claude.ai/code/session_013HSX7RZEWv5f2Bcty8uX8u