### PR TITLE
frontend: migrate views (App, OverlayPreview, ConfigPanel, ScoreboardView) to TypeScript

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, FormEvent } from 'react';
 import { useI18n } from './i18n';
 import { useGameState } from './hooks/useGameState';
 import { useSettings } from './hooks/useSettings';
@@ -8,19 +8,41 @@ import InitScreen from './components/InitScreen';
 import ScoreboardView from './components/ScoreboardView';
 import ConfigPanel from './components/ConfigPanel';
 import SetValueDialog from './components/SetValueDialog';
+import type { GameState } from './api/client';
+import type { ConfigModel } from './components/TeamCard';
+import type { PreviewData } from './components/CenterPanel';
+import type { ScoreButtonFontStyle } from './components/ScoreButton';
 import {
   TEAM_A_COLOR,
   TEAM_B_COLOR,
   FONT_SCALES,
 } from './theme';
 
-function getInitialOid() {
+type Team = 1 | 2;
+
+interface DialogState {
+  open: boolean;
+  title: string;
+  initialValue: number;
+  maxValue: number;
+  team: Team | null;
+  isSet: boolean;
+}
+
+interface FontScale {
+  scale: number;
+  offset_y: number;
+}
+
+function getInitialOid(): string {
   const params = new URLSearchParams(window.location.search);
   const urlOid = params.get('oid');
   if (urlOid) return urlOid;
   try {
     return localStorage.getItem('volley_oid') || '';
-  } catch { return ''; }
+  } catch {
+    return '';
+  }
 }
 
 export default function App() {
@@ -28,22 +50,22 @@ export default function App() {
   const { settings, setSetting } = useSettings();
   const { isPortrait, buttonSize } = useOrientation();
 
-  const [oid, setOid] = useState(getInitialOid);
-  const [oidInput, setOidInput] = useState(oid);
+  const [oid, setOid] = useState<string>(getInitialOid);
+  const [oidInput, setOidInput] = useState<string>(oid);
   const [undoMode, setUndoMode] = useState(false);
-  const [activeTab, setActiveTab] = useState('scoreboard');
-  const [isFullscreen, setIsFullscreen] = useState(!!document.fullscreenElement);
+  const [activeTab, setActiveTab] = useState<'scoreboard' | 'config'>('scoreboard');
+  const [isFullscreen, setIsFullscreen] = useState<boolean>(!!document.fullscreenElement);
   const [showControls, setShowControls] = useState(true);
-  const hideTimerRef = useRef(null);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const resetHideTimer = useCallback(() => {
     if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
     hideTimerRef.current = setTimeout(() => setShowControls(false), 10000);
-  }, [setShowControls]);
+  }, []);
 
-  const previewData = usePreview(oid, settings.showPreview);
+  const previewData = usePreview(oid, settings.showPreview) as PreviewData | null;
 
-  const [dialog, setDialog] = useState({
+  const [dialog, setDialog] = useState<DialogState>({
     open: false,
     title: '',
     initialValue: 0,
@@ -52,7 +74,36 @@ export default function App() {
     isSet: false,
   });
 
-  const { state, customization, connected, error, initialize, actions, refreshCustomization, setCustomization } = useGameState(oid);
+  interface GameStateHook {
+    state: GameState | null;
+    customization: ConfigModel | null;
+    connected: boolean;
+    error: string | null;
+    initialize: () => Promise<void>;
+    actions: {
+      addPoint: (team: Team, undo?: boolean) => Promise<unknown>;
+      addSet: (team: Team, undo?: boolean) => Promise<unknown>;
+      addTimeout: (team: Team, undo?: boolean) => Promise<unknown>;
+      changeServe: (team: Team) => Promise<unknown>;
+      setScore: (team: Team, setNumber: number, value: number) => Promise<unknown>;
+      setSets: (team: Team, value: number) => Promise<unknown>;
+      reset: () => Promise<unknown>;
+      setVisibility: (visible: boolean) => Promise<unknown>;
+      setSimpleMode: (enabled: boolean) => Promise<unknown>;
+    };
+    refreshCustomization: () => Promise<void>;
+    setCustomization: (c: ConfigModel) => void;
+  }
+
+  const {
+    state,
+    customization,
+    error,
+    initialize,
+    actions,
+    refreshCustomization,
+    setCustomization,
+  } = useGameState(oid) as unknown as GameStateHook;
 
   useEffect(() => {
     if (showControls && activeTab === 'scoreboard' && state) {
@@ -63,14 +114,13 @@ export default function App() {
       if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
       window.removeEventListener('pointerdown', resetHideTimer);
     };
-  }, [showControls, activeTab, !!state, resetHideTimer]);
+  }, [showControls, activeTab, state, resetHideTimer]);
 
-  const setsLimit = state?.config?.sets_limit ?? 5;
-  const pointsLimit = state?.config?.points_limit ?? 25;
+  const setsLimit = (state?.config?.sets_limit as number | undefined) ?? 5;
   const matchFinished = state?.match_finished ?? false;
   const simpleMode = state?.simple_mode ?? false;
 
-  const computeCurrentSet = useCallback(() => {
+  const computeCurrentSet = useCallback((): number => {
     if (!state) return 1;
     const t1 = state.team_1.sets;
     const t2 = state.team_2.sets;
@@ -88,7 +138,7 @@ export default function App() {
   }, [state, computeCurrentSet]);
 
   const handleInit = useCallback(
-    (e) => {
+    (e?: FormEvent<HTMLFormElement>) => {
       e?.preventDefault();
       if (oidInput.trim()) {
         setOid(oidInput.trim());
@@ -105,7 +155,7 @@ export default function App() {
   }, [oid, initialize]);
 
   const handleAddPoint = useCallback(
-    (team) => {
+    (team: Team) => {
       if (!undoMode && matchFinished) return;
       actions.addPoint(team, undoMode);
       if (undoMode) setUndoMode(false);
@@ -117,7 +167,7 @@ export default function App() {
   );
 
   const handleAddSet = useCallback(
-    (team) => {
+    (team: Team) => {
       if (!undoMode && matchFinished) return;
       actions.addSet(team, undoMode);
       if (undoMode) setUndoMode(false);
@@ -126,7 +176,7 @@ export default function App() {
   );
 
   const handleAddTimeout = useCallback(
-    (team) => {
+    (team: Team) => {
       if (!undoMode && matchFinished) return;
       actions.addTimeout(team, undoMode);
       if (undoMode) setUndoMode(false);
@@ -138,7 +188,7 @@ export default function App() {
   );
 
   const handleChangeServe = useCallback(
-    (team) => { actions.changeServe(team); },
+    (team: Team) => { actions.changeServe(team); },
     [actions]
   );
 
@@ -159,7 +209,9 @@ export default function App() {
       document.exitFullscreen();
       setIsFullscreen(false);
     } else {
-      document.documentElement.requestFullscreen().then(() => setIsFullscreen(true)).catch(() => setIsFullscreen(false));
+      document.documentElement.requestFullscreen()
+        .then(() => setIsFullscreen(true))
+        .catch(() => setIsFullscreen(false));
     }
   }, []);
 
@@ -183,7 +235,7 @@ export default function App() {
   }, []);
 
   const handleSetChange = useCallback(
-    (set) => {
+    (set: number) => {
       const clamped = Math.max(1, Math.min(set, setsLimit));
       setCurrentSet(clamped);
     },
@@ -191,15 +243,16 @@ export default function App() {
   );
 
   const handleDoubleTapScore = useCallback(
-    (team) => { actions.addPoint(team, true); },
+    (team: Team) => { actions.addPoint(team, true); },
     [actions]
   );
 
   const handleLongPressScore = useCallback(
-    (team) => {
+    (team: Team) => {
       if (!state) return;
       const teamState = team === 1 ? state.team_1 : state.team_2;
-      const currentScore = teamState.scores[`set_${currentSet}`] ?? 0;
+      const rawScore = teamState.scores?.[`set_${currentSet}`];
+      const currentScore = typeof rawScore === 'number' ? rawScore : 0;
       setDialog({
         open: true,
         title: t('dialog.setScore', { team }),
@@ -209,11 +262,11 @@ export default function App() {
         isSet: false,
       });
     },
-    [state, currentSet]
+    [state, currentSet, t]
   );
 
   const handleLongPressSet = useCallback(
-    (team) => {
+    (team: Team) => {
       if (!state) return;
       const teamState = team === 1 ? state.team_1 : state.team_2;
       setDialog({
@@ -225,11 +278,12 @@ export default function App() {
         isSet: true,
       });
     },
-    [state, setsLimit]
+    [state, setsLimit, t]
   );
 
   const handleDialogSubmit = useCallback(
-    (value) => {
+    (value: number) => {
+      if (dialog.team === null) return;
       if (dialog.isSet) {
         actions.setSets(dialog.team, value);
       } else {
@@ -240,24 +294,30 @@ export default function App() {
     [dialog, actions, currentSet]
   );
 
+  const asColor = (v: unknown, fallback: string): string =>
+    typeof v === 'string' && v ? v : fallback;
+  const asLogo = (v: unknown): string | null =>
+    typeof v === 'string' && v ? v : null;
+
   const btnColorA = settings.followTeamColors
-    ? (customization?.['Team 1 Color'] ?? TEAM_A_COLOR)
+    ? asColor(customization?.['Team 1 Color'], TEAM_A_COLOR)
     : (settings.team1BtnColor ?? TEAM_A_COLOR);
   const btnTextA = settings.followTeamColors
-    ? (customization?.['Team 1 Text Color'] ?? '#ffffff')
+    ? asColor(customization?.['Team 1 Text Color'], '#ffffff')
     : (settings.team1BtnText ?? '#ffffff');
   const btnColorB = settings.followTeamColors
-    ? (customization?.['Team 2 Color'] ?? TEAM_B_COLOR)
+    ? asColor(customization?.['Team 2 Color'], TEAM_B_COLOR)
     : (settings.team2BtnColor ?? TEAM_B_COLOR);
   const btnTextB = settings.followTeamColors
-    ? (customization?.['Team 2 Text Color'] ?? '#ffffff')
+    ? asColor(customization?.['Team 2 Text Color'], '#ffffff')
     : (settings.team2BtnText ?? '#ffffff');
 
-  const iconLogoA = settings.showIcon ? (customization?.['Team 1 Logo'] ?? null) : null;
-  const iconLogoB = settings.showIcon ? (customization?.['Team 2 Logo'] ?? null) : null;
+  const iconLogoA = settings.showIcon ? asLogo(customization?.['Team 1 Logo']) : null;
+  const iconLogoB = settings.showIcon ? asLogo(customization?.['Team 2 Logo']) : null;
 
-  const fontProps = FONT_SCALES[settings.selectedFont] || FONT_SCALES.Default;
-  const fontStyle = settings.selectedFont && settings.selectedFont !== 'Default'
+  const fontScales = FONT_SCALES as Record<string, FontScale>;
+  const fontProps: FontScale = fontScales[settings.selectedFont] ?? fontScales.Default;
+  const fontStyle: ScoreButtonFontStyle = settings.selectedFont && settings.selectedFont !== 'Default'
     ? { fontFamily: `'${settings.selectedFont}'`, fontScale: fontProps.scale, fontOffsetY: fontProps.offset_y }
     : { fontFamily: undefined, fontScale: 1.0, fontOffsetY: 0.0 };
 

--- a/frontend/src/components/ConfigPanel.tsx
+++ b/frontend/src/components/ConfigPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useI18n } from '../i18n';
 import { useSettings } from '../hooks/useSettings';
 import { useOrientation } from '../hooks/useOrientation';
@@ -6,12 +6,16 @@ import * as api from '../api/client';
 import TeamsSection from './config/TeamsSection';
 import OverlaySection from './config/OverlaySection';
 import PositionSection from './config/PositionSection';
-import ButtonsSection from './config/ButtonsSection';
-import BehaviorSection from './config/BehaviorSection';
+import ButtonsSection, { ButtonsSectionProps } from './config/ButtonsSection';
+import BehaviorSection, { BehaviorSectionProps } from './config/BehaviorSection';
 import LinksSection from './config/LinksSection';
+import type { ConfigModel, PredefinedTeams } from './TeamCard';
+import type { LinksSectionLinks } from './config/LinksSection';
 
-const SECTIONS = ['teams', 'overlay', 'position', 'buttons', 'behavior', 'links'];
-const SECTION_KEYS = {
+type Section = 'teams' | 'overlay' | 'position' | 'buttons' | 'behavior' | 'links';
+
+const SECTIONS: readonly Section[] = ['teams', 'overlay', 'position', 'buttons', 'behavior', 'links'];
+const SECTION_KEYS: Record<Section, string> = {
   teams: 'section.teams',
   overlay: 'section.overlay',
   position: 'section.position',
@@ -19,7 +23,7 @@ const SECTION_KEYS = {
   behavior: 'section.behavior',
   links: 'section.links',
 };
-const SECTION_ICONS = {
+const SECTION_ICONS: Record<Section, string> = {
   teams: 'groups',
   overlay: 'palette',
   position: 'open_with',
@@ -28,14 +32,36 @@ const SECTION_ICONS = {
   links: 'link',
 };
 
-export default function ConfigPanel({ oid, customization, actions, onBack, onReset, onLogout, onCustomizationSaved, onCustomizationRefreshed }) {
+type Themes = Record<string, ConfigModel>;
+type LinksData = LinksSectionLinks | null;
+
+export interface ConfigPanelProps {
+  oid: string;
+  customization: ConfigModel | null | undefined;
+  actions?: unknown;
+  onBack: () => void;
+  onReset: () => void;
+  onLogout: () => void;
+  onCustomizationSaved?: () => void | Promise<void>;
+  onCustomizationRefreshed?: (fresh: ConfigModel) => void;
+}
+
+export default function ConfigPanel({
+  oid,
+  customization,
+  onBack,
+  onReset,
+  onLogout,
+  onCustomizationSaved,
+  onCustomizationRefreshed,
+}: ConfigPanelProps) {
   const { t } = useI18n();
   const { settings, setSetting } = useSettings();
   const { isPortrait } = useOrientation();
 
-  const [model, setModel] = useState(() => ({ ...customization }));
+  const [model, setModel] = useState<ConfigModel>(() => ({ ...(customization ?? {}) }));
   const [saving, setSaving] = useState(false);
-  const [saveError, setSaveError] = useState(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
     if (customization) {
@@ -44,21 +70,21 @@ export default function ConfigPanel({ oid, customization, actions, onBack, onRes
   }, [customization]);
 
   const [refreshing, setRefreshing] = useState(false);
-  const [predefinedTeams, setPredefinedTeams] = useState({});
-  const [themes, setThemes] = useState({});
-  const [styles, setStyles] = useState([]);
-  const [links, setLinks] = useState(null);
+  const [predefinedTeams, setPredefinedTeams] = useState<PredefinedTeams>({});
+  const [themes, setThemes] = useState<Themes>({});
+  const [styles, setStyles] = useState<string[]>([]);
+  const [links, setLinks] = useState<LinksData>(null);
   const [selectedTheme, setSelectedTheme] = useState('');
-  const [activeSection, setActiveSection] = useState('teams');
+  const [activeSection, setActiveSection] = useState<Section | null>('teams');
 
   useEffect(() => {
-    api.getTeams().then(setPredefinedTeams).catch(console.warn);
-    api.getThemes().then(setThemes).catch(console.warn);
-    api.getLinks(oid).then(setLinks).catch(console.warn);
+    api.getTeams().then((d) => setPredefinedTeams(d as PredefinedTeams)).catch(console.warn);
+    api.getThemes().then((d) => setThemes(d as Themes)).catch(console.warn);
+    api.getLinks(oid).then((d) => setLinks(d as LinksData)).catch(console.warn);
     api.getStyles(oid).then(setStyles).catch(console.warn);
   }, [oid]);
 
-  const updateField = useCallback((key, value) => {
+  const updateField = useCallback((key: string, value: unknown) => {
     setModel((m) => ({ ...m, [key]: value }));
   }, []);
 
@@ -70,7 +96,8 @@ export default function ConfigPanel({ oid, customization, actions, onBack, onRes
       if (onCustomizationSaved) await onCustomizationSaved();
       onBack();
     } catch (e) {
-      setSaveError(e.message || t('config.failedToSave'));
+      const msg = e instanceof Error ? e.message : t('config.failedToSave');
+      setSaveError(msg);
     } finally {
       setSaving(false);
     }
@@ -88,16 +115,18 @@ export default function ConfigPanel({ oid, customization, actions, onBack, onRes
     }
   }, [oid, t, onCustomizationRefreshed]);
 
-  const handleApplyTheme = useCallback((themeName) => {
+  const handleApplyTheme = useCallback((themeName: string) => {
     const themeData = themes[themeName];
     if (themeData) {
       setModel((m) => ({ ...m, ...themeData }));
     }
   }, [themes]);
 
-  const isCustomOverlay = links?.overlay && !links.overlay.includes('overlays.uno');
+  const isCustomOverlay = !!(
+    links?.overlay && typeof links.overlay === 'string' && !links.overlay.includes('overlays.uno')
+  );
 
-  function renderSection(sec) {
+  function renderSection(sec: Section | null) {
     switch (sec) {
       case 'teams':
         return <TeamsSection model={model} updateField={updateField} predefinedTeams={predefinedTeams} />;
@@ -117,9 +146,19 @@ export default function ConfigPanel({ oid, customization, actions, onBack, onRes
       case 'position':
         return <PositionSection model={model} updateField={updateField} />;
       case 'buttons':
-        return <ButtonsSection settings={settings} setSetting={setSetting} />;
+        return (
+          <ButtonsSection
+            settings={settings}
+            setSetting={setSetting as ButtonsSectionProps['setSetting']}
+          />
+        );
       case 'behavior':
-        return <BehaviorSection settings={settings} setSetting={setSetting} />;
+        return (
+          <BehaviorSection
+            settings={settings}
+            setSetting={setSetting as BehaviorSectionProps['setSetting']}
+          />
+        );
       case 'links':
         return <LinksSection links={links} />;
       default:
@@ -129,7 +168,6 @@ export default function ConfigPanel({ oid, customization, actions, onBack, onRes
 
   return (
     <div className="config-panel">
-      {/* Sticky top bar */}
       <div className="config-top-bar">
         <button className="config-top-btn" onClick={onBack} title={t('config.backToScoreboard')}
           data-testid="scoreboard-tab-button">
@@ -139,7 +177,6 @@ export default function ConfigPanel({ oid, customization, actions, onBack, onRes
         <div style={{ minWidth: 44 }} />
       </div>
 
-      {/* Main body */}
       <div className={`config-body ${isPortrait ? 'config-body-portrait' : 'config-body-landscape'}`}>
         {isPortrait ? (
           <div className="config-accordion">
@@ -184,7 +221,6 @@ export default function ConfigPanel({ oid, customization, actions, onBack, onRes
         )}
       </div>
 
-      {/* Fixed bottom bar */}
       <div className="config-bottom-bar">
         <button className="config-bottom-btn config-bottom-btn-save"
           onClick={handleSave} disabled={saving} title={t('config.saveCustomization')} data-testid="save-button">
@@ -207,7 +243,6 @@ export default function ConfigPanel({ oid, customization, actions, onBack, onRes
         </button>
       </div>
 
-      {/* Save error */}
       {saveError && (
         <div className="config-save-error">{saveError}</div>
       )}

--- a/frontend/src/components/OverlayPreview.tsx
+++ b/frontend/src/components/OverlayPreview.tsx
@@ -1,49 +1,75 @@
-import React, { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useState, CSSProperties } from 'react';
 import { useI18n } from '../i18n';
 
 const CHAMPIONSHIP_LAYOUT_ID = '446a382f-25c0-4d1d-ae25-48373334e06b';
 
+export interface OverlayPreviewProps {
+  overlayUrl: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  layoutId?: string;
+  cardWidth?: number;
+}
+
+interface Bounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 /**
  * Renders an overlay preview by loading the full overlay output page in a
  * hidden iframe and using CSS transforms to crop/scale to just the scoreboard
- * region.  Mirrors the logic in app/preview.py create_iframe_card().
+ * region. Mirrors the logic in app/preview.py create_iframe_card().
  */
-export default function OverlayPreview({ overlayUrl, x, y, width, height, layoutId, cardWidth = 300 }) {
+export default function OverlayPreview({
+  overlayUrl,
+  x,
+  y,
+  width,
+  height,
+  layoutId,
+  cardWidth = 300,
+}: OverlayPreviewProps) {
   const { t } = useI18n();
-  const containerRef = useRef(null);
-  const [customBounds, setCustomBounds] = useState(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [customBounds, setCustomBounds] = useState<Bounds | null>(null);
   // Unique token per mount — forces the browser to bypass cache when the iframe
   // is recreated (e.g. after page reload or navigating back from ConfigPanel),
   // ensuring the overlay page re-establishes its WebSocket connection immediately.
-  const [cacheBust] = useState(() => Date.now());
+  const [cacheBust] = useState<number>(() => Date.now());
 
-  const getBustedUrl = (urlStr, params = {}) => {
+  const getBustedUrl = (urlStr: string, params: Record<string, string> = {}): string => {
     try {
       const url = new URL(urlStr, window.location.href);
       Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
-      url.searchParams.set('_t', cacheBust);
+      url.searchParams.set('_t', String(cacheBust));
       return url.toString();
     } catch {
       return urlStr;
     }
   };
 
-  const isCustomOverlay = layoutId && (layoutId.startsWith('C-') || layoutId === 'auto')
-    || (overlayUrl && !overlayUrl.includes('overlays.uno'));
+  const isCustomOverlay = !!(
+    (layoutId && (layoutId.startsWith('C-') || layoutId === 'auto'))
+    || (overlayUrl && !overlayUrl.includes('overlays.uno'))
+  );
 
-  // Listen for postMessage from custom overlays reporting their render area
   useEffect(() => {
     if (!isCustomOverlay) return;
-    function onMessage(event) {
-      // Validate origin — only accept messages from the overlay URL's origin
+    function onMessage(event: MessageEvent) {
       try {
         const allowedOrigin = new URL(overlayUrl).origin;
         if (event.origin !== allowedOrigin) return;
       } catch {
         return;
       }
-      if (event.data?.type === 'overlayRenderArea') {
-        setCustomBounds(event.data.bounds);
+      const data = event.data as { type?: string; bounds?: Bounds } | undefined;
+      if (data?.type === 'overlayRenderArea' && data.bounds) {
+        setCustomBounds(data.bounds);
       }
     }
     window.addEventListener('message', onMessage);
@@ -57,7 +83,7 @@ export default function OverlayPreview({ overlayUrl, x, y, width, height, layout
     const iframeW = 1920;
     const iframeH = 1080;
 
-    let wrapperStyle = {
+    let wrapperStyle: CSSProperties = {
       position: 'absolute',
       width: iframeW,
       height: iframeH,
@@ -98,7 +124,7 @@ export default function OverlayPreview({ overlayUrl, x, y, width, height, layout
             height={iframeH}
             style={{ border: 0, background: 'transparent' }}
             sandbox="allow-scripts allow-same-origin"
-            allowTransparency="true"
+            allowTransparency
             title={t('preview.title')}
             data-testid="overlay-preview"
           />
@@ -110,15 +136,13 @@ export default function OverlayPreview({ overlayUrl, x, y, width, height, layout
   // --- Standard overlay (overlays.uno) ---
   const championship = layoutId === CHAMPIONSHIP_LAYOUT_ID;
   const iframeWidth = 600;
-  const iframeHeight = iframeWidth * 9 / 16; // 337.5
+  const iframeHeight = iframeWidth * 9 / 16;
 
   const cardHeight = cardWidth * height / width;
 
-  // Region size in iframe pixels
   const regionW = (width / 100) * iframeWidth;
   const regionH = (height / (championship ? 60 : 100)) * iframeHeight;
 
-  // Top-left corner in abstract coords → iframe pixels
   const leftCoord = x - width / 2;
   const topCoord = y - height * (5 / 17);
   const leftPx = ((leftCoord + 50) / 100) * iframeWidth;
@@ -126,12 +150,10 @@ export default function OverlayPreview({ overlayUrl, x, y, width, height, layout
     ? (topCoord / 100) * iframeHeight
     : ((topCoord + 50) / 100) * iframeHeight;
 
-  // Scale to fit region into the card
   const scale = regionW > 0 && regionH > 0
     ? Math.min(cardWidth / regionW, (cardHeight / 2) / regionH)
     : 1;
 
-  // Append aspect ratio param + cache-bust; keep background transparent
   const src = getBustedUrl(overlayUrl, { aspect: '16:9' });
 
   return (
@@ -155,7 +177,7 @@ export default function OverlayPreview({ overlayUrl, x, y, width, height, layout
           height={iframeHeight}
           style={{ border: 0, background: 'transparent', position: 'absolute', top: -topPx, left: -leftPx }}
           sandbox="allow-scripts allow-same-origin"
-          allowTransparency="true"
+          allowTransparency={'true' as unknown as boolean}
           title={t('preview.title')}
           data-testid="overlay-preview"
         />

--- a/frontend/src/components/ScoreboardView.tsx
+++ b/frontend/src/components/ScoreboardView.tsx
@@ -1,14 +1,59 @@
-import React from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import { useI18n } from '../i18n';
 import TeamPanel from './TeamPanel';
 import CenterPanel from './CenterPanel';
 import ControlButtons from './ControlButtons';
+import type { GameState } from '../api/client';
+import type { ConfigModel } from './TeamCard';
+import type { PreviewData } from './CenterPanel';
+import type { ScoreButtonFontStyle } from './ScoreButton';
 import {
   TEAM_A_SERVE_ACTIVE,
   TEAM_B_SERVE_ACTIVE,
   TEAM_A_LIGHT,
   TEAM_B_LIGHT,
 } from '../theme';
+
+export interface ScoreboardViewProps {
+  state: GameState;
+  customization: ConfigModel | null | undefined;
+  currentSet: number;
+  setsLimit: number;
+  isPortrait: boolean;
+  buttonSize?: number;
+  previewData: PreviewData | null | undefined;
+  showPreview: boolean;
+  showControls: boolean;
+  setShowControls: Dispatch<SetStateAction<boolean>>;
+  undoMode: boolean;
+  simpleMode: boolean;
+  matchFinished: boolean;
+  isFullscreen: boolean;
+  darkMode: boolean;
+  btnColorA: string;
+  btnTextA: string;
+  btnColorB: string;
+  btnTextB: string;
+  iconLogoA: string | null;
+  iconLogoB: string | null;
+  iconOpacity?: number;
+  fontStyle?: ScoreButtonFontStyle;
+  onAddPoint: (teamId: 1 | 2) => void;
+  onAddSet: (teamId: 1 | 2) => void;
+  onAddTimeout: (teamId: 1 | 2) => void;
+  onChangeServe: (teamId: 1 | 2) => void;
+  onDoubleTapScore: (teamId: 1 | 2) => void;
+  onLongPressScore: (teamId: 1 | 2) => void;
+  onLongPressSet: (teamId: 1 | 2) => void;
+  onSetChange: (set: number) => void;
+  onToggleVisibility: () => void;
+  onToggleSimpleMode: () => void;
+  onToggleUndo: () => void;
+  onToggleDarkMode: () => void;
+  onToggleFullscreen: () => void;
+  onTogglePreview: () => void;
+  onOpenConfig: () => void;
+}
 
 export default function ScoreboardView({
   state,
@@ -49,7 +94,7 @@ export default function ScoreboardView({
   onToggleFullscreen,
   onTogglePreview,
   onOpenConfig,
-}) {
+}: ScoreboardViewProps) {
   const { t } = useI18n();
 
   return (


### PR DESCRIPTION
## Summary
- Convert the four remaining top-level React source files to `.tsx`: `App`, `OverlayPreview`, `ConfigPanel`, `ScoreboardView`.
- Introduce typed prop interfaces (`OverlayPreviewProps`, `ConfigPanelProps`, `ScoreboardViewProps`) and a typed `DialogState` + `GameStateHook` shape for App.
- Reuse shared types already established in earlier PRs: `GameState`, `ConfigModel`, `PredefinedTeams`, `PreviewData`, `ScoreButtonFontStyle`, `LinksSectionLinks`, `Settings`/`SetSetting`.
- Narrow `setSetting` at call sites of `ButtonsSection`/`BehaviorSection` via `ButtonsSectionProps['setSetting']`/`BehaviorSectionProps['setSetting']` casts to satisfy the section-specific generic signatures.
- Route `useGameState` and `usePreview` (still `.js`) returns through a narrow type cast since those hooks remain JS for now.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test -- --run` — 158/158 passing
- [x] `npm run build` — production build succeeds
- [x] `pytest tests/` — 275/275 passing

After this PR only `src/test/*.test.jsx` + `src/test/helpers.jsx` remain as `.jsx`; those will be migrated in the next PR.

https://claude.ai/code/session_01NUAp3CkDRkUKyVo7VAQ4z4