### PR TITLE
auth: harden overlay server (F-1, F-2, F-3/F-5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ volley-overlay-control/
 │   ├── ws_client.py           # Persistent WebSocket client for external overlay servers (optional)
 │   ├── customization.py       # Team names, colors, logos, layout geometry
 │   ├── conf.py                # Configuration object — wraps env vars
-│   ├── authentication.py      # AuthMiddleware, PasswordAuthenticator
+│   ├── authentication.py      # PasswordAuthenticator (API-key validation)
 │   ├── app_storage.py         # In-memory key-value storage
 │   ├── oid_utils.py           # OID parsing utilities (extract_oid, compose_output)
 │   ├── env_vars_manager.py    # Centralized env var access with remote config caching

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -1,6 +1,6 @@
 # Authentication Coverage Audit
 
-Last audited: 2026-04-18 (branch `claude/auth-middleware-audit`).
+Last audited: 2026-04-18 (branch `claude/overlay-auth-hardening`).
 
 This document is the single source of truth for **which routes are
 protected, which are intentionally public, and where the gaps are**. It
@@ -14,20 +14,14 @@ different environment variable:
 
 | Layer | Env var | How it's enforced | Where |
 | :--- | :--- | :--- | :--- |
-| `AuthMiddleware` | `SCOREBOARD_USERS` | Registered as middleware when `PasswordAuthenticator.do_authenticate_users()` returns `True`. **The current implementation is a pass-through `call_next`** — it does not block any request. | `app/authentication.py`, registered in `app/bootstrap.py::_register_auth` |
 | `verify_api_key` dependency | `SCOREBOARD_USERS` | Per-route `Depends(verify_api_key)`. Returns `401` when the header is missing, `403` when the Bearer token does not match any configured user. | `app/api/dependencies.py` |
 | `require_admin` dependency | `OVERLAY_MANAGER_PASSWORD` | Per-route `Depends(require_admin)`. Returns `503` when the password env var is unset, `401` when the header is missing, `403` when the Bearer token does not match. | `app/admin/routes.py` |
+| `require_overlay_server_token` dependency | `OVERLAY_SERVER_TOKEN` | Per-route `Depends(require_overlay_server_token)`. **No-op when the env var is unset** (logs a startup warning). When set: `401` without header, `403` with a mismatched Bearer token. | `app/overlay/routes.py` |
 
 The `check_oid_access` helper is a second-level check layered on top of
 `verify_api_key`: it compares the caller's `control` OID (stored in
 `SCOREBOARD_USERS`) against the OID in the request and returns `403`
 when they differ.
-
-> **Finding F-1 (low):** `AuthMiddleware.dispatch` is a pass-through and
-> has been since the REST API adopted dependency-based auth. It is kept
-> as a hook for future static-asset protection, but the module docstring
-> suggests it still "restricts access" — this is misleading. Either
-> delete the class or update the docstring.
 
 ## 2. Route inventory
 
@@ -83,20 +77,25 @@ This router powers the **in-process custom overlay server**
 It is **also consumed by `CustomOverlayBackend` when a remote app
 instance points at this server** (`APP_CUSTOM_OVERLAY_URL=…`).
 
-| Method | Path | Auth today | Classification |
+| Method | Path | Auth | Classification |
 | :--- | :--- | :--- | :--- |
 | `GET` | `/favicon.ico` | — | Public OK |
-| `GET` | `/overlay/{overlay_id_or_output_key}` | — | **Capability URL** — intentionally public for OBS. Accepts either the raw OID or its SHA-256 prefix ("output key"). See F-2. |
-| `WS` | `/ws/{overlay_id}` | — | **Capability URL** — public for OBS browser sources. See F-2. |
-| `POST` | `/api/state/{overlay_id}` | — | **F-3 (high): unauthenticated mutation.** Anyone who can guess an overlay ID can overwrite its live scoreboard state. |
-| `GET`,`POST` | `/create/overlay/{overlay_id}` | — | **F-3 (high): unauthenticated mutation.** `GET` creates an overlay — drive-by requests suffice. |
-| `GET`,`POST`,`DELETE` | `/delete/overlay/{overlay_id}` | — | **F-3 (high): unauthenticated mutation.** `GET` deletes. |
-| `GET` | `/list/overlay` | `require_admin` | **F-4 (high): recon.** Returns every overlay id plus its deterministic output key. Trivially defeats the capability-URL design. Gated in this audit PR. |
-| `GET` | `/api/raw_config/{overlay_id}` | — | **F-5 (medium): leaks model + customization.** |
-| `POST` | `/api/raw_config/{overlay_id}` | — | **F-3 (high): unauthenticated mutation.** |
-| `GET` | `/api/config/{overlay_id}` | — | **F-5 (medium):** returns `outputUrl` + `outputKey`, breaking the capability-URL assumption for any known OID. |
+| `GET` | `/overlay/{output_key}` | — | **Capability URL** — intentionally public for OBS. Only the SHA-256 output key is accepted (F-2 fix). |
+| `WS` | `/ws/{output_key}` | — | **Capability URL** — public for OBS browser sources. Only the output key is accepted (F-2 fix). |
+| `POST` | `/api/state/{overlay_id}` | `require_overlay_server_token` | Mutation endpoint (F-3 fix). |
+| `GET`,`POST` | `/create/overlay/{overlay_id}` | `require_overlay_server_token` | Mutation endpoint (F-3 fix). |
+| `GET`,`POST`,`DELETE` | `/delete/overlay/{overlay_id}` | `require_overlay_server_token` | Mutation endpoint (F-3 fix). |
+| `GET` | `/list/overlay` | `require_admin` | **F-4 fix.** Returns every overlay id plus its output key — gated behind the admin password. |
+| `GET` | `/api/raw_config/{overlay_id}` | `require_overlay_server_token` | Leak endpoint (F-5 fix). |
+| `POST` | `/api/raw_config/{overlay_id}` | `require_overlay_server_token` | Mutation endpoint (F-3 fix). |
+| `GET` | `/api/config/{overlay_id}` | `require_overlay_server_token` | Leak endpoint (F-5 fix). |
 | `GET` | `/api/themes` | — | Public OK (theme name list is not sensitive). |
-| `POST` | `/api/theme/{overlay_id}/{theme_name}` | — | **F-3 (high): unauthenticated mutation.** |
+| `POST` | `/api/theme/{overlay_id}/{theme_name}` | `require_overlay_server_token` | Mutation endpoint (F-3 fix). |
+
+> **Note on `require_overlay_server_token`:** when `OVERLAY_SERVER_TOKEN`
+> is unset the dependency is a no-op (logged at startup). Existing
+> deployments keep working unchanged; setting the env var opts in to
+> enforcement. See F-3 below.
 
 ### 2.4 Static mounts and system endpoints — `app/bootstrap.py`
 
@@ -113,43 +112,41 @@ instance points at this server** (`APP_CUSTOM_OVERLAY_URL=…`).
 | `GET` | `/**` (SPA fallback) | — | Serves `index.html` for unknown paths |
 
 All of these are intentionally public. If a future change needs to gate
-static assets (e.g. hiding the SPA behind a login wall), the hook point
-is `AuthMiddleware.dispatch` — see F-1.
+static assets (e.g. hiding the SPA behind a login wall), add a custom
+`BaseHTTPMiddleware` at that point — there is no longer a pre-wired hook.
 
 ## 3. Findings
 
-### F-1 — `AuthMiddleware` is a no-op (low)
+All five findings documented in the initial audit have been addressed.
+The sections below describe each finding and the fix that was applied.
 
-`AuthMiddleware.dispatch` just calls `call_next` today, yet the class
-docstring reads "Restrict access to the API when user authentication is
-enabled." The behavior has shifted to per-route dependencies, but the
-module is still registered in `_register_auth()` when
-`SCOREBOARD_USERS` is set. This is misleading but harmless.
+### F-1 — Dead `AuthMiddleware` (low) — **fixed**
 
-**Recommendation:** update the docstring to clearly say "no-op hook for
-future static-asset protection", or remove the middleware and the
-`_register_auth()` registration. Either change is fine; the important
-thing is that code and docs agree.
+`AuthMiddleware.dispatch` was a pass-through that served no purpose;
+the real auth lives in per-route dependencies. The class and its
+registration in `_register_auth()` have been removed. If future
+cross-cutting auth is needed (e.g. gating static assets behind a login
+wall), add a dedicated middleware at that time.
 
-### F-2 — Overlay capability URL is weakened by `resolve_overlay_id` (medium)
+### F-2 — Overlay capability URL was weakened by `resolve_overlay_id` (medium) — **fixed**
 
-`/overlay/{…}` and `/ws/{…}` both call
-`OverlayStateStore.resolve_overlay_id`, which accepts **either** the
-raw overlay ID or its SHA-256 prefix. Because `get_output_key` is a
-deterministic hash of the ID, the key is only a capability as long as
-the raw ID is not learnable. `/list/overlay`, `/api/config/{id}`, and
-`/overlay/{raw_id}` itself all leak the mapping.
+`/overlay/{…}` and `/ws/{…}` used to accept **either** the raw overlay
+ID or its SHA-256 prefix. Because `get_output_key` is a deterministic
+hash of the ID, the key was only a capability as long as the raw ID
+was not learnable — which `/list/overlay` and `/api/config/{id}`
+(pre-F-3/F-5 fixes) both leaked.
 
-**Recommendation:** change `resolve_overlay_id` to accept the output
-key only. The in-process backend already constructs URLs using the
-output key (`LocalOverlayBackend.fetch_output_token`), so this is
-backward-compatible for the default deployment. OBS configurations
-that hardcode `/overlay/{raw_id}` would need updating — call this out
-in release notes.
+`resolve_overlay_id` now accepts the output key only.
+`LocalOverlayBackend.fetch_output_token` already returns URLs using the
+output key form, so the default deployment is unaffected. **OBS
+configurations that hardcode `/overlay/{raw_id}` must be updated to
+use the output key** — call this out in release notes.
 
-### F-3 — Unauthenticated mutation endpoints on the overlay router (high)
+### F-3 — Unauthenticated mutation endpoints on the overlay router (high) — **fixed**
 
-The overlay router exposes seven mutation endpoints without any auth:
+The overlay router used to expose seven mutation endpoints without any
+auth. These are now gated by the new
+`require_overlay_server_token` dependency:
 
 - `POST /api/state/{id}`
 - `GET`/`POST /create/overlay/{id}`
@@ -157,62 +154,57 @@ The overlay router exposes seven mutation endpoints without any auth:
 - `POST /api/raw_config/{id}`
 - `POST /api/theme/{id}/{name}`
 
-These are a direct data-integrity risk: anyone with network access to
-the app (or who gets a victim to visit a crafted URL, since `GET` is
-accepted for create/delete) can overwrite, create, or destroy overlays.
+The dependency reads `OVERLAY_SERVER_TOKEN`:
 
-**Recommendation:** introduce a new env var `OVERLAY_SERVER_TOKEN` and
-a matching `require_overlay_server_token` dependency. Apply it to all
-mutation endpoints. When the env var is unset, log a startup warning
-but leave the endpoints open (for backward compatibility with existing
-deployments). `CustomOverlayBackend` would need to learn to send the
-token — that's the only client-side change.
+- **Unset** → dependency is a no-op (backward compatible); a warning is
+  emitted at startup when the overlay routes are mounted.
+- **Set** → requests must include `Authorization: Bearer <token>`,
+  otherwise 401/403 is returned.
 
-### F-4 — `/list/overlay` leaks all overlay IDs and output keys (high)
+`CustomOverlayBackend` forwards the same token via a new
+`_auth_headers()` helper so control-app deployments pointed at an
+external overlay server (`APP_CUSTOM_OVERLAY_URL`) can set
+`OVERLAY_SERVER_TOKEN` on both sides and start enforcing.
 
-`GET /list/overlay` returns `{"overlays": [{"id": "...", "output_key": "..."}, ...]}`
-for every overlay on disk. This is the single most damaging recon
-primitive today — it defeats the capability-URL design (F-2) for every
-overlay in one request, and there is no known consumer in this repo.
+### F-4 — `/list/overlay` leaks all overlay IDs and output keys (high) — **fixed**
 
-**Recommendation:** gate behind `require_admin`. Already implemented as
-part of this audit PR; the behavior change is:
+`/list/overlay` is now gated behind `require_admin`
+(`OVERLAY_MANAGER_PASSWORD`). When the password is unset the endpoint
+returns 503 instead of leaking data.
 
-- When `OVERLAY_MANAGER_PASSWORD` is set → requires `Authorization: Bearer <password>`.
-- When unset → endpoint returns `503 Overlay management is disabled.`
-  instead of data. Operators that currently rely on `/list/overlay`
-  being open must either set `OVERLAY_MANAGER_PASSWORD` or open a
-  follow-up issue.
+### F-5 — Read endpoints leak config (medium) — **fixed**
 
-### F-5 — Read endpoints leak config (medium)
-
-- `GET /api/raw_config/{id}` returns the full model and customization
-  (team names, logos, colors).
-- `GET /api/config/{id}` returns the `outputUrl` and `outputKey` —
-  useful for an attacker building an OBS source against someone else's
-  overlay.
-
-**Recommendation:** same gate proposed in F-3 (`require_overlay_server_token`).
-`CustomOverlayBackend` calls both endpoints and would need to send
-the token.
+`GET /api/raw_config/{id}` and `GET /api/config/{id}` now require
+`OVERLAY_SERVER_TOKEN` (same dependency as F-3). The `outputUrl` /
+`outputKey` pair returned by `/api/config/{id}` is no longer readable
+by unauthenticated callers.
 
 ## 4. Tripwire tests
 
-`tests/test_auth_coverage.py` pins the current behavior of every
-sensitive route so that future changes to auth coverage cannot slip in
-silently. The matrix is parametrized over
-`(method, path, expected_status_without_token, expected_status_with_valid_token)`
-with `SCOREBOARD_USERS` / `OVERLAY_MANAGER_PASSWORD` set as
-appropriate. When a finding is fixed, update the expected status in
-that test.
+`tests/test_auth_coverage.py` pins the auth behavior of every sensitive
+route so that future changes to coverage cannot slip in silently. The
+matrix covers:
 
-## 5. Follow-up plan
+- Scoreboard REST API (`SCOREBOARD_USERS` set) — 401 without Bearer,
+  403 with invalid Bearer.
+- Admin API (`OVERLAY_MANAGER_PASSWORD` set) — 401/403/200 as
+  appropriate.
+- Overlay server mutation + read endpoints (`OVERLAY_SERVER_TOKEN` set)
+  — 401/403 without correct Bearer; "no-op open" behavior verified
+  when the env var is unset.
+- `/list/overlay` — admin-gated, with 503 when admin password is unset.
 
-The items below are **recommendations**, not changes applied in this
-audit PR (except F-4, which has minimal blast radius):
+When adding a new route, add a matching entry in this test file.
 
-1. Fix F-1 (docstring or deletion) — trivial.
-2. Fix F-3 and F-5 together by introducing `OVERLAY_SERVER_TOKEN` —
-   requires coordinated change to `CustomOverlayBackend`.
-3. Fix F-2 by hardening `resolve_overlay_id` — call out in release
-   notes.
+## 5. Release notes
+
+Two deployment-visible changes operators should be aware of:
+
+1. **`/overlay/{raw_id}` no longer works** — only
+   `/overlay/{output_key}` is valid. Re-copy the URL from `/manage` or
+   the control UI into OBS if needed.
+2. **`OVERLAY_SERVER_TOKEN` is recommended** — set it on any deployment
+   that exposes overlay routes (the default in-process overlay server
+   setup). Control apps pointed at an external overlay server via
+   `APP_CUSTOM_OVERLAY_URL` must also set it to the same value. Leaving
+   it unset is backward-compatible but triggers a startup warning.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -79,7 +79,7 @@ The React frontend lives in the `frontend/` directory and is built with Vite. In
 │   ├── conf.py              # Configuration object mapping env vars to settings.
 │   ├── constants.py         # Centralized hardcoded strings, URLs, and favicon.
 │   ├── messages.py          # Internationalization (i18n) string definitions.
-│   ├── authentication.py    # PasswordAuthenticator and AuthMiddleware.
+│   ├── authentication.py    # PasswordAuthenticator (API key validation).
 │   ├── app_storage.py       # In-memory key-value storage.
 │   ├── oid_utils.py         # OID parsing utilities (extract_oid, compose_output).
 │   ├── api/                 # REST API + WebSocket layer for frontends.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Configure the application using the following environment variables:
 | `PREDEFINED_OVERLAYS` | JSON with a list of preconfigured overlays. | |
 | `HIDE_CUSTOM_OVERLAY_WHEN_PREDEFINED` | If `true`, hides the option to manually enter an overlay. | `false` |
 | `OVERLAY_MANAGER_PASSWORD` | Password that unlocks the overlay manager page at `/manage`. Leave empty to disable the page. | |
+| `OVERLAY_SERVER_TOKEN` | *(Recommended)* Bearer token required by the built-in overlay server's mutation and config endpoints (`/api/state/{id}`, `/api/raw_config/{id}`, `/api/config/{id}`, `/create/overlay/{id}`, `/delete/overlay/{id}`, `/api/theme/{id}/{name}`). When unset the endpoints stay open and a warning is logged at startup. If you also run the control app against an **external** overlay server via `APP_CUSTOM_OVERLAY_URL`, set the same value on both sides. See [AUTHENTICATION.md](AUTHENTICATION.md) (F-3, F-5). | |
 | `APP_THEMES` | JSON with a list of customization themes. | |
 | `REMOTE_CONFIG_URL` | URL to a remote JSON file with the configuration. | |
 | `SINGLE_OVERLAY_MODE` | If `true`, restricts the app to a single active overlay at a time. | `true` |
@@ -258,6 +259,35 @@ sources, the managed overlay wins.
 > **Security note**: `OVERLAY_MANAGER_PASSWORD` is a single shared password.
 > Treat it the same way you treat `SCOREBOARD_USERS` — do not expose the
 > service directly to the public internet without additional protection.
+
+### Overlay server token (`OVERLAY_SERVER_TOKEN`)
+
+When the built-in overlay server is mounted (i.e. the `overlay_templates/`
+directory is present), its mutation and config endpoints can be gated behind
+a Bearer token. Set `OVERLAY_SERVER_TOKEN` to any non-empty value and every
+request to the following routes must include
+`Authorization: Bearer <token>`:
+
+- `POST /api/state/{id}`
+- `GET` / `POST /create/overlay/{id}`
+- `GET` / `POST` / `DELETE /delete/overlay/{id}`
+- `GET` / `POST /api/raw_config/{id}`
+- `GET /api/config/{id}`
+- `POST /api/theme/{id}/{name}`
+
+When the variable is unset the routes stay open and a warning is logged at
+startup — existing deployments keep working unchanged.
+
+If the control app is pointed at an **external** overlay server via
+`APP_CUSTOM_OVERLAY_URL`, set `OVERLAY_SERVER_TOKEN` to the same value on
+both sides. The control app's `CustomOverlayBackend` forwards the token in
+every request it makes to the overlay server.
+
+The OBS capability URLs (`/overlay/{output_key}` and `/ws/{output_key}`) are
+intentionally **not** gated by this token — they are the public-by-design
+entry points that OBS loads.
+
+See [AUTHENTICATION.md](AUTHENTICATION.md) for the full route inventory.
 
 ### Remote Configuration
 Import configuration from an external resource via `REMOTE_CONFIG_URL`. The application fetches this JSON file on startup. Useful for centralized management.

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -13,6 +13,7 @@ variable to be set and the request to include a matching
 
 import os
 import logging
+import secrets
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException
@@ -78,7 +79,7 @@ def require_admin(authorization: str = Header(None)) -> None:
             detail="Missing admin password. Use 'Authorization: Bearer <password>'.",
         )
     token = authorization.removeprefix("Bearer ").strip()
-    if token != password:
+    if not secrets.compare_digest(token, password):
         raise HTTPException(status_code=403, detail="Invalid admin password.")
 
 

--- a/app/authentication.py
+++ b/app/authentication.py
@@ -1,5 +1,6 @@
 import logging
 import json
+import secrets
 from app.env_vars_manager import EnvVarsManager
 from app.oid_utils import UNO_OUTPUT_BASE_URL
 
@@ -38,12 +39,18 @@ class PasswordAuthenticator:
 
     @classmethod
     def get_username_for_api_key(cls, key: str):
-        """Return the username whose password matches *key*, or ``None``."""
+        """Return the username whose password matches *key*, or ``None``.
+
+        Uses ``secrets.compare_digest`` for each comparison so individual
+        password checks are constant-time and don't leak a matching prefix
+        via timing (see AUTHENTICATION.md §3 and PR #149 review).
+        """
         users = cls._get_users()
-        if users is None:
+        if users is None or not isinstance(key, str):
             return None
         for username, userconf in users.items():
-            if userconf.get("password") == key:
+            password = userconf.get("password")
+            if isinstance(password, str) and secrets.compare_digest(password, key):
                 return username
         return None
 

--- a/app/authentication.py
+++ b/app/authentication.py
@@ -1,27 +1,9 @@
 import logging
 import json
-from fastapi import Request
-from fastapi.responses import RedirectResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 from app.env_vars_manager import EnvVarsManager
 from app.oid_utils import UNO_OUTPUT_BASE_URL
 
 logger = logging.getLogger("Authenticator")
-
-
-class AuthMiddleware(BaseHTTPMiddleware):
-    """No-op hook reserved for future server-level auth.
-
-    All request-level authentication currently lives in per-route
-    dependencies (``app.api.dependencies.verify_api_key`` and
-    ``app.admin.routes.require_admin``). This middleware exists solely as
-    a registration point so that future cross-cutting concerns — such as
-    gating static assets or the SPA behind a login wall — can be added
-    without touching every route. See ``AUTHENTICATION.md`` (F-1).
-    """
-
-    async def dispatch(self, request: Request, call_next):
-        return await call_next(request)
 
 
 class PasswordAuthenticator:

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -18,7 +18,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.admin import admin_page_router, admin_router
 from app.api import api_router
-from app.authentication import AuthMiddleware, PasswordAuthenticator
+from app.authentication import PasswordAuthenticator
 
 logger = logging.getLogger("Bootstrap")
 
@@ -54,7 +54,6 @@ async def _lifespan(application: FastAPI):
 def _register_auth(application: FastAPI) -> None:
     if PasswordAuthenticator.do_authenticate_users():
         logger.info("User authentication enabled")
-        application.add_middleware(AuthMiddleware)
 
 
 def _register_api_routes(application: FastAPI) -> None:
@@ -83,6 +82,13 @@ def _register_overlay_routes(application: FastAPI) -> None:
     )
     application.include_router(overlay_router)
     logger.info("Overlay routes mounted (templates: %s)", OVERLAY_TEMPLATES_DIR)
+
+    if not os.environ.get("OVERLAY_SERVER_TOKEN", "").strip():
+        logger.warning(
+            "OVERLAY_SERVER_TOKEN is not set — overlay server mutation "
+            "and config endpoints are unauthenticated. See "
+            "AUTHENTICATION.md (F-3, F-5) for details."
+        )
 
 
 def _register_static_mounts(application: FastAPI) -> None:

--- a/app/overlay/routes.py
+++ b/app/overlay/routes.py
@@ -13,16 +13,47 @@ import time
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
-from fastapi import APIRouter, Depends, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse, Response
 from fastapi.routing import APIRoute
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, ConfigDict
 
 from app.admin.routes import require_admin
+from app.env_vars_manager import EnvVarsManager
 from app.overlay.state_store import OverlayStateStore, deep_merge, normalize_state
 
 logger = logging.getLogger(__name__)
+
+
+def _get_overlay_server_token() -> Optional[str]:
+    """Return the configured overlay-server token (or None if unset)."""
+    token = EnvVarsManager.get_env_var("OVERLAY_SERVER_TOKEN", None)
+    if token is None:
+        return None
+    token = token.strip()
+    return token or None
+
+
+def require_overlay_server_token(authorization: str = Header(None)) -> None:
+    """Gate overlay-server mutation / leaky read endpoints.
+
+    When ``OVERLAY_SERVER_TOKEN`` is unset the check is a no-op so
+    existing deployments keep working (with a startup warning; see
+    ``AUTHENTICATION.md`` F-3 and F-5). When the env var is set, the
+    request must include ``Authorization: Bearer <token>``.
+    """
+    token = _get_overlay_server_token()
+    if token is None:
+        return
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(
+            status_code=401,
+            detail="Missing overlay server token. Use 'Authorization: Bearer <token>'.",
+        )
+    provided = authorization.removeprefix("Bearer ").strip()
+    if provided != token:
+        raise HTTPException(status_code=403, detail="Invalid overlay server token.")
 
 
 # ---------------------------------------------------------------------------
@@ -233,7 +264,10 @@ def create_overlay_router(
 
     # -- State update (HTTP) -----------------------------------------------
 
-    @router.post("/api/state/{overlay_id}")
+    @router.post(
+        "/api/state/{overlay_id}",
+        dependencies=[Depends(require_overlay_server_token)],
+    )
     async def update_state(
         overlay_id: str, state_update: OverlayStateUpdate
     ):
@@ -244,7 +278,9 @@ def create_overlay_router(
     # -- Overlay CRUD ------------------------------------------------------
 
     @router.api_route(
-        "/create/overlay/{overlay_id}", methods=["GET", "POST"]
+        "/create/overlay/{overlay_id}",
+        methods=["GET", "POST"],
+        dependencies=[Depends(require_overlay_server_token)],
     )
     async def create_overlay(overlay_id: str):
         if store.overlay_exists(overlay_id):
@@ -255,6 +291,7 @@ def create_overlay_router(
     @router.api_route(
         "/delete/overlay/{overlay_id}",
         methods=["GET", "POST", "DELETE"],
+        dependencies=[Depends(require_overlay_server_token)],
     )
     async def delete_overlay(overlay_id: str):
         existed = store.delete_overlay(overlay_id)
@@ -275,7 +312,10 @@ def create_overlay_router(
 
     # -- Raw config --------------------------------------------------------
 
-    @router.get("/api/raw_config/{overlay_id}")
+    @router.get(
+        "/api/raw_config/{overlay_id}",
+        dependencies=[Depends(require_overlay_server_token)],
+    )
     async def get_raw_config(overlay_id: str):
         if not store.overlay_exists(overlay_id):
             raise HTTPException(
@@ -283,7 +323,10 @@ def create_overlay_router(
             )
         return store.get_raw_config(overlay_id)
 
-    @router.post("/api/raw_config/{overlay_id}")
+    @router.post(
+        "/api/raw_config/{overlay_id}",
+        dependencies=[Depends(require_overlay_server_token)],
+    )
     async def set_raw_config(overlay_id: str, payload: RawConfigPayload):
         if not store.overlay_exists(overlay_id):
             raise HTTPException(
@@ -299,7 +342,10 @@ def create_overlay_router(
 
     # -- Config / output URL -----------------------------------------------
 
-    @router.get("/api/config/{overlay_id}")
+    @router.get(
+        "/api/config/{overlay_id}",
+        dependencies=[Depends(require_overlay_server_token)],
+    )
     async def get_config(request: Request, overlay_id: str):
         public_url = os.environ.get("OVERLAY_PUBLIC_URL", "").rstrip("/")
         base_url = (
@@ -320,7 +366,10 @@ def create_overlay_router(
     async def list_themes():
         return {"themes": list(PRESET_THEMES.keys())}
 
-    @router.post("/api/theme/{overlay_id}/{theme_name}")
+    @router.post(
+        "/api/theme/{overlay_id}/{theme_name}",
+        dependencies=[Depends(require_overlay_server_token)],
+    )
     async def apply_theme(overlay_id: str, theme_name: str):
         if theme_name not in PRESET_THEMES:
             raise HTTPException(

--- a/app/overlay/routes.py
+++ b/app/overlay/routes.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import time
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
@@ -52,7 +53,7 @@ def require_overlay_server_token(authorization: str = Header(None)) -> None:
             detail="Missing overlay server token. Use 'Authorization: Bearer <token>'.",
         )
     provided = authorization.removeprefix("Bearer ").strip()
-    if provided != token:
+    if not secrets.compare_digest(provided, token):
         raise HTTPException(status_code=403, detail="Invalid overlay server token.")
 
 

--- a/app/overlay/state_store.py
+++ b/app/overlay/state_store.py
@@ -223,23 +223,26 @@ class OverlayStateStore:
         """Return a short deterministic hash of the overlay name."""
         return hashlib.sha256(overlay_id.encode()).hexdigest()[:12]
 
-    def resolve_overlay_id(self, id_or_key: str) -> Optional[str]:
-        """Resolve an overlay ID or output key to the real overlay ID."""
-        if os.path.exists(self.get_state_file_path(id_or_key)):
-            return id_or_key
+    def resolve_overlay_id(self, output_key: str) -> Optional[str]:
+        """Resolve an output key to its real overlay ID.
+
+        Accepts the SHA-256 output key only (not the raw overlay id).
+        This turns ``/overlay/{output_key}`` and ``/ws/{output_key}``
+        into true capability URLs: knowing an overlay's raw id is no
+        longer enough to view or stream it. See ``AUTHENTICATION.md``
+        (F-2).
+        """
         with self._lock:
-            # Check in-memory cache first
-            cached = self._output_key_cache.get(id_or_key)
+            cached = self._output_key_cache.get(output_key)
             if cached and os.path.exists(self.get_state_file_path(cached)):
                 return cached
-            # Scan data dir and rebuild cache
             if os.path.isdir(self._data_dir):
                 for filename in os.listdir(self._data_dir):
                     if filename.startswith("overlay_state_") and filename.endswith(".json"):
                         candidate = filename[len("overlay_state_"):-5]
                         key = self.get_output_key(candidate)
                         self._output_key_cache[key] = candidate
-                        if key == id_or_key:
+                        if key == output_key:
                             return candidate
         return None
 

--- a/app/overlay_backends/custom.py
+++ b/app/overlay_backends/custom.py
@@ -36,6 +36,18 @@ class CustomOverlayBackend(OverlayBackend):
     def _base_url(self):
         return EnvVarsManager.get_custom_overlay_url().rstrip('/')
 
+    def _auth_headers(self):
+        """Return Authorization header when OVERLAY_SERVER_TOKEN is set.
+
+        Sent per-request (not via ``session.headers``) because the same
+        ``requests.Session`` is shared with the Uno backend, which must
+        never receive this header.
+        """
+        token = EnvVarsManager.get_env_var('OVERLAY_SERVER_TOKEN', None)
+        if token and token.strip():
+            return {"Authorization": f"Bearer {token.strip()}"}
+        return {}
+
     def _custom_id(self, oid=None):
         check_oid = oid if oid is not None else self.conf.oid
         cid, _ = split_custom_oid(check_oid)
@@ -56,6 +68,7 @@ class CustomOverlayBackend(OverlayBackend):
                 self.session.post(
                     f"{self._base_url()}/api/raw_config/{custom_id}",
                     json=payload, timeout=2.0,
+                    headers=self._auth_headers(),
                 )
             except Exception as e:
                 logger.error("Failed to save raw_config remote: %s", e)
@@ -68,7 +81,8 @@ class CustomOverlayBackend(OverlayBackend):
         base_url = self._base_url()
         try:
             resp = self.session.get(
-                f"{base_url}/api/config/{custom_id}", timeout=5.0
+                f"{base_url}/api/config/{custom_id}", timeout=5.0,
+                headers=self._auth_headers(),
             )
             if resp.status_code == 200:
                 ws_url = resp.json().get('controlWebSocketUrl')
@@ -155,6 +169,7 @@ class CustomOverlayBackend(OverlayBackend):
         try:
             resp = self.session.get(
                 f"{self._base_url()}/api/raw_config/{custom_id}", timeout=2.0,
+                headers=self._auth_headers(),
             )
             if resp.status_code == 200:
                 data = resp.json().get("model", {})
@@ -178,6 +193,7 @@ class CustomOverlayBackend(OverlayBackend):
                 self.session.post(
                     f"{self._base_url()}/api/raw_config/{custom_id}",
                     json={"customization": data}, timeout=2.0,
+                    headers=self._auth_headers(),
                 )
             except Exception as e:
                 logger.warning("Failed to persist preferredStyle: %s", e)
@@ -191,6 +207,7 @@ class CustomOverlayBackend(OverlayBackend):
         try:
             resp = self.session.get(
                 f"{self._base_url()}/api/raw_config/{custom_id}", timeout=2.0,
+                headers=self._auth_headers(),
             )
             if resp.status_code == 200:
                 data = resp.json().get("customization", {})
@@ -202,6 +219,7 @@ class CustomOverlayBackend(OverlayBackend):
                         self.session.post(
                             f"{self._base_url()}/api/raw_config/{custom_id}",
                             json={"customization": data}, timeout=2.0,
+                            headers=self._auth_headers(),
                         )
                     except Exception as e:
                         logger.warning("Failed to persist preferredStyle: %s", e)
@@ -219,6 +237,7 @@ class CustomOverlayBackend(OverlayBackend):
         try:
             response = self.session.get(
                 f"{self._base_url()}/api/config/{custom_id}", timeout=5.0,
+                headers=self._auth_headers(),
             )
             if response.status_code == 200:
                 return response.json().get('availableStyles', [])
@@ -230,7 +249,9 @@ class CustomOverlayBackend(OverlayBackend):
         try:
             custom_id = self._custom_id(oid)
             url = f"{self._base_url()}/api/config/{custom_id}"
-            response = self.session.get(url, timeout=5.0)
+            response = self.session.get(
+                url, timeout=5.0, headers=self._auth_headers(),
+            )
             if response.status_code == 200:
                 output_url = response.json().get('outputUrl')
                 if output_url:
@@ -264,6 +285,7 @@ class CustomOverlayBackend(OverlayBackend):
             self.session.post(
                 f"{self._base_url()}/api/state/{custom_id}",
                 json=payload, timeout=2.0,
+                headers=self._auth_headers(),
             )
         except Exception as e:
             logger.error("Error updating local overlay: %s", e)

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -841,6 +841,15 @@
               "title": "Overlay Id",
               "type": "string"
             }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -881,6 +890,15 @@
               "title": "Overlay Id",
               "type": "string"
             }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -917,6 +935,15 @@
             "required": true,
             "schema": {
               "title": "Overlay Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
               "type": "string"
             }
           }
@@ -967,6 +994,15 @@
             "required": true,
             "schema": {
               "title": "Overlay Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
               "type": "string"
             }
           }
@@ -1026,6 +1062,15 @@
             "required": true,
             "schema": {
               "title": "Theme Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
               "type": "string"
             }
           }
@@ -2398,6 +2443,15 @@
               "title": "Overlay Id",
               "type": "string"
             }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2434,6 +2488,15 @@
             "required": true,
             "schema": {
               "title": "Overlay Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
               "type": "string"
             }
           }
@@ -2476,6 +2539,15 @@
               "title": "Overlay Id",
               "type": "string"
             }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2514,6 +2586,15 @@
               "title": "Overlay Id",
               "type": "string"
             }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -2550,6 +2631,15 @@
             "required": true,
             "schema": {
               "title": "Overlay Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
               "type": "string"
             }
           }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -934,7 +934,9 @@ export interface operations {
     get_config_api_config__overlay_id__get: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                authorization?: string;
+            };
             path: {
                 overlay_id: string;
             };
@@ -965,7 +967,9 @@ export interface operations {
     get_raw_config_api_raw_config__overlay_id__get: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                authorization?: string;
+            };
             path: {
                 overlay_id: string;
             };
@@ -996,7 +1000,9 @@ export interface operations {
     set_raw_config_api_raw_config__overlay_id__post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                authorization?: string;
+            };
             path: {
                 overlay_id: string;
             };
@@ -1031,7 +1037,9 @@ export interface operations {
     update_state_api_state__overlay_id__post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                authorization?: string;
+            };
             path: {
                 overlay_id: string;
             };
@@ -1066,7 +1074,9 @@ export interface operations {
     apply_theme_api_theme__overlay_id___theme_name__post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                authorization?: string;
+            };
             path: {
                 overlay_id: string;
                 theme_name: string;
@@ -1981,7 +1991,9 @@ export interface operations {
     create_overlay_create_overlay__overlay_id__get_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                authorization?: string;
+            };
             path: {
                 overlay_id: string;
             };
@@ -2012,7 +2024,9 @@ export interface operations {
     create_overlay_create_overlay__overlay_id__get_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                authorization?: string;
+            };
             path: {
                 overlay_id: string;
             };
@@ -2043,7 +2057,9 @@ export interface operations {
     delete_overlay_delete_overlay__overlay_id__delete_get_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                authorization?: string;
+            };
             path: {
                 overlay_id: string;
             };
@@ -2074,7 +2090,9 @@ export interface operations {
     delete_overlay_delete_overlay__overlay_id__delete_get_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                authorization?: string;
+            };
             path: {
                 overlay_id: string;
             };
@@ -2105,7 +2123,9 @@ export interface operations {
     delete_overlay_delete_overlay__overlay_id__delete_get_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                authorization?: string;
+            };
             path: {
                 overlay_id: string;
             };

--- a/tests/test_auth_coverage.py
+++ b/tests/test_auth_coverage.py
@@ -25,6 +25,7 @@ from app.overlay.state_store import OverlayStateStore
 
 API_USER_PASSWORD = "user-secret"
 ADMIN_PASSWORD = "admin-secret"
+OVERLAY_SERVER_TOKEN = "overlay-server-secret"
 
 
 # ---------------------------------------------------------------------------
@@ -37,6 +38,7 @@ def _reset_env(monkeypatch, tmp_path):
     managed_overlays_store._reset_for_tests(str(tmp_path / "admin"))
     monkeypatch.delenv("SCOREBOARD_USERS", raising=False)
     monkeypatch.delenv("OVERLAY_MANAGER_PASSWORD", raising=False)
+    monkeypatch.delenv("OVERLAY_SERVER_TOKEN", raising=False)
     monkeypatch.delenv("PREDEFINED_OVERLAYS", raising=False)
     yield
     managed_overlays_store._reset_for_tests(str(tmp_path / "admin"))
@@ -94,6 +96,13 @@ def overlay_client_no_admin(tmp_path):
 @pytest.fixture
 def overlay_client_with_admin(tmp_path, monkeypatch):
     monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", ADMIN_PASSWORD)
+    return TestClient(_make_overlay_app(tmp_path))
+
+
+@pytest.fixture
+def overlay_client_with_server_token(tmp_path, monkeypatch):
+    """Overlay router with OVERLAY_SERVER_TOKEN set so F-3/F-5 gates engage."""
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN", OVERLAY_SERVER_TOKEN)
     return TestClient(_make_overlay_app(tmp_path))
 
 
@@ -209,13 +218,13 @@ def test_list_overlay_disabled_when_admin_unset(overlay_client_no_admin):
     assert response.status_code == 503
 
 
-# The following routes are documented as *unauthenticated* (findings F-3
-# and F-5). These tests pin the current behavior so that adding auth to
-# any of them surfaces in this file instead of slipping through silently.
-# When a follow-up PR fixes F-3 / F-5, update the expected assertions.
+# Overlay router mutation + leaky read endpoints are gated by
+# ``require_overlay_server_token`` (F-3, F-5). These tests pin that
+# gate in both postures: enforced when ``OVERLAY_SERVER_TOKEN`` is set,
+# and backward-compatible no-op when the env var is unset.
 
 
-OVERLAY_OPEN_MUTATION_ROUTES = [
+OVERLAY_TOKEN_GATED_ROUTES = [
     ("POST", "/api/state/any-id", {}),
     ("GET", "/create/overlay/any-id", None),
     ("POST", "/create/overlay/any-id", None),
@@ -223,49 +232,105 @@ OVERLAY_OPEN_MUTATION_ROUTES = [
     ("POST", "/delete/overlay/any-id", None),
     ("DELETE", "/delete/overlay/any-id", None),
     ("POST", "/api/theme/any-id/dark", None),
+    ("GET", "/api/raw_config/any-id", None),
+    ("POST", "/api/raw_config/any-id", {"model": {}}),
+    ("GET", "/api/config/any-id", None),
 ]
 
 
-@pytest.mark.parametrize("method,path,body", OVERLAY_OPEN_MUTATION_ROUTES)
-def test_overlay_mutation_routes_are_currently_open(
-    overlay_client_with_admin, method, path, body,
+@pytest.mark.parametrize("method,path,body", OVERLAY_TOKEN_GATED_ROUTES)
+def test_overlay_server_token_rejects_missing(
+    overlay_client_with_server_token, method, path, body,
 ):
-    """F-3: these routes accept writes with no auth header. Test pins the
-    status quo so a future fix updates this file."""
-    response = overlay_client_with_admin.request(method, path, json=body)
+    """F-3/F-5: when OVERLAY_SERVER_TOKEN is set, the gated routes must
+    reject requests that omit the Bearer header."""
+    response = overlay_client_with_server_token.request(
+        method, path, json=body,
+    )
+    assert response.status_code == 401, (
+        f"{method} {path} should 401 without a Bearer token when "
+        f"OVERLAY_SERVER_TOKEN is set (got {response.status_code})"
+    )
+
+
+@pytest.mark.parametrize("method,path,body", OVERLAY_TOKEN_GATED_ROUTES)
+def test_overlay_server_token_rejects_invalid(
+    overlay_client_with_server_token, method, path, body,
+):
+    response = overlay_client_with_server_token.request(
+        method, path, json=body, headers={"Authorization": "Bearer wrong"},
+    )
+    assert response.status_code == 403, (
+        f"{method} {path} should 403 with an invalid Bearer token "
+        f"(got {response.status_code})"
+    )
+
+
+@pytest.mark.parametrize("method,path,body", OVERLAY_TOKEN_GATED_ROUTES)
+def test_overlay_server_token_accepts_correct(
+    overlay_client_with_server_token, method, path, body,
+):
+    """With the correct token the auth layer steps out of the way; downstream
+    business-logic responses (200/404/etc.) are fine — the test only asserts
+    the route is no longer rejecting on auth grounds."""
+    response = overlay_client_with_server_token.request(
+        method, path, json=body,
+        headers={"Authorization": f"Bearer {OVERLAY_SERVER_TOKEN}"},
+    )
     assert response.status_code not in (401, 403), (
-        f"{method} {path} unexpectedly rejected auth "
-        f"({response.status_code}). If this is the intended behavior, "
-        f"update AUTHENTICATION.md F-3 and flip this assertion."
+        f"{method} {path} rejected a correct Bearer token "
+        f"({response.status_code})"
     )
 
 
-OVERLAY_OPEN_READ_ROUTES = [
-    ("GET", "/api/config/any-id"),
-    ("GET", "/api/themes"),
-]
-
-
-@pytest.mark.parametrize("method,path", OVERLAY_OPEN_READ_ROUTES)
-def test_overlay_read_routes_are_currently_open(
-    overlay_client_with_admin, method, path,
+@pytest.mark.parametrize("method,path,body", OVERLAY_TOKEN_GATED_ROUTES)
+def test_overlay_server_token_unset_is_noop(
+    overlay_client_no_admin, method, path, body,
 ):
-    """F-5: these routes return data without auth. `/api/themes` is
-    intentionally public; `/api/config/{id}` is a known leak."""
-    response = overlay_client_with_admin.request(method, path)
-    assert response.status_code not in (401, 403)
-
-
-def test_overlay_raw_config_get_is_currently_open(overlay_client_with_admin):
-    """F-5: raw_config returns 404 on missing overlays — still reachable
-    without auth, which is the leak we are documenting."""
-    response = overlay_client_with_admin.get("/api/raw_config/any-id")
-    assert response.status_code not in (401, 403)
-
-
-def test_overlay_raw_config_post_is_currently_open(overlay_client_with_admin):
-    """F-3: raw_config POST mutates state with no auth header."""
-    response = overlay_client_with_admin.post(
-        "/api/raw_config/any-id", json={"model": {}},
+    """Backward-compat: when OVERLAY_SERVER_TOKEN is unset the dependency
+    is a no-op and the gated routes respond without any auth header. The
+    startup warning is logged elsewhere."""
+    response = overlay_client_no_admin.request(method, path, json=body)
+    assert response.status_code not in (401, 403), (
+        f"{method} {path} unexpectedly rejected auth with no token "
+        f"configured ({response.status_code}). The "
+        f"OVERLAY_SERVER_TOKEN=unset path must stay backward-compatible."
     )
-    assert response.status_code not in (401, 403)
+
+
+def test_overlay_themes_list_is_public(overlay_client_with_server_token):
+    """`/api/themes` is intentionally public (see AUTHENTICATION.md §2.3) —
+    listing preset theme names is not sensitive."""
+    response = overlay_client_with_server_token.get("/api/themes")
+    assert response.status_code == 200
+    assert "themes" in response.json()
+
+
+# ---------------------------------------------------------------------------
+# F-2: `/overlay/{…}` and `/ws/{…}` are capability URLs — the raw overlay
+# id must no longer resolve, only the SHA-256 output key.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_overlay_id_rejects_raw_id(tmp_path):
+    """F-2: ``resolve_overlay_id`` now accepts the SHA-256 output key
+    only. Passing the raw overlay id must return ``None`` even when the
+    overlay exists."""
+    from app.overlay.state_store import OverlayStateStore
+
+    raw_id = "f-2-capability-check"
+    store = OverlayStateStore(
+        data_dir=str(tmp_path / "overlays"),
+        templates_dir=str(tmp_path / "templates"),
+    )
+    store.create_overlay(raw_id)
+
+    assert store.resolve_overlay_id(raw_id) is None, (
+        "Raw overlay id must not resolve — the output key is the capability."
+    )
+
+    output_key = OverlayStateStore.get_output_key(raw_id)
+    assert store.resolve_overlay_id(output_key) == raw_id, (
+        "Output key must resolve back to the raw id for downstream state "
+        "lookups."
+    )


### PR DESCRIPTION
## Summary

Follow-up to #148. Closes the three remaining findings from the authentication audit documented in `AUTHENTICATION.md`:

- **F-1 — dead `AuthMiddleware` (low)**: removed the pass-through class and its registration hook. Real auth lives in per-route dependencies; the middleware served no purpose.
- **F-2 — capability URL hardening (medium)**: `resolve_overlay_id` now accepts the SHA-256 output key **only**, not the raw overlay id. `/overlay/{…}` and `/ws/{…}` become true capability URLs. `LocalOverlayBackend.fetch_output_token` already returns output-key URLs so the default deployment is unaffected. **OBS configs that hardcoded `/overlay/{raw_id}` must be re-copied from `/manage`** — called out in release notes.
- **F-3 + F-5 — unauthenticated overlay-server mutations / leaks (high + medium)**: nine routes (`POST /api/state/{id}`, `GET`/`POST /create/overlay/{id}`, `GET`/`POST`/`DELETE /delete/overlay/{id}`, `GET`/`POST /api/raw_config/{id}`, `GET /api/config/{id}`, `POST /api/theme/{id}/{name}`) now go through a new `require_overlay_server_token` dependency reading `OVERLAY_SERVER_TOKEN`.
  - Unset → no-op (backward compatible); startup warning logged.
  - Set → `401` without Bearer, `403` on mismatch.
  - `CustomOverlayBackend` forwards the same token via a new `_auth_headers()` helper. Sent per-request (not via `session.headers`) because the same `requests.Session` is shared with `UnoOverlayBackend`, which must never receive this header.

Uno overlays are unaffected — they use `overlays.uno` SaaS, not `app/overlay/routes.py`.

## Docs

- `AUTHENTICATION.md` rewritten: findings marked fixed, overlay router table updated, new release-notes section.
- `README.md` documents `OVERLAY_SERVER_TOKEN` (env var table + dedicated section).
- `AGENTS.md` / `DEVELOPER_GUIDE.md` references to the deleted `AuthMiddleware` removed.

## Tests

`tests/test_auth_coverage.py` extended:

- Four postures for the F-3/F-5 gated routes: missing token → 401, invalid token → 403, correct token → non-401/403, `OVERLAY_SERVER_TOKEN` unset → no-op (backward-compat).
- New F-2 tripwire: `resolve_overlay_id` returns `None` for a raw id and the real id only for the output key.
- `/api/themes` pinned as intentionally public.

Full suite green: **275 backend tests, 158 frontend tests**.

## Schema

`frontend/schema/openapi.json` and `frontend/src/api/schema.d.ts` regenerated (CI schema-drift guard).

## Test plan

- [x] `pytest tests/ -m "not mobile_browser"` — 275 passed
- [x] `cd frontend && npm run typecheck` — clean
- [x] `cd frontend && npm test -- --run` — 158 passed
- [x] OpenAPI schema + TS types regenerated
- [ ] Manual: set `OVERLAY_SERVER_TOKEN`, verify overlay server `POST /api/state/{id}` requires the Bearer header
- [ ] Manual: unset `OVERLAY_SERVER_TOKEN`, verify routes still work and startup warning is logged
- [ ] Manual: verify `/overlay/{output_key}` renders and `/overlay/{raw_id}` now 404s

https://claude.ai/code/session_01NUAp3CkDRkUKyVo7VAQ4z4