### PR TITLE
feat(preview): add standalone /preview page with zoom, theme, fullscreen

### DIFF
--- a/app/api/routes/overlays.py
+++ b/app/api/routes/overlays.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import urllib.parse
 
 from fastapi import APIRouter, Depends, Header, Request
 from pydantic import BaseModel, Field
@@ -98,11 +99,34 @@ async def get_links(request: Request,
         )
         links["overlay"] = overlay_url
 
-        # Custom overlays need a preview URL for the frontend preview card.
-        # The preview URL encodes geometry hints; the OverlayPreview component
-        # uses postMessage bounds for actual positioning.
+        # Build a preview-page URL pointing at the SPA /preview route. The
+        # in-app preview card consumes the geometry params from this URL, and
+        # users can also open it directly as a standalone scalable preview.
+        # Custom overlays use layout_id=auto so the overlay JS reports its
+        # render bounds via postMessage; geometry params are ignored in that
+        # branch but kept for a uniform URL shape.
         if session.backend.is_custom_overlay(oid):
-            links["preview"] = f"{overlay_url}?layout_id=auto"
+            layout_id = "auto"
+            x = y = 0.0
+            width = height = 100.0
+        else:
+            layout_id = session.conf.id or ""
+            cust = session.customization
+            x = cust.get_h_pos()
+            y = cust.get_v_pos()
+            width = cust.get_width()
+            height = cust.get_height()
+
+        base_url = str(request.base_url).rstrip('/')
+        preview_qs = urllib.parse.urlencode({
+            "output": overlay_url,
+            "x": x,
+            "y": y,
+            "width": width,
+            "height": height,
+            "layout_id": layout_id,
+        })
+        links["preview"] = f"{base_url}/preview?{preview_qs}"
 
     return links
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -439,6 +439,100 @@ body {
   align-items: center;
 }
 
+/* ── Standalone preview page (/preview) ─────────────────────────────── */
+
+.preview-page {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.preview-page--dark {
+  background-color: #1d1d1d;
+  color: #f0f0f0;
+}
+
+.preview-page--light {
+  background-color: #ffffff;
+  color: #333333;
+}
+
+.preview-page-stage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.preview-page .preview-container {
+  margin-top: 0;
+  box-shadow: none;
+}
+
+.preview-page-empty {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: system-ui, -apple-system, sans-serif;
+  background-color: #1d1d1d;
+  color: #f0f0f0;
+}
+
+.preview-page-toolbar {
+  position: fixed;
+  bottom: 12px;
+  left: 12px;
+  right: 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  opacity: 0.25;
+  transition: opacity 0.15s ease;
+  pointer-events: auto;
+}
+
+.preview-page-toolbar:hover,
+.preview-page-toolbar:focus-within {
+  opacity: 0.95;
+}
+
+.preview-tool-spacer {
+  flex: 1 1 auto;
+}
+
+.preview-tool-btn {
+  background: transparent;
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  padding: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: inherit;
+  line-height: 0;
+}
+
+.preview-tool-btn:hover:not(:disabled) {
+  background: rgba(127, 127, 127, 0.18);
+}
+
+.preview-tool-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.preview-tool-btn .material-icons {
+  font-size: 20px;
+}
+
 /* ── Set pagination ──────────────────────────────────────────────────── */
 
 .set-pagination {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -447,7 +447,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  overflow: hidden;
+  overflow: auto;
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 

--- a/frontend/src/PreviewApp.tsx
+++ b/frontend/src/PreviewApp.tsx
@@ -1,0 +1,134 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import OverlayPreview from './components/OverlayPreview';
+import { I18nProvider, useI18n } from './i18n';
+
+const SCALE_MIN = 0.5;
+const SCALE_MAX = 2.0;
+const SCALE_STEP = 0.2;
+
+function readNumberParam(params: URLSearchParams, key: string, fallback: number): number {
+  const v = params.get(key);
+  if (v === null || v === '') return fallback;
+  const n = parseFloat(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function PreviewPageInner() {
+  const { t } = useI18n();
+
+  const queryParams = useMemo(
+    () => new URLSearchParams(window.location.search),
+    [],
+  );
+  const overlayUrl = queryParams.get('output') || '';
+  const x = readNumberParam(queryParams, 'x', 0);
+  const y = readNumberParam(queryParams, 'y', 0);
+  const width = readNumberParam(queryParams, 'width', 100);
+  const height = readNumberParam(queryParams, 'height', 100);
+  const layoutId = queryParams.get('layout_id') || '';
+
+  const [scale, setScale] = useState<number>(1);
+  const [darkBackdrop, setDarkBackdrop] = useState<boolean>(true);
+  const [isFullscreen, setIsFullscreen] = useState<boolean>(false);
+  const [pageWidth, setPageWidth] = useState<number>(window.innerWidth);
+
+  useEffect(() => {
+    const onResize = () => setPageWidth(window.innerWidth);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  useEffect(() => {
+    const onFs = () => setIsFullscreen(!!document.fullscreenElement);
+    document.addEventListener('fullscreenchange', onFs);
+    return () => document.removeEventListener('fullscreenchange', onFs);
+  }, []);
+
+  const cardWidth = Math.max(120, Math.round((pageWidth / 1.2) * scale));
+
+  const onZoomIn = useCallback(
+    () => setScale((s) => Math.min(SCALE_MAX, +(s + SCALE_STEP).toFixed(2))),
+    [],
+  );
+  const onZoomOut = useCallback(
+    () => setScale((s) => Math.max(SCALE_MIN, +(s - SCALE_STEP).toFixed(2))),
+    [],
+  );
+  const onToggleBackdrop = useCallback(() => setDarkBackdrop((v) => !v), []);
+  const onToggleFullscreen = useCallback(() => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(() => {});
+    } else {
+      document.documentElement.requestFullscreen().catch(() => {});
+    }
+  }, []);
+
+  if (!overlayUrl) {
+    return <div className="preview-page-empty">{t('preview.missingOutput')}</div>;
+  }
+
+  return (
+    <div className={`preview-page ${darkBackdrop ? 'preview-page--dark' : 'preview-page--light'}`}>
+      <div className="preview-page-stage">
+        <OverlayPreview
+          overlayUrl={overlayUrl}
+          x={x}
+          y={y}
+          width={width}
+          height={height}
+          layoutId={layoutId || undefined}
+          cardWidth={cardWidth}
+        />
+      </div>
+      <div className="preview-page-toolbar" data-testid="preview-toolbar">
+        <button
+          type="button"
+          className="preview-tool-btn"
+          title={t('preview.zoomOut')}
+          aria-label={t('preview.zoomOut')}
+          onClick={onZoomOut}
+          disabled={scale <= SCALE_MIN}
+        >
+          <span className="material-icons">remove</span>
+        </button>
+        <button
+          type="button"
+          className="preview-tool-btn"
+          title={t('preview.zoomIn')}
+          aria-label={t('preview.zoomIn')}
+          onClick={onZoomIn}
+          disabled={scale >= SCALE_MAX}
+        >
+          <span className="material-icons">add</span>
+        </button>
+        <div className="preview-tool-spacer" />
+        <button
+          type="button"
+          className="preview-tool-btn"
+          title={darkBackdrop ? t('ctrl.lightMode') : t('ctrl.darkMode')}
+          aria-label={darkBackdrop ? t('ctrl.lightMode') : t('ctrl.darkMode')}
+          onClick={onToggleBackdrop}
+        >
+          <span className="material-icons">{darkBackdrop ? 'light_mode' : 'dark_mode'}</span>
+        </button>
+        <button
+          type="button"
+          className="preview-tool-btn"
+          title={isFullscreen ? t('ctrl.exitFullscreen') : t('ctrl.fullscreen')}
+          aria-label={isFullscreen ? t('ctrl.exitFullscreen') : t('ctrl.fullscreen')}
+          onClick={onToggleFullscreen}
+        >
+          <span className="material-icons">{isFullscreen ? 'fullscreen_exit' : 'fullscreen'}</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function PreviewApp() {
+  return (
+    <I18nProvider>
+      <PreviewPageInner />
+    </I18nProvider>
+  );
+}

--- a/frontend/src/PreviewApp.tsx
+++ b/frontend/src/PreviewApp.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import OverlayPreview from './components/OverlayPreview';
 import { I18nProvider, useI18n } from './i18n';
 
@@ -16,10 +16,7 @@ function readNumberParam(params: URLSearchParams, key: string, fallback: number)
 function PreviewPageInner() {
   const { t } = useI18n();
 
-  const queryParams = useMemo(
-    () => new URLSearchParams(window.location.search),
-    [],
-  );
+  const queryParams = new URLSearchParams(window.location.search);
   const overlayUrl = queryParams.get('output') || '';
   const x = readNumberParam(queryParams, 'x', 0);
   const y = readNumberParam(queryParams, 'y', 0);

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -113,6 +113,9 @@ const translations: Record<string, TranslationDict> = {
 
     // Preview
     'preview.title': 'Overlay preview',
+    'preview.zoomIn': 'Zoom in',
+    'preview.zoomOut': 'Zoom out',
+    'preview.missingOutput': 'No overlay output URL provided.',
 
     // Color picker
     'colorPicker.presets': 'Presets',
@@ -231,6 +234,9 @@ const translations: Record<string, TranslationDict> = {
 
     // Preview
     'preview.title': 'Vista previa del overlay',
+    'preview.zoomIn': 'Acercar',
+    'preview.zoomOut': 'Alejar',
+    'preview.missingOutput': 'No se ha proporcionado URL de salida del overlay.',
 
     // Color picker
     'colorPicker.presets': 'Predefinidos',

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,17 +3,25 @@ import ReactDOM from 'react-dom/client';
 import { I18nProvider } from './i18n';
 import { SettingsProvider } from './hooks/useSettings';
 import App from './App';
+import PreviewApp from './PreviewApp';
 import './App.css';
 
 const root = document.getElementById('root');
 if (!root) throw new Error('Root element #root not found');
 
+const isPreviewRoute =
+  window.location.pathname.replace(/\/+$/, '') === '/preview';
+
 ReactDOM.createRoot(root).render(
   <React.StrictMode>
-    <I18nProvider>
-      <SettingsProvider>
-        <App />
-      </SettingsProvider>
-    </I18nProvider>
+    {isPreviewRoute ? (
+      <PreviewApp />
+    ) : (
+      <I18nProvider>
+        <SettingsProvider>
+          <App />
+        </SettingsProvider>
+      </I18nProvider>
+    )}
   </React.StrictMode>
 );

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,7 +10,7 @@ const root = document.getElementById('root');
 if (!root) throw new Error('Root element #root not found');
 
 const isPreviewRoute =
-  window.location.pathname.replace(/\/+$/, '') === '/preview';
+  window.location.pathname.replace(/\/+$/, '').endsWith('/preview');
 
 ReactDOM.createRoot(root).render(
   <React.StrictMode>

--- a/frontend/src/test/PreviewApp.test.tsx
+++ b/frontend/src/test/PreviewApp.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PreviewApp from '../PreviewApp';
+
+function setLocation(search: string, pathname = '/preview') {
+  window.history.replaceState({}, '', `${pathname}${search}`);
+}
+
+describe('PreviewApp', () => {
+  beforeEach(() => {
+    setLocation('');
+  });
+
+  afterEach(() => {
+    setLocation('', '/');
+  });
+
+  it('shows missing-output message when output param is absent', () => {
+    setLocation('');
+    render(<PreviewApp />);
+    expect(screen.getByText(/no overlay output/i)).toBeInTheDocument();
+  });
+
+  it('renders OverlayPreview iframe when output param is provided', () => {
+    setLocation(
+      '?output=https%3A%2F%2Foverlays.uno%2Foutput%2Fabc&x=-33&y=-41&width=30&height=10&layout_id=lyt',
+    );
+    render(<PreviewApp />);
+    const iframe = screen.getByTestId('overlay-preview');
+    expect(iframe.getAttribute('src')).toContain('overlays.uno/output/abc');
+  });
+
+  it('renders the toolbar with zoom, theme and fullscreen controls', () => {
+    setLocation(
+      '?output=https%3A%2F%2Foverlays.uno%2Foutput%2Fabc&x=0&y=0&width=30&height=10',
+    );
+    render(<PreviewApp />);
+    const toolbar = screen.getByTestId('preview-toolbar');
+    expect(toolbar).toBeInTheDocument();
+    expect(toolbar.querySelectorAll('button').length).toBe(4);
+  });
+
+  it('toggles backdrop class when light/dark button is clicked', async () => {
+    setLocation(
+      '?output=https%3A%2F%2Foverlays.uno%2Foutput%2Fabc&x=0&y=0&width=30&height=10',
+    );
+    const { container } = render(<PreviewApp />);
+    const page = container.querySelector('.preview-page') as HTMLElement;
+    expect(page.classList.contains('preview-page--dark')).toBe(true);
+
+    const themeBtn = screen.getByLabelText(/light mode/i);
+    await userEvent.click(themeBtn);
+    expect(page.classList.contains('preview-page--light')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- New SPA `/preview` route (no router dep — `main.tsx` dispatches on pathname) that hosts the existing `OverlayPreview` on a centered stage with a low-opacity bottom toolbar: zoom −/+, dark/light backdrop, fullscreen. Toolbar opacity 0.25 idle / 0.95 hover.
- `/api/v1/links` now returns a real preview-page URL for **both** custom and overlays.uno OIDs (was custom-only and pointed at the same overlay output URL). Encodes `output`, `x`, `y`, `width`, `height`, `layout_id`.
- In-app preview card still works because `usePreview` already parses geometry from the preview URL's query string — the param names are unchanged.
- Geometry for overlays.uno is sourced from `session.customization.get_h_pos/get_v_pos/get_width/get_height` (mirrors the original NiceGUI `/preview` route on `main`).
- i18n: added `preview.zoomIn`, `preview.zoomOut`, `preview.missingOutput` (en + es).

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npx vitest run` — 162/162 pass (including 4 new `PreviewApp.test.tsx` cases)
- [x] `pytest` — passes for everything not requiring `httpx` (162 passed); httpx-gated suites unrelated to this change
- [ ] Smoke: open the preview link from the Links dialog for a custom overlay → standalone page renders, zoom +/− resizes, light/dark toggles backdrop, fullscreen works
- [ ] Smoke: same for an overlays.uno OID
- [ ] Smoke: in-app preview card still renders correctly after the API URL shape change

🤖 Generated with [Claude Code](https://claude.com/claude-code)