### PR TITLE
docs+audit: authentication coverage audit + /list/overlay gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,11 +218,15 @@ Full list in [README.md](README.md).
 | `/api/config/{overlay_id}` | Overlay config (output URL, available styles) |
 | `/api/state/{overlay_id}` | Overlay state update endpoint |
 | `/create/overlay/{overlay_id}` | Create a new overlay |
-| `/list/overlay` | List all overlays |
+| `/list/overlay` | List all overlays — requires `OVERLAY_MANAGER_PASSWORD` (see `AUTHENTICATION.md` F-4) |
 | `/api/themes` | List preset overlay themes |
 | `/health` | Health check — returns `200 OK` with timestamp |
 | `/sw.js` | PWA service worker (from frontend build) |
 | `/manifest.webmanifest` | PWA manifest (from frontend build) |
+
+For the complete authentication matrix — including the overlay router
+mutation endpoints that are currently *unauthenticated* — see
+[AUTHENTICATION.md](AUTHENTICATION.md).
 
 ---
 

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -1,0 +1,218 @@
+# Authentication Coverage Audit
+
+Last audited: 2026-04-18 (branch `claude/auth-middleware-audit`).
+
+This document is the single source of truth for **which routes are
+protected, which are intentionally public, and where the gaps are**. It
+complements `README.md` (user-facing env var setup) and
+`DEVELOPER_GUIDE.md` (code organisation) with a route-by-route inventory.
+
+## 1. Auth mechanisms in use
+
+The codebase has **three independent auth layers**, each gated by a
+different environment variable:
+
+| Layer | Env var | How it's enforced | Where |
+| :--- | :--- | :--- | :--- |
+| `AuthMiddleware` | `SCOREBOARD_USERS` | Registered as middleware when `PasswordAuthenticator.do_authenticate_users()` returns `True`. **The current implementation is a pass-through `call_next`** — it does not block any request. | `app/authentication.py`, registered in `app/bootstrap.py::_register_auth` |
+| `verify_api_key` dependency | `SCOREBOARD_USERS` | Per-route `Depends(verify_api_key)`. Returns `401` when the header is missing, `403` when the Bearer token does not match any configured user. | `app/api/dependencies.py` |
+| `require_admin` dependency | `OVERLAY_MANAGER_PASSWORD` | Per-route `Depends(require_admin)`. Returns `503` when the password env var is unset, `401` when the header is missing, `403` when the Bearer token does not match. | `app/admin/routes.py` |
+
+The `check_oid_access` helper is a second-level check layered on top of
+`verify_api_key`: it compares the caller's `control` OID (stored in
+`SCOREBOARD_USERS`) against the OID in the request and returns `403`
+when they differ.
+
+> **Finding F-1 (low):** `AuthMiddleware.dispatch` is a pass-through and
+> has been since the REST API adopted dependency-based auth. It is kept
+> as a hook for future static-asset protection, but the module docstring
+> suggests it still "restricts access" — this is misleading. Either
+> delete the class or update the docstring.
+
+## 2. Route inventory
+
+Legend: `Y` = authenticated when the corresponding env var is set;
+`—` = always public; `L` = leaks data (see findings).
+
+### 2.1 Scoreboard REST API — `api_router` (`app/api/routes.py`)
+
+Prefix `/api/v1`. Every route below has `Depends(verify_api_key)`; the
+ones that also take an `oid` go through `check_oid_access` transitively
+via `get_session` (or explicitly inside the handler).
+
+| Method | Path | Auth | Notes |
+| :--- | :--- | :--- | :--- |
+| `POST` | `/session/init` | Y + OID | Explicit `check_oid_access` |
+| `GET` | `/state` | Y + OID | Via `get_session` |
+| `GET` | `/customization` | Y + OID | |
+| `GET` | `/config` | Y + OID | |
+| `POST` | `/game/add-point` | Y + OID | |
+| `POST` | `/game/add-set` | Y + OID | |
+| `POST` | `/game/add-timeout` | Y + OID | |
+| `POST` | `/game/change-serve` | Y + OID | |
+| `POST` | `/game/set-score` | Y + OID | |
+| `POST` | `/game/set-sets` | Y + OID | |
+| `POST` | `/game/reset` | Y + OID | |
+| `POST` | `/display/visibility` | Y + OID | |
+| `POST` | `/display/simple-mode` | Y + OID | |
+| `PUT` | `/customization` | Y + OID | |
+| `GET` | `/overlays` | Y | Filters by `allowed_users` |
+| `GET` | `/teams` | Y | |
+| `GET` | `/themes` | Y | |
+| `GET` | `/links` | Y + OID | |
+| `GET` | `/styles` | Y + OID | |
+| `WS` | `/ws` | Y + OID | Explicit `check_oid_access`; accepts token via `?token=…` query param |
+
+### 2.2 Admin — `admin_router` + `admin_page_router` (`app/admin/routes.py`)
+
+| Method | Path | Auth | Notes |
+| :--- | :--- | :--- | :--- |
+| `GET` | `/manage` | — | Static HTML page; JS prompts for password client-side and stores it in `sessionStorage`. |
+| `GET` | `/api/v1/admin/status` | — | Returns `{"enabled": bool}` only — does not leak the password itself. |
+| `POST` | `/api/v1/admin/login` | `require_admin` | Used by the management page to validate the password. |
+| `GET` | `/api/v1/admin/overlays` | `require_admin` | |
+| `POST` | `/api/v1/admin/overlays` | `require_admin` | |
+| `PUT` | `/api/v1/admin/overlays/{name}` | `require_admin` | |
+| `DELETE` | `/api/v1/admin/overlays/{name}` | `require_admin` | |
+
+### 2.3 Overlay server — `overlay_router` (`app/overlay/routes.py`)
+
+This router powers the **in-process custom overlay server**
+(`LocalOverlayBackend`) and is mounted when
+`_register_overlay_routes()` finds the `overlay_templates/` directory.
+It is **also consumed by `CustomOverlayBackend` when a remote app
+instance points at this server** (`APP_CUSTOM_OVERLAY_URL=…`).
+
+| Method | Path | Auth today | Classification |
+| :--- | :--- | :--- | :--- |
+| `GET` | `/favicon.ico` | — | Public OK |
+| `GET` | `/overlay/{overlay_id_or_output_key}` | — | **Capability URL** — intentionally public for OBS. Accepts either the raw OID or its SHA-256 prefix ("output key"). See F-2. |
+| `WS` | `/ws/{overlay_id}` | — | **Capability URL** — public for OBS browser sources. See F-2. |
+| `POST` | `/api/state/{overlay_id}` | — | **F-3 (high): unauthenticated mutation.** Anyone who can guess an overlay ID can overwrite its live scoreboard state. |
+| `GET`,`POST` | `/create/overlay/{overlay_id}` | — | **F-3 (high): unauthenticated mutation.** `GET` creates an overlay — drive-by requests suffice. |
+| `GET`,`POST`,`DELETE` | `/delete/overlay/{overlay_id}` | — | **F-3 (high): unauthenticated mutation.** `GET` deletes. |
+| `GET` | `/list/overlay` | — | **F-4 (high): recon.** Returns every overlay id plus its deterministic output key. Trivially defeats the capability-URL design. |
+| `GET` | `/api/raw_config/{overlay_id}` | — | **F-5 (medium): leaks model + customization.** |
+| `POST` | `/api/raw_config/{overlay_id}` | — | **F-3 (high): unauthenticated mutation.** |
+| `GET` | `/api/config/{overlay_id}` | — | **F-5 (medium):** returns `outputUrl` + `outputKey`, breaking the capability-URL assumption for any known OID. |
+| `GET` | `/api/themes` | — | Public OK (theme name list is not sensitive). |
+| `POST` | `/api/theme/{overlay_id}/{theme_name}` | — | **F-3 (high): unauthenticated mutation.** |
+
+### 2.4 Static mounts and system endpoints — `app/bootstrap.py`
+
+| Method | Path | Auth | Notes |
+| :--- | :--- | :--- | :--- |
+| `GET` | `/fonts/**` | — | Static assets |
+| `GET` | `/static/**` | — | Overlay static assets |
+| `GET` | `/pwa/**` | — | PWA manifest/icons |
+| `GET` | `/assets/**` | — | SPA build output |
+| `GET` | `/sw.js` | — | PWA service worker |
+| `GET` | `/manifest.webmanifest` | — | PWA manifest |
+| `GET` | `/manifest.json` | — | PWA manifest |
+| `GET` | `/health` | — | Health check |
+| `GET` | `/**` (SPA fallback) | — | Serves `index.html` for unknown paths |
+
+All of these are intentionally public. If a future change needs to gate
+static assets (e.g. hiding the SPA behind a login wall), the hook point
+is `AuthMiddleware.dispatch` — see F-1.
+
+## 3. Findings
+
+### F-1 — `AuthMiddleware` is a no-op (low)
+
+`AuthMiddleware.dispatch` just calls `call_next` today, yet the class
+docstring reads "Restrict access to the API when user authentication is
+enabled." The behavior has shifted to per-route dependencies, but the
+module is still registered in `_register_auth()` when
+`SCOREBOARD_USERS` is set. This is misleading but harmless.
+
+**Recommendation:** update the docstring to clearly say "no-op hook for
+future static-asset protection", or remove the middleware and the
+`_register_auth()` registration. Either change is fine; the important
+thing is that code and docs agree.
+
+### F-2 — Overlay capability URL is weakened by `resolve_overlay_id` (medium)
+
+`/overlay/{…}` and `/ws/{…}` both call
+`OverlayStateStore.resolve_overlay_id`, which accepts **either** the
+raw overlay ID or its SHA-256 prefix. Because `get_output_key` is a
+deterministic hash of the ID, the key is only a capability as long as
+the raw ID is not learnable. `/list/overlay`, `/api/config/{id}`, and
+`/overlay/{raw_id}` itself all leak the mapping.
+
+**Recommendation:** change `resolve_overlay_id` to accept the output
+key only. The in-process backend already constructs URLs using the
+output key (`LocalOverlayBackend.fetch_output_token`), so this is
+backward-compatible for the default deployment. OBS configurations
+that hardcode `/overlay/{raw_id}` would need updating — call this out
+in release notes.
+
+### F-3 — Unauthenticated mutation endpoints on the overlay router (high)
+
+The overlay router exposes seven mutation endpoints without any auth:
+
+- `POST /api/state/{id}`
+- `GET`/`POST /create/overlay/{id}`
+- `GET`/`POST`/`DELETE /delete/overlay/{id}`
+- `POST /api/raw_config/{id}`
+- `POST /api/theme/{id}/{name}`
+
+These are a direct data-integrity risk: anyone with network access to
+the app (or who gets a victim to visit a crafted URL, since `GET` is
+accepted for create/delete) can overwrite, create, or destroy overlays.
+
+**Recommendation:** introduce a new env var `OVERLAY_SERVER_TOKEN` and
+a matching `require_overlay_server_token` dependency. Apply it to all
+mutation endpoints. When the env var is unset, log a startup warning
+but leave the endpoints open (for backward compatibility with existing
+deployments). `CustomOverlayBackend` would need to learn to send the
+token — that's the only client-side change.
+
+### F-4 — `/list/overlay` leaks all overlay IDs and output keys (high)
+
+`GET /list/overlay` returns `{"overlays": [{"id": "...", "output_key": "..."}, ...]}`
+for every overlay on disk. This is the single most damaging recon
+primitive today — it defeats the capability-URL design (F-2) for every
+overlay in one request, and there is no known consumer in this repo.
+
+**Recommendation:** gate behind `require_admin`. Already implemented as
+part of this audit PR; the behavior change is:
+
+- When `OVERLAY_MANAGER_PASSWORD` is set → requires `Authorization: Bearer <password>`.
+- When unset → endpoint returns `503 Overlay management is disabled.`
+  instead of data. Operators that currently rely on `/list/overlay`
+  being open must either set `OVERLAY_MANAGER_PASSWORD` or open a
+  follow-up issue.
+
+### F-5 — Read endpoints leak config (medium)
+
+- `GET /api/raw_config/{id}` returns the full model and customization
+  (team names, logos, colors).
+- `GET /api/config/{id}` returns the `outputUrl` and `outputKey` —
+  useful for an attacker building an OBS source against someone else's
+  overlay.
+
+**Recommendation:** same gate proposed in F-3 (`require_overlay_server_token`).
+`CustomOverlayBackend` calls both endpoints and would need to send
+the token.
+
+## 4. Tripwire tests
+
+`tests/test_auth_coverage.py` pins the current behavior of every
+sensitive route so that future changes to auth coverage cannot slip in
+silently. The matrix is parametrized over
+`(method, path, expected_status_without_token, expected_status_with_valid_token)`
+with `SCOREBOARD_USERS` / `OVERLAY_MANAGER_PASSWORD` set as
+appropriate. When a finding is fixed, update the expected status in
+that test.
+
+## 5. Follow-up plan
+
+The items below are **recommendations**, not changes applied in this
+audit PR (except F-4, which has minimal blast radius):
+
+1. Fix F-1 (docstring or deletion) — trivial.
+2. Fix F-3 and F-5 together by introducing `OVERLAY_SERVER_TOKEN` —
+   requires coordinated change to `CustomOverlayBackend`.
+3. Fix F-2 by hardening `resolve_overlay_id` — call out in release
+   notes.

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -91,7 +91,7 @@ instance points at this server** (`APP_CUSTOM_OVERLAY_URL=…`).
 | `POST` | `/api/state/{overlay_id}` | — | **F-3 (high): unauthenticated mutation.** Anyone who can guess an overlay ID can overwrite its live scoreboard state. |
 | `GET`,`POST` | `/create/overlay/{overlay_id}` | — | **F-3 (high): unauthenticated mutation.** `GET` creates an overlay — drive-by requests suffice. |
 | `GET`,`POST`,`DELETE` | `/delete/overlay/{overlay_id}` | — | **F-3 (high): unauthenticated mutation.** `GET` deletes. |
-| `GET` | `/list/overlay` | — | **F-4 (high): recon.** Returns every overlay id plus its deterministic output key. Trivially defeats the capability-URL design. |
+| `GET` | `/list/overlay` | `require_admin` | **F-4 (high): recon.** Returns every overlay id plus its deterministic output key. Trivially defeats the capability-URL design. Gated in this audit PR. |
 | `GET` | `/api/raw_config/{overlay_id}` | — | **F-5 (medium): leaks model + customization.** |
 | `POST` | `/api/raw_config/{overlay_id}` | — | **F-3 (high): unauthenticated mutation.** |
 | `GET` | `/api/config/{overlay_id}` | — | **F-5 (medium):** returns `outputUrl` + `outputKey`, breaking the capability-URL assumption for any known OID. |

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -275,6 +275,12 @@ the React scoreboard UI.
 The routers are registered in `main.py` **before** the SPA mount so that
 `/manage` is served by FastAPI rather than falling through to `index.html`.
 
+> For the full per-route authentication matrix (scoreboard API, admin
+> API, overlay server, static mounts) and known gaps, see
+> [AUTHENTICATION.md](AUTHENTICATION.md). When adding a new route,
+> classify it there and add a matching entry in
+> `tests/test_auth_coverage.py`.
+
 ### C. Configuration & Extras
 
 #### `app/customization.py`

--- a/README.md
+++ b/README.md
@@ -278,6 +278,10 @@ Import configuration from an external resource via `REMOTE_CONFIG_URL`. The appl
 | `/api/themes` | List preset overlay themes |
 | `/health` | Health check endpoint. Returns `200 OK` with a timestamp. |
 
+For a full audit of every route and its authentication requirements
+(including the overlay server endpoints consumed by OBS and
+`CustomOverlayBackend`), see [AUTHENTICATION.md](AUTHENTICATION.md).
+
 ---
 
 ## Troubleshooting

--- a/app/authentication.py
+++ b/app/authentication.py
@@ -10,16 +10,17 @@ logger = logging.getLogger("Authenticator")
 
 
 class AuthMiddleware(BaseHTTPMiddleware):
-    """Restrict access to the API when user authentication is enabled.
+    """No-op hook reserved for future server-level auth.
 
-    The REST API endpoints have their own ``verify_api_key`` dependency,
-    so this middleware currently just passes requests through.  It is kept
-    as a hook for future server-level auth (e.g. static asset protection).
+    All request-level authentication currently lives in per-route
+    dependencies (``app.api.dependencies.verify_api_key`` and
+    ``app.admin.routes.require_admin``). This middleware exists solely as
+    a registration point so that future cross-cutting concerns — such as
+    gating static assets or the SPA behind a login wall — can be added
+    without touching every route. See ``AUTHENTICATION.md`` (F-1).
     """
 
     async def dispatch(self, request: Request, call_next):
-        # The API layer handles its own Bearer-token auth via dependencies.
-        # Static assets (/fonts, /pwa, /health) are public.
         return await call_next(request)
 
 

--- a/app/overlay/routes.py
+++ b/app/overlay/routes.py
@@ -13,12 +13,13 @@ import time
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
-from fastapi import APIRouter, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse, Response
 from fastapi.routing import APIRoute
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, ConfigDict
 
+from app.admin.routes import require_admin
 from app.overlay.state_store import OverlayStateStore, deep_merge, normalize_state
 
 logger = logging.getLogger(__name__)
@@ -262,8 +263,14 @@ def create_overlay_router(
             return {"status": "deleted", "overlay_id": overlay_id}
         raise HTTPException(status_code=404, detail="Overlay not found")
 
-    @router.get("/list/overlay")
+    @router.get("/list/overlay", dependencies=[Depends(require_admin)])
     async def list_overlays():
+        """Return every overlay id plus its output key.
+
+        Gated behind ``OVERLAY_MANAGER_PASSWORD`` because the response
+        defeats the capability-URL design of ``/overlay/{output_key}``.
+        See ``AUTHENTICATION.md`` (F-4).
+        """
         return {"overlays": store.list_overlays()}
 
     # -- Raw config --------------------------------------------------------

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -2598,7 +2598,19 @@
     },
     "/list/overlay": {
       "get": {
+        "description": "Return every overlay id plus its output key.\n\nGated behind ``OVERLAY_MANAGER_PASSWORD`` because the response\ndefeats the capability-URL design of ``/overlay/{output_key}``.\nSee ``AUTHENTICATION.md`` (F-4).",
         "operationId": "list_overlays_list_overlay_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -2607,6 +2619,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "List Overlays",

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -569,7 +569,14 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List Overlays */
+        /**
+         * List Overlays
+         * @description Return every overlay id plus its output key.
+         *
+         *     Gated behind ``OVERLAY_MANAGER_PASSWORD`` because the response
+         *     defeats the capability-URL design of ``/overlay/{output_key}``.
+         *     See ``AUTHENTICATION.md`` (F-4).
+         */
         get: operations["list_overlays_list_overlay_get"];
         put?: never;
         post?: never;
@@ -2149,7 +2156,9 @@ export interface operations {
     list_overlays_list_overlay_get: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                authorization?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -2162,6 +2171,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/tests/test_auth_coverage.py
+++ b/tests/test_auth_coverage.py
@@ -1,0 +1,271 @@
+"""Tripwire tests pinning the authentication coverage documented in
+``AUTHENTICATION.md``. Any change to the auth behavior of a route
+below should update the expected status codes here and the companion
+entry in ``AUTHENTICATION.md``.
+
+The tests deliberately assert on *coarse* outcomes: either "auth
+rejects" (``401``/``403``) or "auth is not consulted" (anything else).
+They do not care about downstream business-logic responses, so
+fixtures stay minimal and the matrix is easy to scan.
+"""
+
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fastapi.templating import Jinja2Templates
+
+from app.admin import admin_page_router, admin_router
+from app.admin.store import managed_overlays_store
+from app.api import api_router
+from app.overlay.routes import create_overlay_router
+from app.overlay.state_store import OverlayStateStore
+
+
+API_USER_PASSWORD = "user-secret"
+ADMIN_PASSWORD = "admin-secret"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch, tmp_path):
+    managed_overlays_store._reset_for_tests(str(tmp_path / "admin"))
+    monkeypatch.delenv("SCOREBOARD_USERS", raising=False)
+    monkeypatch.delenv("OVERLAY_MANAGER_PASSWORD", raising=False)
+    monkeypatch.delenv("PREDEFINED_OVERLAYS", raising=False)
+    yield
+    managed_overlays_store._reset_for_tests(str(tmp_path / "admin"))
+
+
+@pytest.fixture
+def api_client_with_users(monkeypatch):
+    users = json.dumps({"alice": {"password": API_USER_PASSWORD}})
+    monkeypatch.setenv("SCOREBOARD_USERS", users)
+    app = FastAPI()
+    app.include_router(api_router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def admin_client(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", ADMIN_PASSWORD)
+    app = FastAPI()
+    app.include_router(admin_page_router)
+    app.include_router(admin_router)
+    return TestClient(app)
+
+
+def _make_overlay_app(tmp_path):
+    store = OverlayStateStore(
+        data_dir=str(tmp_path / "overlays"),
+        templates_dir=str(tmp_path / "templates"),
+    )
+
+    class _FakeBroadcast:
+        def get_client_count(self, _overlay_id):
+            return 0
+
+        async def cleanup_overlay(self, _overlay_id):
+            return None
+
+        def add_client(self, *_args, **_kwargs):
+            return None
+
+        def remove_client(self, *_args, **_kwargs):
+            return None
+
+    templates = Jinja2Templates(directory=str(tmp_path / "templates"))
+    app = FastAPI()
+    app.include_router(create_overlay_router(store, _FakeBroadcast(), templates))
+    return app
+
+
+@pytest.fixture
+def overlay_client_no_admin(tmp_path):
+    """Overlay router with no admin password configured."""
+    return TestClient(_make_overlay_app(tmp_path))
+
+
+@pytest.fixture
+def overlay_client_with_admin(tmp_path, monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", ADMIN_PASSWORD)
+    return TestClient(_make_overlay_app(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Scoreboard REST API (/api/v1/*) — verify_api_key
+# ---------------------------------------------------------------------------
+
+
+SCOREBOARD_SAMPLE_ROUTES = [
+    ("GET", "/api/v1/state?oid=anything"),
+    ("GET", "/api/v1/customization?oid=anything"),
+    ("GET", "/api/v1/config?oid=anything"),
+    ("GET", "/api/v1/teams"),
+    ("GET", "/api/v1/themes"),
+    ("GET", "/api/v1/overlays"),
+    ("GET", "/api/v1/links?oid=anything"),
+    ("GET", "/api/v1/styles?oid=anything"),
+    ("POST", "/api/v1/session/init"),
+    ("POST", "/api/v1/game/add-point?oid=anything"),
+    ("POST", "/api/v1/game/add-set?oid=anything"),
+    ("POST", "/api/v1/game/add-timeout?oid=anything"),
+    ("POST", "/api/v1/game/change-serve?oid=anything"),
+    ("POST", "/api/v1/game/set-score?oid=anything"),
+    ("POST", "/api/v1/game/set-sets?oid=anything"),
+    ("POST", "/api/v1/game/reset?oid=anything"),
+    ("POST", "/api/v1/display/visibility?oid=anything"),
+    ("POST", "/api/v1/display/simple-mode?oid=anything"),
+    ("PUT", "/api/v1/customization?oid=anything"),
+]
+
+
+@pytest.mark.parametrize("method,path", SCOREBOARD_SAMPLE_ROUTES)
+def test_scoreboard_api_rejects_missing_token(api_client_with_users, method, path):
+    response = api_client_with_users.request(method, path, json={})
+    assert response.status_code == 401, (
+        f"{method} {path} should 401 without a Bearer token when "
+        f"SCOREBOARD_USERS is set (got {response.status_code})"
+    )
+
+
+@pytest.mark.parametrize("method,path", SCOREBOARD_SAMPLE_ROUTES)
+def test_scoreboard_api_rejects_invalid_token(api_client_with_users, method, path):
+    response = api_client_with_users.request(
+        method, path, json={}, headers={"Authorization": "Bearer wrong"},
+    )
+    assert response.status_code == 403, (
+        f"{method} {path} should 403 with an invalid Bearer token "
+        f"(got {response.status_code})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Admin API (/api/v1/admin/*) — require_admin
+# ---------------------------------------------------------------------------
+
+
+ADMIN_PROTECTED_ROUTES = [
+    ("POST", "/api/v1/admin/login"),
+    ("GET", "/api/v1/admin/overlays"),
+    ("POST", "/api/v1/admin/overlays"),
+    ("PUT", "/api/v1/admin/overlays/anything"),
+    ("DELETE", "/api/v1/admin/overlays/anything"),
+]
+
+
+@pytest.mark.parametrize("method,path", ADMIN_PROTECTED_ROUTES)
+def test_admin_api_rejects_missing_token(admin_client, method, path):
+    response = admin_client.request(method, path, json={})
+    assert response.status_code == 401
+
+
+@pytest.mark.parametrize("method,path", ADMIN_PROTECTED_ROUTES)
+def test_admin_api_rejects_invalid_token(admin_client, method, path):
+    response = admin_client.request(
+        method, path, json={}, headers={"Authorization": "Bearer wrong"},
+    )
+    assert response.status_code == 403
+
+
+def test_admin_status_is_public(admin_client):
+    """`/api/v1/admin/status` intentionally exposes only a boolean."""
+    response = admin_client.get("/api/v1/admin/status")
+    assert response.status_code == 200
+    assert response.json() == {"enabled": True}
+
+
+# ---------------------------------------------------------------------------
+# Overlay router — /list/overlay is gated; mutation routes are currently open
+# ---------------------------------------------------------------------------
+
+
+def test_list_overlay_requires_admin_when_configured(overlay_client_with_admin):
+    """F-4: `/list/overlay` now requires OVERLAY_MANAGER_PASSWORD."""
+    missing = overlay_client_with_admin.get("/list/overlay")
+    assert missing.status_code == 401
+
+    wrong = overlay_client_with_admin.get(
+        "/list/overlay", headers={"Authorization": "Bearer wrong"},
+    )
+    assert wrong.status_code == 403
+
+    ok = overlay_client_with_admin.get(
+        "/list/overlay", headers={"Authorization": f"Bearer {ADMIN_PASSWORD}"},
+    )
+    assert ok.status_code == 200
+    assert "overlays" in ok.json()
+
+
+def test_list_overlay_disabled_when_admin_unset(overlay_client_no_admin):
+    """When OVERLAY_MANAGER_PASSWORD is unset, `/list/overlay` returns 503
+    instead of leaking overlay ids + output keys (was 200 pre-audit)."""
+    response = overlay_client_no_admin.get("/list/overlay")
+    assert response.status_code == 503
+
+
+# The following routes are documented as *unauthenticated* (findings F-3
+# and F-5). These tests pin the current behavior so that adding auth to
+# any of them surfaces in this file instead of slipping through silently.
+# When a follow-up PR fixes F-3 / F-5, update the expected assertions.
+
+
+OVERLAY_OPEN_MUTATION_ROUTES = [
+    ("POST", "/api/state/any-id", {}),
+    ("GET", "/create/overlay/any-id", None),
+    ("POST", "/create/overlay/any-id", None),
+    ("GET", "/delete/overlay/any-id", None),
+    ("POST", "/delete/overlay/any-id", None),
+    ("DELETE", "/delete/overlay/any-id", None),
+    ("POST", "/api/theme/any-id/dark", None),
+]
+
+
+@pytest.mark.parametrize("method,path,body", OVERLAY_OPEN_MUTATION_ROUTES)
+def test_overlay_mutation_routes_are_currently_open(
+    overlay_client_with_admin, method, path, body,
+):
+    """F-3: these routes accept writes with no auth header. Test pins the
+    status quo so a future fix updates this file."""
+    response = overlay_client_with_admin.request(method, path, json=body)
+    assert response.status_code not in (401, 403), (
+        f"{method} {path} unexpectedly rejected auth "
+        f"({response.status_code}). If this is the intended behavior, "
+        f"update AUTHENTICATION.md F-3 and flip this assertion."
+    )
+
+
+OVERLAY_OPEN_READ_ROUTES = [
+    ("GET", "/api/config/any-id"),
+    ("GET", "/api/themes"),
+]
+
+
+@pytest.mark.parametrize("method,path", OVERLAY_OPEN_READ_ROUTES)
+def test_overlay_read_routes_are_currently_open(
+    overlay_client_with_admin, method, path,
+):
+    """F-5: these routes return data without auth. `/api/themes` is
+    intentionally public; `/api/config/{id}` is a known leak."""
+    response = overlay_client_with_admin.request(method, path)
+    assert response.status_code not in (401, 403)
+
+
+def test_overlay_raw_config_get_is_currently_open(overlay_client_with_admin):
+    """F-5: raw_config returns 404 on missing overlays — still reachable
+    without auth, which is the leak we are documenting."""
+    response = overlay_client_with_admin.get("/api/raw_config/any-id")
+    assert response.status_code not in (401, 403)
+
+
+def test_overlay_raw_config_post_is_currently_open(overlay_client_with_admin):
+    """F-3: raw_config POST mutates state with no auth header."""
+    response = overlay_client_with_admin.post(
+        "/api/raw_config/any-id", json={"model": {}},
+    )
+    assert response.status_code not in (401, 403)


### PR DESCRIPTION
## Summary

- **`AUTHENTICATION.md`** — new single-source-of-truth audit of every route/mount (scoreboard API, admin router, overlay server, static mounts) with five findings F-1..F-5 and recommended fixes. Headline finding: the overlay router exposes seven unauthenticated mutation endpoints (`/api/state/{id}`, `/create/overlay/{id}`, `/delete/overlay/{id}`, `POST /api/raw_config/{id}`, `POST /api/theme/{id}/{name}`).
- **`/list/overlay` now requires `OVERLAY_MANAGER_PASSWORD`** (F-4). Before this change the endpoint returned every overlay id plus its SHA-256 output key, defeating the capability-URL design of `/overlay/{output_key}`. No in-repo code consumes it. When the password env var is unset the route returns `503` instead of leaking data.
- **Fix the misleading `AuthMiddleware` docstring** (F-1): it is (and always has been) a pass-through hook reserved for future static-asset protection, not a real auth gate.
- **`tests/test_auth_coverage.py`** — 62 new parametrized tripwire tests pinning the current auth behavior of every sensitive route. Any future change to coverage must update this file.
- Cross-link `AUTHENTICATION.md` from `README.md`, `DEVELOPER_GUIDE.md`, and `AGENTS.md`.
- Regenerate `frontend/schema/openapi.json` + `schema.d.ts` (required by the CI drift guard).

No behavior change for the scoreboard REST API or admin router — they were already correctly gated by `verify_api_key` / `require_admin` respectively.

## Findings called out for follow-up (not fixed here)

| Finding | Severity | Summary |
| :--- | :--- | :--- |
| F-1 | low | `AuthMiddleware.dispatch` is a pass-through — docstring now reflects that. Safe to delete the middleware in a follow-up if the future-hook use case is abandoned. |
| F-2 | medium | `resolve_overlay_id` accepts both the raw OID and the output key, so the capability URL is weaker than it looks. |
| F-3 | high | Seven unauthenticated mutation endpoints on the overlay router. Fix requires a new `OVERLAY_SERVER_TOKEN` env var + matching `CustomOverlayBackend` change. |
| F-4 | high | **Fixed in this PR** — `/list/overlay` now requires admin. |
| F-5 | medium | `GET /api/raw_config/{id}` and `GET /api/config/{id}` leak config. Same fix as F-3. |

## Test plan

- [x] `pytest tests/ -m "not mobile_browser"` → 244 passed (182 existing + 62 new coverage tests).
- [x] `cd frontend && npm run typecheck` → clean.
- [x] `cd frontend && npm test -- --run` → 158 passed.
- [x] Regenerated schemas committed; CI drift guard should pass.
- [ ] CI green on PR.

https://claude.ai/code/session_01NUAp3CkDRkUKyVo7VAQ4z4