### PR TITLE
fix: fall back to HTTP when WS send_raw_config fails for custom overlays

### DIFF
--- a/app/backend.py
+++ b/app/backend.py
@@ -226,14 +226,13 @@ class Backend:
 
     def save_model(self, current_model, simple):
         Backend.logger.info('saving model...')
-        
+
         # Uno overlays store in user session, custom overlays store globally
         if self.is_custom_overlay(self.conf.oid):
             raw_payload = {"model": current_model}
-            # Prefer WS for raw_config persistence
-            if self._ws_client and self._ws_client.is_connected:
-                self._ws_client.send_raw_config(raw_payload)
-            else:
+            # Prefer WS for raw_config persistence; fall back to HTTP if WS send fails
+            ws_saved = self._ws_client and self._ws_client.is_connected and self._ws_client.send_raw_config(raw_payload)
+            if not ws_saved:
                 custom_id, _ = self.get_custom_overlay_id(self.conf.oid)
                 base_url = EnvVarsManager.get_custom_overlay_url().rstrip('/')
                 try:
@@ -285,10 +284,9 @@ class Backend:
         # update local overlay as well, fetching current state if custom
         if self.is_custom_overlay():
             raw_payload = {"customization": to_save}
-            # Prefer WS for raw_config persistence
-            if self._ws_client and self._ws_client.is_connected:
-                self._ws_client.send_raw_config(raw_payload)
-            else:
+            # Prefer WS for raw_config persistence; fall back to HTTP if WS send fails
+            ws_saved = self._ws_client and self._ws_client.is_connected and self._ws_client.send_raw_config(raw_payload)
+            if not ws_saved:
                 custom_id, _ = self.get_custom_overlay_id(self.conf.oid)
                 base_url = EnvVarsManager.get_custom_overlay_url().rstrip('/')
                 try:

--- a/app/backend.py
+++ b/app/backend.py
@@ -231,7 +231,7 @@ class Backend:
         if self.is_custom_overlay(self.conf.oid):
             raw_payload = {"model": current_model}
             # Prefer WS for raw_config persistence; fall back to HTTP if WS send fails
-            ws_saved = self._ws_client and self._ws_client.is_connected and self._ws_client.send_raw_config(raw_payload)
+            ws_saved = self.ws_connected and self._ws_client.send_raw_config(raw_payload)
             if not ws_saved:
                 custom_id, _ = self.get_custom_overlay_id(self.conf.oid)
                 base_url = EnvVarsManager.get_custom_overlay_url().rstrip('/')
@@ -285,7 +285,7 @@ class Backend:
         if self.is_custom_overlay():
             raw_payload = {"customization": to_save}
             # Prefer WS for raw_config persistence; fall back to HTTP if WS send fails
-            ws_saved = self._ws_client and self._ws_client.is_connected and self._ws_client.send_raw_config(raw_payload)
+            ws_saved = self.ws_connected and self._ws_client.send_raw_config(raw_payload)
             if not ws_saved:
                 custom_id, _ = self.get_custom_overlay_id(self.conf.oid)
                 base_url = EnvVarsManager.get_custom_overlay_url().rstrip('/')

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -407,3 +407,83 @@ def test_api_schema_accepts_custom_overlay_oid():
     assert req.oid == "C-mybroadcast"
     req2 = InitRequest(oid="C-mybroadcast/line")
     assert req2.oid == "C-mybroadcast/line"
+
+
+# --- WS raw_config fallback tests ---
+
+def _make_ws_client(send_raw_config_return=True):
+    """Helper that returns a mock WSControlClient."""
+    ws = MagicMock()
+    ws.is_connected = True
+    ws.send_raw_config.return_value = send_raw_config_return
+    ws.send_state.return_value = True
+    return ws
+
+
+def test_save_json_customization_ws_success_skips_http(backend, mock_requests_session, conf):
+    """When WS send_raw_config succeeds, HTTP POST to raw_config must NOT be called."""
+    conf.oid = "C-test_overlay"
+    conf.multithread = False
+    backend._ws_client = _make_ws_client(send_raw_config_return=True)
+
+    backend.save_json_customization({"preferredStyle": "line"})
+
+    raw_config_calls = [
+        c for c in mock_requests_session.post.call_args_list
+        if '/api/raw_config/' in str(c)
+    ]
+    assert raw_config_calls == [], "HTTP raw_config POST should be skipped when WS succeeds"
+    backend._ws_client.send_raw_config.assert_called_once()
+
+
+def test_save_json_customization_ws_failure_falls_back_to_http(backend, mock_requests_session, conf):
+    """When WS send_raw_config fails, the customization must still be saved via HTTP."""
+    conf.oid = "C-test_overlay"
+    conf.multithread = False
+    backend._ws_client = _make_ws_client(send_raw_config_return=False)
+
+    backend.save_json_customization({"preferredStyle": "line"})
+
+    raw_config_calls = [
+        c for c in mock_requests_session.post.call_args_list
+        if '/api/raw_config/' in str(c)
+    ]
+    assert len(raw_config_calls) == 1, "HTTP raw_config POST must be called as fallback when WS fails"
+    assert raw_config_calls[0][0][0] == "http://localhost:8000/api/raw_config/test_overlay"
+    posted_body = raw_config_calls[0][1]["json"]
+    assert posted_body == {"customization": {"preferredStyle": "line"}}
+
+
+def test_save_model_ws_success_skips_http(backend, mock_requests_session, conf):
+    """When WS send_raw_config succeeds, HTTP POST to raw_config must NOT be called."""
+    conf.oid = "C-test_overlay"
+    conf.multithread = False
+    backend._ws_client = _make_ws_client(send_raw_config_return=True)
+
+    backend.save_model({"Team 1 Sets": "1"}, simple=False)
+
+    raw_config_calls = [
+        c for c in mock_requests_session.post.call_args_list
+        if '/api/raw_config/' in str(c)
+    ]
+    assert raw_config_calls == [], "HTTP raw_config POST should be skipped when WS succeeds"
+    backend._ws_client.send_raw_config.assert_called_once()
+
+
+def test_save_model_ws_failure_falls_back_to_http(backend, mock_requests_session, conf):
+    """When WS send_raw_config fails, the model must still be saved via HTTP."""
+    conf.oid = "C-test_overlay"
+    conf.multithread = False
+    backend._ws_client = _make_ws_client(send_raw_config_return=False)
+
+    mock_model = {"Team 1 Sets": "1"}
+    backend.save_model(mock_model, simple=False)
+
+    raw_config_calls = [
+        c for c in mock_requests_session.post.call_args_list
+        if '/api/raw_config/' in str(c)
+    ]
+    assert len(raw_config_calls) == 1, "HTTP raw_config POST must be called as fallback when WS fails"
+    assert raw_config_calls[0][0][0] == "http://localhost:8000/api/raw_config/test_overlay"
+    posted_body = raw_config_calls[0][1]["json"]
+    assert posted_body == {"model": mock_model}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- When saving `preferredStyle` (or any customization/model) for a custom overlay, the code preferred WebSocket for `raw_config` persistence but silently ignored the return value of `send_raw_config`. If the WS send failed, no HTTP fallback was attempted, leaving the overlay server's persistent storage unchanged.
- On any subsequent overlay reload the server returned the stale config, causing the old style to reappear — the "keeps the previous selection" symptom reported.
- Fixed both `save_json_customization` and `save_model` to check the return value and fall back to an HTTP POST when the WS send returns `False`.

## What changed

**`app/backend.py`**
- `save_json_customization`: replaced unconditional `send_raw_config` call with a guarded call whose return value drives an HTTP fallback.
- `save_model`: same change applied consistently.

**`tests/test_backend.py`**
- 4 new tests covering WS-success (HTTP skipped) and WS-failure (HTTP fallback called with correct payload) for both methods.

## Test plan

- [ ] All 37 existing backend tests still pass
- [ ] `test_save_json_customization_ws_success_skips_http` — HTTP raw_config not called when WS succeeds
- [ ] `test_save_json_customization_ws_failure_falls_back_to_http` — HTTP raw_config called with correct body when WS fails
- [ ] `test_save_model_ws_success_skips_http` — HTTP raw_config not called when WS succeeds
- [ ] `test_save_model_ws_failure_falls_back_to_http` — HTTP raw_config called with correct body when WS fails

## Note on overlay provider

If the style still doesn't update **instantly** (without an overlay reload), that is a separate concern on the overlay provider side: the overlay needs to watch `overlay_control.preferredStyle` in live state updates and apply it dynamically. The backend already sends `preferredStyle` correctly in every `update_local_overlay` push.

https://claude.ai/code/session_01VKf7N8R8WNPdGWNFyhrKQn
EOF
)