### PR TITLE
fix(preview): wait for session before fetching overlay links

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,6 @@ import ConfigPanel from './components/ConfigPanel';
 import SetValueDialog from './components/SetValueDialog';
 import type { GameState } from './api/client';
 import type { ConfigModel } from './components/TeamCard';
-import type { PreviewData } from './components/CenterPanel';
 import type { ScoreButtonFontStyle } from './components/ScoreButton';
 import {
   TEAM_A_COLOR,
@@ -84,7 +83,7 @@ export default function App() {
 
   // Gate preview fetch on session readiness — /api/v1/links returns 404 until
   // initSession has created the session.
-  const previewData = usePreview(oid, settings.showPreview, !!state) as PreviewData | null;
+  const previewData = usePreview(oid, settings.showPreview, !!state);
 
   useEffect(() => {
     if (showControls && activeTab === 'scoreboard' && state) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,8 +63,6 @@ export default function App() {
     hideTimerRef.current = setTimeout(() => setShowControls(false), 10000);
   }, []);
 
-  const previewData = usePreview(oid, settings.showPreview) as PreviewData | null;
-
   const [dialog, setDialog] = useState<DialogState>({
     open: false,
     title: '',
@@ -83,6 +81,10 @@ export default function App() {
     refreshCustomization,
     setCustomization,
   } = useGameState(oid);
+
+  // Gate preview fetch on session readiness — /api/v1/links returns 404 until
+  // initSession has created the session.
+  const previewData = usePreview(oid, settings.showPreview, !!state) as PreviewData | null;
 
   useEffect(() => {
     if (showControls && activeTab === 'scoreboard' && state) {

--- a/frontend/src/hooks/usePreview.ts
+++ b/frontend/src/hooks/usePreview.ts
@@ -18,14 +18,14 @@ export function usePreview(
   const [previewData, setPreviewData] = useState<PreviewData | null>(null);
 
   useEffect(() => {
-    if (!oid || !showPreview) {
+    if (!oid || !showPreview || !ready) {
+      // /api/v1/links requires an initialised session. On first load the hook
+      // fires in parallel with session init and races it — wait for `ready`
+      // before fetching, and clear stale data in the meantime (e.g. after an
+      // oid change, before the new session is up).
       setPreviewData(null);
       return;
     }
-    // /api/v1/links requires an initialised session. On first load the hook
-    // fires in parallel with session init and races it — gate the fetch on
-    // `ready` so we wait until the session exists.
-    if (!ready) return;
     let cancelled = false;
     setPreviewData(null);
     api.getLinks(oid).then((links) => {

--- a/frontend/src/hooks/usePreview.ts
+++ b/frontend/src/hooks/usePreview.ts
@@ -10,7 +10,11 @@ export interface PreviewData {
   layoutId: string;
 }
 
-export function usePreview(oid: string | null, showPreview: boolean): PreviewData | null {
+export function usePreview(
+  oid: string | null,
+  showPreview: boolean,
+  ready: boolean = true,
+): PreviewData | null {
   const [previewData, setPreviewData] = useState<PreviewData | null>(null);
 
   useEffect(() => {
@@ -18,6 +22,10 @@ export function usePreview(oid: string | null, showPreview: boolean): PreviewDat
       setPreviewData(null);
       return;
     }
+    // /api/v1/links requires an initialised session. On first load the hook
+    // fires in parallel with session init and races it — gate the fetch on
+    // `ready` so we wait until the session exists.
+    if (!ready) return;
     let cancelled = false;
     setPreviewData(null);
     api.getLinks(oid).then((links) => {
@@ -39,7 +47,7 @@ export function usePreview(oid: string | null, showPreview: boolean): PreviewDat
       if (!cancelled) setPreviewData(null);
     });
     return () => { cancelled = true; };
-  }, [oid, showPreview]);
+  }, [oid, showPreview, ready]);
 
   return previewData;
 }


### PR DESCRIPTION
## Summary

- On first page load the overlay preview did not appear even when enabled; a refresh made it show up.
- Root cause: `usePreview` fires `GET /api/v1/links` on mount, racing `initSession`. `/links` requires an active session and returns 404 until init finishes. The hook swallowed the error and never retried (deps unchanged). On refresh the server-side session persisted from the prior load, so the call succeeded — masking the bug.
- Fix: added a `ready` flag to `usePreview`, wired to `!!state` in `App.tsx`, so the links fetch is deferred until the session has been initialised.

## Test plan

- [x] `npm test` — 158/158 tests pass
- [x] `npm run build` — builds cleanly
- [ ] Manual: clear localStorage/session, load app with `showPreview=true` → preview card should appear without needing a refresh
- [ ] Manual: toggle preview off/on → still works
- [ ] Manual: page refresh with existing session → preview still appears
