### PR TITLE
frontend: migrate five scoreboard panels to TypeScript

### DIFF
--- a/frontend/src/components/CenterPanel.tsx
+++ b/frontend/src/components/CenterPanel.tsx
@@ -1,13 +1,34 @@
-import React from 'react';
 import ScoreButton from './ScoreButton';
 import ScoreTable from './ScoreTable';
 import OverlayPreview from './OverlayPreview';
+import type { GameState } from '../api/client';
+import type { ConfigModel } from './TeamCard';
 
-/**
- * Center panel with set buttons, team logos, score history, and set pagination.
- * Mirrors the NiceGUI CenterPanel component layout:
- * logos on top, score columns directly below (no set indicator in between).
- */
+export interface PreviewData {
+  overlayUrl: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  layoutId?: string;
+}
+
+export interface CenterPanelProps {
+  state: GameState | null | undefined;
+  customization: ConfigModel | null | undefined;
+  currentSet: number;
+  setsLimit: number;
+  isPortrait: boolean;
+  previewData: PreviewData | null | undefined;
+  onAddSet: (teamId: 1 | 2) => void;
+  onLongPressSet: (teamId: 1 | 2) => void;
+  onSetChange: (set: number) => void;
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === 'string' && v ? v : null;
+}
+
 export default function CenterPanel({
   state,
   customization,
@@ -18,14 +39,14 @@ export default function CenterPanel({
   onAddSet,
   onLongPressSet,
   onSetChange,
-}) {
+}: CenterPanelProps) {
   if (!state) return null;
 
   const t1Sets = state.team_1.sets;
   const t2Sets = state.team_2.sets;
 
-  const logo1 = customization?.['Team 1 Logo'] || null;
-  const logo2 = customization?.['Team 2 Logo'] || null;
+  const logo1 = asString(customization?.['Team 1 Logo']);
+  const logo2 = asString(customization?.['Team 2 Logo']);
 
   return (
     <div className="center-panel">
@@ -40,17 +61,11 @@ export default function CenterPanel({
           data-testid="team-1-sets"
         />
 
-        {/* In landscape, show score history here; in portrait it moves to TeamPanels */}
         {!isPortrait && (
           <div className="logos-scores-section">
             <div className="team-score-column">
               {logo1 && (
-                <img
-                  src={logo1}
-                  alt="Team 1"
-                  className="team-logo"
-                  data-testid="team-1-logo"
-                />
+                <img src={logo1} alt="Team 1" className="team-logo" data-testid="team-1-logo" />
               )}
               <ScoreTable
                 state={state}
@@ -61,12 +76,7 @@ export default function CenterPanel({
             </div>
             <div className="team-score-column">
               {logo2 && (
-                <img
-                  src={logo2}
-                  alt="Team 2"
-                  className="team-logo"
-                  data-testid="team-2-logo"
-                />
+                <img src={logo2} alt="Team 2" className="team-logo" data-testid="team-2-logo" />
               )}
               <ScoreTable
                 state={state}

--- a/frontend/src/components/CenterPanel.tsx
+++ b/frontend/src/components/CenterPanel.tsx
@@ -3,6 +3,7 @@ import ScoreTable from './ScoreTable';
 import OverlayPreview from './OverlayPreview';
 import type { GameState } from '../api/client';
 import type { ConfigModel } from './TeamCard';
+import { asString } from '../utils/coerce';
 
 export interface PreviewData {
   overlayUrl: string;
@@ -23,10 +24,6 @@ export interface CenterPanelProps {
   onAddSet: (teamId: 1 | 2) => void;
   onLongPressSet: (teamId: 1 | 2) => void;
   onSetChange: (set: number) => void;
-}
-
-function asString(v: unknown): string | null {
-  return typeof v === 'string' && v ? v : null;
 }
 
 export default function CenterPanel({

--- a/frontend/src/components/ControlButtons.tsx
+++ b/frontend/src/components/ControlButtons.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useI18n } from '../i18n';
 import {
   VISIBLE_ON_COLOR,
@@ -11,9 +10,24 @@ import {
   PREVIEW_OFF_COLOR,
 } from '../theme';
 
+export interface ControlButtonsProps {
+  visible: boolean;
+  simpleMode: boolean;
+  undoMode: boolean;
+  darkMode: boolean;
+  isFullscreen: boolean;
+  matchFinished?: boolean;
+  onToggleVisibility: () => void;
+  onToggleSimpleMode: () => void;
+  onToggleUndo: () => void;
+  onToggleDarkMode: () => void;
+  onToggleFullscreen: () => void;
+  showPreview: boolean;
+  onTogglePreview: () => void;
+}
+
 /**
  * Bottom control bar with visibility, simple mode, undo, and config navigation.
- * Mirrors the NiceGUI ControlButtons component.
  */
 export default function ControlButtons({
   visible,
@@ -21,7 +35,6 @@ export default function ControlButtons({
   undoMode,
   darkMode,
   isFullscreen,
-  matchFinished,
   onToggleVisibility,
   onToggleSimpleMode,
   onToggleUndo,
@@ -29,7 +42,7 @@ export default function ControlButtons({
   onToggleFullscreen,
   showPreview,
   onTogglePreview,
-}) {
+}: ControlButtonsProps) {
   const { t } = useI18n();
 
   return (

--- a/frontend/src/components/InitScreen.tsx
+++ b/frontend/src/components/InitScreen.tsx
@@ -1,36 +1,56 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, ChangeEvent, FormEvent } from 'react';
 import { useI18n } from '../i18n';
 import * as api from '../api/client';
 
-export default function InitScreen({ oidInput, setOidInput, onSubmit, onSelect, error }) {
+export interface InitScreenProps {
+  oidInput: string;
+  setOidInput: (value: string) => void;
+  onSubmit: (e: FormEvent<HTMLFormElement>) => void;
+  onSelect: (oid: string) => void;
+  error?: string | null;
+}
+
+interface PredefinedOverlay {
+  oid: string;
+  name: string;
+}
+
+function normalizeOverlays(data: unknown): PredefinedOverlay[] {
+  if (Array.isArray(data)) {
+    return data.flatMap((item): PredefinedOverlay[] => {
+      if (item && typeof item === 'object' && 'oid' in item) {
+        const entry = item as { oid?: unknown; name?: unknown };
+        if (typeof entry.oid === 'string' && entry.oid) {
+          const name = typeof entry.name === 'string' && entry.name ? entry.name : entry.oid;
+          return [{ oid: entry.oid, name }];
+        }
+        return [];
+      }
+      if (typeof item === 'string' && item) return [{ oid: item, name: item }];
+      return [];
+    });
+  }
+  if (data && typeof data === 'object') {
+    return Object.entries(data as Record<string, unknown>)
+      .filter(([, oid]) => typeof oid === 'string')
+      .map(([name, oid]) => ({ oid: oid as string, name }));
+  }
+  return [];
+}
+
+export default function InitScreen({ oidInput, setOidInput, onSubmit, onSelect, error }: InitScreenProps) {
   const { t } = useI18n();
-  const [predefinedOverlays, setPredefinedOverlays] = useState([]);
+  const [predefinedOverlays, setPredefinedOverlays] = useState<PredefinedOverlay[]>([]);
 
   useEffect(() => {
     api.getOverlays().then((data) => {
-      let overlays = [];
-      if (Array.isArray(data)) {
-        overlays = data
-          .map((item) => {
-            if (item && typeof item === 'object' && item.oid) {
-              return { oid: item.oid, name: item.name || item.oid };
-            }
-            if (typeof item === 'string' && item) {
-              return { oid: item, name: item };
-            }
-            return null;
-          })
-          .filter(Boolean);
-      } else if (data && typeof data === 'object') {
-        overlays = Object.entries(data).map(([name, oid]) => ({ oid, name }));
-      }
-      setPredefinedOverlays(overlays);
-    }).catch((err) => {
+      setPredefinedOverlays(normalizeOverlays(data));
+    }).catch((err: unknown) => {
       console.warn('Failed to fetch predefined overlays:', err);
     });
   }, []);
 
-  const handleOverlaySelect = useCallback((e) => {
+  const handleOverlaySelect = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
     setOidInput(e.target.value);
     if (e.target.value) {
       onSelect(e.target.value);

--- a/frontend/src/components/ScoreTable.tsx
+++ b/frontend/src/components/ScoreTable.tsx
@@ -1,15 +1,12 @@
 import { ReactElement } from 'react';
 import type { GameState } from '../api/client';
+import { toNumber } from '../utils/coerce';
 
 export interface ScoreTableProps {
   state: GameState | null | undefined;
   setsLimit: number;
   currentSet: number;
   teamId: 1 | 2;
-}
-
-function toNumber(v: unknown): number {
-  return typeof v === 'number' ? v : typeof v === 'string' ? Number(v) || 0 : 0;
 }
 
 /**

--- a/frontend/src/components/ScoreTable.tsx
+++ b/frontend/src/components/ScoreTable.tsx
@@ -1,31 +1,39 @@
-import React from 'react';
+import { ReactElement } from 'react';
+import type { GameState } from '../api/client';
+
+export interface ScoreTableProps {
+  state: GameState | null | undefined;
+  setsLimit: number;
+  currentSet: number;
+  teamId: 1 | 2;
+}
+
+function toNumber(v: unknown): number {
+  return typeof v === 'number' ? v : typeof v === 'string' ? Number(v) || 0 : 0;
+}
 
 /**
  * Per-team score column showing scores for each completed set.
- * Displayed directly below the team logo, no set number indicator.
- * Mirrors the NiceGUI center panel score columns layout.
  */
-export default function ScoreTable({ state, setsLimit, currentSet, teamId }) {
+export default function ScoreTable({ state, setsLimit, currentSet, teamId }: ScoreTableProps) {
   if (!state) return null;
 
   const matchFinished = state.match_finished;
   const teamState = teamId === 1 ? state.team_1 : state.team_2;
   const otherState = teamId === 1 ? state.team_2 : state.team_1;
 
-  // Find the last set with non-zero scores
   let lastNonEmpty = 1;
   for (let i = 1; i <= setsLimit; i++) {
-    const a = state.team_1.scores[`set_${i}`] ?? 0;
-    const b = state.team_2.scores[`set_${i}`] ?? 0;
+    const a = toNumber(state.team_1.scores[`set_${i}`]);
+    const b = toNumber(state.team_2.scores[`set_${i}`]);
     if (a + b > 0) lastNonEmpty = i;
   }
 
-  const cells = [];
+  const cells: ReactElement[] = [];
   for (let i = 1; i <= setsLimit; i++) {
-    const score = teamState.scores[`set_${i}`] ?? 0;
-    const otherScore = otherState.scores[`set_${i}`] ?? 0;
+    const score = toNumber(teamState.scores[`set_${i}`]);
+    const otherScore = toNumber(otherState.scores[`set_${i}`]);
 
-    // Break conditions matching NiceGUI logic
     if (i > 1 && i > lastNonEmpty) break;
     if (i === currentSet && i < setsLimit && !matchFinished) break;
 

--- a/frontend/src/components/TeamPanel.tsx
+++ b/frontend/src/components/TeamPanel.tsx
@@ -4,6 +4,7 @@ import ScoreTable from './ScoreTable';
 import type { GameState } from '../api/client';
 import type { components } from '../api/schema';
 import type { ConfigModel } from './TeamCard';
+import { toNumber, asString } from '../utils/coerce';
 
 type TeamState = components['schemas']['TeamState'];
 
@@ -38,14 +39,6 @@ function isSafeUrl(url: string | null | undefined): url is string {
   } catch {
     return false;
   }
-}
-
-function toNumber(v: unknown): number {
-  return typeof v === 'number' ? v : typeof v === 'string' ? Number(v) || 0 : 0;
-}
-
-function asString(v: unknown): string | null {
-  return typeof v === 'string' && v ? v : null;
 }
 
 /**

--- a/frontend/src/components/TeamPanel.tsx
+++ b/frontend/src/components/TeamPanel.tsx
@@ -1,11 +1,36 @@
-import React from 'react';
-import ScoreButton from './ScoreButton';
+import { CSSProperties, ReactElement } from 'react';
+import ScoreButton, { ScoreButtonFontStyle } from './ScoreButton';
 import ScoreTable from './ScoreTable';
+import type { GameState } from '../api/client';
+import type { components } from '../api/schema';
+import type { ConfigModel } from './TeamCard';
 
-/**
- * Validate that a URL uses http or https protocol.
- */
-function isSafeUrl(url) {
+type TeamState = components['schemas']['TeamState'];
+
+export interface TeamPanelProps {
+  teamId: 1 | 2;
+  teamState: TeamState | null | undefined;
+  currentSet: number;
+  buttonColor: string;
+  buttonTextColor?: string;
+  serveColor: string;
+  timeoutColor: string;
+  buttonSize?: number;
+  isPortrait: boolean;
+  iconLogo?: string | null;
+  iconOpacity?: number;
+  fontStyle?: ScoreButtonFontStyle;
+  state: GameState | null | undefined;
+  setsLimit: number;
+  customization?: ConfigModel | null;
+  onAddPoint: (teamId: 1 | 2) => void;
+  onAddTimeout: (teamId: 1 | 2) => void;
+  onChangeServe: (teamId: 1 | 2) => void;
+  onDoubleTapScore: (teamId: 1 | 2) => void;
+  onLongPressScore: (teamId: 1 | 2) => void;
+}
+
+function isSafeUrl(url: string | null | undefined): url is string {
   if (!url) return false;
   try {
     const parsed = new URL(url);
@@ -15,11 +40,16 @@ function isSafeUrl(url) {
   }
 }
 
+function toNumber(v: unknown): number {
+  return typeof v === 'number' ? v : typeof v === 'string' ? Number(v) || 0 : 0;
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === 'string' && v ? v : null;
+}
+
 /**
  * Team panel with score button, timeout button + indicators, and serve icon.
- * Supports custom button colors, team icon overlay, and icon opacity.
- * In portrait, also shows the set history column (logo + ScoreTable) beside
- * the score button so the CenterPanel has more room for the overlay preview.
  */
 export default function TeamPanel({
   teamId,
@@ -42,14 +72,14 @@ export default function TeamPanel({
   onChangeServe,
   onDoubleTapScore,
   onLongPressScore,
-}) {
-  const score = teamState?.scores?.[`set_${currentSet}`] ?? 0;
+}: TeamPanelProps) {
+  const score = toNumber(teamState?.scores?.[`set_${currentSet}`]);
   const timeouts = teamState?.timeouts ?? 0;
   const isServing = teamState?.serving ?? false;
 
   const scoreText = String(score).padStart(2, '0');
 
-  const timeoutDots = [];
+  const timeoutDots: ReactElement[] = [];
   for (let i = 0; i < timeouts; i++) {
     timeoutDots.push(
       <span
@@ -63,12 +93,10 @@ export default function TeamPanel({
     );
   }
 
-  // Build icon overlay style if iconLogo is set and URL is safe
-  const iconStyle = {};
+  const iconStyle: CSSProperties = {};
   const safeIconLogo = isSafeUrl(iconLogo) ? iconLogo : null;
   if (safeIconLogo) {
     const alpha = 1.0 - iconOpacity / 100;
-    // Parse hex color to rgba for overlay
     let r = 0, g = 0, b = 0;
     const hex = buttonColor.replace('#', '');
     if (hex.length === 6) {
@@ -82,13 +110,11 @@ export default function TeamPanel({
     iconStyle.backgroundPosition = 'center';
   }
 
-  // In portrait, show per-team score history (logo + ScoreTable) beside the score button
-  const teamLogo = customization?.[`Team ${teamId} Logo`] || null;
+  const teamLogo = asString(customization?.[`Team ${teamId} Logo`]);
 
   return (
     <div className={`team-panel ${isPortrait ? 'team-panel-portrait' : 'team-panel-landscape'}`}>
       <div className={isPortrait ? 'team-panel-row' : 'team-panel-col'}>
-        {/* Score history column — portrait only */}
         {isPortrait && state && (
           <div className="team-history-col">
             {teamLogo && (
@@ -153,4 +179,3 @@ export default function TeamPanel({
     </div>
   );
 }
-

--- a/frontend/src/utils/coerce.ts
+++ b/frontend/src/utils/coerce.ts
@@ -1,0 +1,7 @@
+export function toNumber(v: unknown): number {
+  return typeof v === 'number' ? v : typeof v === 'string' ? Number(v) || 0 : 0;
+}
+
+export function asString(v: unknown): string | null {
+  return typeof v === 'string' && v ? v : null;
+}


### PR DESCRIPTION
## Summary
Fifth incremental TS migration batch. Converts the mid-layer scoreboard view components from `.jsx` to `.tsx`, typed against the generated OpenAPI schema so the `state` shape is no longer `any`.

- **`InitScreen`**: typed props (`FormEvent`, `ChangeEvent`). Extracted a `normalizeOverlays(data: unknown)` helper that handles both the array-of-`OverlayPayload` shape and the legacy `{ name: oid }` dict shape.
- **`ScoreTable`**: `state: GameState | null | undefined`, `teamId: 1 | 2`. Score values come out of the schema's `scores: Record<string, unknown>` bucket, so a small `toNumber` coerces before comparison.
- **`ControlButtons`**: straight prop-type conversion. Unused `matchFinished` prop is typed as optional rather than removed, since callers still pass it.
- **`CenterPanel`**: typed `PreviewData` (extracted from inline shape), `teamId: 1 | 2` narrowed for the add-set/long-press callbacks.
- **`TeamPanel`**: imports `ScoreButtonFontStyle`, uses `TeamState` from the schema, keeps the existing `isSafeUrl` type-guard for the icon overlay.

No behavior changes.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test -- --run` — 158 / 158 passing
- [x] `npm run build` — production build succeeds
- [x] `pytest tests/` — 275 / 275 passing
- [ ] Manual smoke: render scoreboard with real state, flip simple mode / undo / fullscreen.

https://claude.ai/code/session_01NUAp3CkDRkUKyVo7VAQ4z4