### PR TITLE
feat(oid): resolve overlays by existence, not by C- prefix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ volley-overlay-control/
 | Session | `SessionManager` | `app/api/session_manager.py` | Thread-safe game session management by OID |
 | WS Hub | `WSHub` | `app/api/ws_hub.py` | WebSocket notification hub for real-time state push |
 | Sync | `Backend` | `app/backend.py` | Coordinator — delegates to overlay backend strategies |
-| Overlay | `LocalOverlayBackend` | `app/overlay_backends.py` | In-process overlay state management (default for C- OIDs) |
+| Overlay | `LocalOverlayBackend` | `app/overlay_backends.py` | In-process overlay state management (default for custom overlays) |
 | Overlay | `OverlayStateStore` | `app/overlay/state_store.py` | In-memory + JSON persistence for overlay state |
 | Overlay | `ObsBroadcastHub` | `app/overlay/broadcast.py` | Debounced WebSocket broadcasts to OBS browser sources |
 | Admin | `admin_router`, `admin_page_router` | `app/admin/routes.py` | `/manage` page + `/api/v1/admin/custom-overlays` CRUD for custom overlays (Bearer = `OVERLAY_MANAGER_PASSWORD`) |
@@ -177,13 +177,15 @@ The entire match lives in a flat dictionary with these keys:
 
 `Backend` communicates with overlay backends using the strategy pattern:
 
-| OID Prefix | Type | Backend Class | Communication |
-|-----------|------|--------------|---------------|
-| *(none / plain token)* | overlays.uno cloud | `UnoOverlayBackend` | HTTP to overlays.uno API |
-| `C-{id}` or `C-{id}/{style}` | Custom (local) | `LocalOverlayBackend` | In-process via `OverlayStateStore` |
-| `C-{id}` (with `APP_CUSTOM_OVERLAY_URL` set) | Custom (external) | `CustomOverlayBackend` | WebSocket + HTTP to external server |
+| OID Pattern | Type | Backend Class | Communication |
+|-------------|------|--------------|---------------|
+| Existing local overlay id (e.g. `mybroadcast`) — bare or legacy `C-mybroadcast[/style]` | Custom (local) | `LocalOverlayBackend` | In-process via `OverlayStateStore` |
+| Same as above, with `APP_CUSTOM_OVERLAY_URL` set | Custom (external) | `CustomOverlayBackend` | WebSocket + HTTP to external server |
+| 22-char alphanumeric token (e.g. `2cIXk2IjHvMuva6Wwele8j`) | overlays.uno cloud | `UnoOverlayBackend` | HTTP to overlays.uno API |
 
-**Default behavior:** Custom overlays (`C-` prefix) are managed **in-process** by `LocalOverlayBackend`. State flows directly from `GameManager` → `Backend` → `LocalOverlayBackend` → `OverlayStateStore` → `ObsBroadcastHub` → OBS browser sources.
+**Resolution order:** `Backend._resolve_kind()` (see `app/overlay_backends/utils.resolve_overlay_kind`) checks the local overlay store first; if a custom overlay with that id exists, it wins. Otherwise, an OID matching the UNO format (22 alphanumeric characters) is treated as a cloud overlay; anything else is INVALID. **No auto-creation** — overlays must be created up-front from `/manage`. The legacy `C-` prefix is still accepted but is no longer required and is not used in the UI/docs.
+
+**Default behavior:** Custom overlays are managed **in-process** by `LocalOverlayBackend`. State flows directly from `GameManager` → `Backend` → `LocalOverlayBackend` → `OverlayStateStore` → `ObsBroadcastHub` → OBS browser sources.
 
 **External server mode:** When `APP_CUSTOM_OVERLAY_URL` is set, the system falls back to `CustomOverlayBackend` which communicates with an external overlay server. See [CUSTOM_OVERLAY.md](CUSTOM_OVERLAY.md) for the external server API contract.
 
@@ -270,7 +272,7 @@ Use `app/oid_utils.py` for `extract_oid()` and `compose_output()` — do not imp
 
 - **Do not block the event loop** — long-running I/O must use the `ThreadPoolExecutor` in `Backend`.
 - **Do not skip `GameManager.save()`** — after any mutation, save must be called.
-- **Custom overlay IDs start with `C-`** — `Backend.is_custom_overlay()` checks this prefix.
+- **Custom overlay detection:** `Backend.is_custom_overlay()` calls `resolve_overlay_kind()` (in `app/overlay_backends/utils.py`), which returns `OverlayKind.CUSTOM` only if the local overlay store has a file for that id. The legacy `C-` prefix is still accepted (and stripped) but never auto-creates a missing overlay.
 - **Undo is a flag, not a stack** — reverses only the most recent action of that type.
 
 ---

--- a/CUSTOM_OVERLAY.md
+++ b/CUSTOM_OVERLAY.md
@@ -2,14 +2,15 @@
 
 ## Built-In Overlay Engine
 
-Remote-Scoreboard includes a **built-in overlay engine** that serves custom overlays in-process — no external server is needed. When you use an overlay ID starting with `C-` (e.g., `C-mybroadcast`), the system automatically:
+Remote-Scoreboard includes a **built-in overlay engine** that serves custom overlays in-process — no external server is needed. Overlays must be created up-front from the `/manage` page (protected by `OVERLAY_MANAGER_PASSWORD`); the system never auto-creates overlays from the control UI. Once an overlay named e.g. `mybroadcast` exists, the system:
 
-1. Creates the overlay if it doesn't exist
-2. Persists state to `data/overlay_state_mybroadcast.json`
-3. Serves 16 overlay style templates at `/overlay/{id}` (for OBS browser sources)
-4. Broadcasts real-time updates to OBS via WebSocket at `/ws/{id}`
+1. Persists state to `data/overlay_state_mybroadcast.json`
+2. Serves 16 overlay style templates at `/overlay/{id}` (for OBS browser sources)
+3. Broadcasts real-time updates to OBS via WebSocket at `/ws/{id}`
 
-This is the default behavior and requires no configuration beyond choosing a `C-` prefixed overlay ID.
+The overlay's name is used directly as the OID in the control UI.
+
+> **Backward compatibility:** the legacy `C-<id>` syntax (e.g. `C-mybroadcast`) is still accepted when the overlay already exists, but it is no longer the recommended form and is omitted from the documentation and UI.
 
 ---
 
@@ -24,20 +25,19 @@ This document outlines the API contract that your external custom overlay must i
 > 1. Implement `GET /api/config/{id}` returning `{ "outputUrl": "...", "availableStyles": [...] }`
 > 2. Implement `POST /api/state/{id}` accepting the full match state JSON
 > 3. Implement `GET /api/raw_config/{id}` and `POST /api/raw_config/{id}` for state persistence
-> 4. Use overlay IDs prefixed with `C-` (e.g., `C-mybroadcast`)
-> 5. Return `200 OK` within 2 seconds on POST requests
-> 6. *(Optional)* Implement `/ws/control/{id}` WebSocket endpoint and return `controlWebSocketUrl` in `/api/config` for low-latency persistent connections
+> 4. Return `200 OK` within 2 seconds on POST requests
+> 5. *(Optional)* Implement `/ws/control/{id}` WebSocket endpoint and return `controlWebSocketUrl` in `/api/config` for low-latency persistent connections
 
 ---
 
 ## 🔗 The Connection Protocol
 
-When the user configures an overlay ID starting with `C-` (e.g., `C-mybroadcast`) **and** `APP_CUSTOM_OVERLAY_URL` is set, Remote-Scoreboard identifies this as a **Custom External Overlay**.
+When the user enters an overlay ID that resolves to a custom overlay **and** `APP_CUSTOM_OVERLAY_URL` is set, Remote-Scoreboard identifies this as a **Custom External Overlay**.
 
 It will then communicate directly with your custom overlay server using the Base URL defined in the `APP_CUSTOM_OVERLAY_URL` environment variable.
 
 > [!NOTE]
-> If `APP_CUSTOM_OVERLAY_URL` is **not** set, `C-` prefixed overlays use the built-in overlay engine (see above) and none of the endpoints described below need to be implemented.
+> If `APP_CUSTOM_OVERLAY_URL` is **not** set, custom overlays use the built-in overlay engine (see above) and none of the endpoints described below need to be implemented.
 
 **Output URL resolution**
 
@@ -47,10 +47,10 @@ Remote-Scoreboard determines the final output URL shown in the "Links" dialog us
 2.  If `APP_CUSTOM_OVERLAY_OUTPUT_URL` is set, Remote-Scoreboard replaces the host and port of the fetched `outputUrl` with the value from this environment variable, but preserves the path (which should contain the `outputKey`). This is useful when the overlay server is behind a proxy or on a different network.
 3.  If `APP_CUSTOM_OVERLAY_OUTPUT_URL` is **not** set, Remote-Scoreboard uses the `outputUrl` from your server as-is. Ensure your overlay server returns a publicly accessible URL in this case (e.g., by configuring its own `OVERLAY_PUBLIC_URL`).
 
-The `custom_id` passed to your server will be the user's overlay ID **without** the `C-` prefix. For `C-mybroadcast`, the `custom_id` passed in URLs is `mybroadcast`.
+The `custom_id` passed to your server is the bare overlay ID (the legacy `C-` prefix, when present, is stripped before forwarding).
 
 **Styling Support**
-Users can append a specific style constraint to their overlay ID using the `/` separator (e.g., `C-mybroadcast/line`). This specifies to the system exactly which layout template to use.
+Users can append a specific style constraint to their overlay ID using the `/` separator (e.g., `mybroadcast/line`). This specifies to the system exactly which layout template to use.
 Alternatively, users can change the current layout directly from the Remote-Scoreboard controller UI using the "Preferred Style" dropdown options fetched from your `/api/config/{custom_id}` endpoint.
 Remote-Scoreboard will send `preferredStyle` inside the `overlay_control` block of the JSON payload, and custom overlays can default to this style when the output URL has no explicit `?style` query constraint.
 

--- a/CUSTOM_OVERLAY_API.yaml
+++ b/CUSTOM_OVERLAY_API.yaml
@@ -4,9 +4,10 @@ info:
   version: "1.0"
   description: >
     HTTP contract that any custom overlay server must implement to be driven
-    by Remote-Scoreboard. Overlay IDs must be prefixed with `C-` in the
-    Remote-Scoreboard UI (e.g. `C-mybroadcast`). The prefix is stripped before
-    being passed to these endpoints as `{custom_id}`.
+    by Remote-Scoreboard. Overlay IDs are used as-is in the Remote-Scoreboard
+    UI (e.g. `mybroadcast`); the legacy `C-` prefix is still accepted for
+    backward compatibility but stripped before being passed to these endpoints
+    as `{custom_id}`.
 
     The base URL of the overlay server is configured via the
     `APP_CUSTOM_OVERLAY_URL` environment variable (default
@@ -119,8 +120,8 @@ components:
       in: path
       required: true
       description: >
-        Overlay identifier — the user's overlay ID with the `C-` prefix
-        removed (e.g. `mybroadcast` for overlay ID `C-mybroadcast`).
+        Overlay identifier — the user's overlay ID (the legacy `C-` prefix,
+        when present, is stripped before being forwarded).
       schema:
         type: string
         example: mybroadcast

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -209,7 +209,7 @@ The "Bridge" to overlay systems.
 
 Three overlay backend implementations share the `OverlayBackend` abstract interface:
 
-- **`LocalOverlayBackend`** — Default for custom overlays (`C-` prefix). Manages state in-process via `OverlayStateStore`, broadcasts to OBS via `ObsBroadcastHub`. No external server needed.
+- **`LocalOverlayBackend`** — Default for custom overlays (selected when the OID maps to a locally-existing overlay; the legacy `C-` prefix is also accepted for backward compatibility). Manages state in-process via `OverlayStateStore`, broadcasts to OBS via `ObsBroadcastHub`. No external server needed.
 - **`CustomOverlayBackend`** — Optional external server mode (activated when `APP_CUSTOM_OVERLAY_URL` is set). Communicates via WebSocket + HTTP fallback.
 - **`UnoOverlayBackend`** — Cloud overlays. Communicates with the overlays.uno REST API.
 
@@ -255,8 +255,9 @@ WebSocket notification hub for broadcasting state updates to connected frontend 
 #### `app/admin/` — custom overlay management
 
 Standalone surface for managing **custom** overlays (those backed by the
-in-process overlay engine, OID prefix `C-`) at runtime, independent of the
-React scoreboard UI.
+in-process overlay engine) at runtime, independent of the React scoreboard
+UI. Overlays must be created here before they can be used as OIDs in the
+control UI — the system never auto-creates overlays from the control flow.
 
 - **`app/admin/routes.py`** — Two FastAPI routers:
   - `admin_page_router` → `GET /manage` serves the standalone HTML page.
@@ -358,7 +359,7 @@ The app assumes it is the **primary controller**. However, `GameManager.reset()`
 
 ### Custom Overlay State Flow
 
-By default, custom overlays (`C-` prefix) are managed **in-process** by `LocalOverlayBackend`. State flows directly from `GameManager` → `LocalOverlayBackend` → `OverlayStateStore` → `ObsBroadcastHub` → OBS browser sources — no inter-process communication needed.
+By default, custom overlays are managed **in-process** by `LocalOverlayBackend` (an OID is treated as custom when a matching overlay file exists locally — the legacy `C-` prefix is also accepted). State flows directly from `GameManager` → `LocalOverlayBackend` → `OverlayStateStore` → `ObsBroadcastHub` → OBS browser sources — no inter-process communication needed.
 
 If `APP_CUSTOM_OVERLAY_URL` is set, the system falls back to `CustomOverlayBackend` which communicates with an external overlay server. See [CUSTOM_OVERLAY.md](CUSTOM_OVERLAY.md) for the external server API contract and [ARCHITECTURE.md](../ARCHITECTURE.md) for the full data flow diagrams.
 

--- a/FRONTEND_DEVELOPMENT.md
+++ b/FRONTEND_DEVELOPMENT.md
@@ -52,7 +52,7 @@ pip install -r requirements.txt
 cd frontend && npm ci && npm run build && cd ..
 
 # Configure (minimal)
-export UNO_OVERLAY_OID=C-my-overlay   # or a cloud overlay OID
+export UNO_OVERLAY_OID=my-overlay   # or a cloud overlay OID
 
 # Start the server
 python main.py
@@ -67,7 +67,7 @@ Before using any game endpoint, you must initialise a session:
 ```bash
 curl -X POST http://localhost:8080/api/v1/session/init \
   -H "Content-Type: application/json" \
-  -d '{"oid": "C-my-overlay"}'
+  -d '{"oid": "my-overlay"}'
 ```
 
 Response:
@@ -106,7 +106,7 @@ You can also override match rules when initialising:
 
 ```json
 {
-  "oid": "C-my-overlay",
+  "oid": "my-overlay",
   "points_limit": 21,
   "points_limit_last_set": 15,
   "sets_limit": 3
@@ -120,7 +120,7 @@ You can also override match rules when initialising:
 If the server has `SCOREBOARD_USERS` configured, all API endpoints (except the WebSocket handshake) require a Bearer token:
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/game/add-point?oid=C-my-overlay \
+curl -X POST http://localhost:8080/api/v1/game/add-point?oid=my-overlay \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <password>" \
   -d '{"team": 1}'
@@ -327,7 +327,7 @@ Connect to `ws://localhost:8080/api/v1/ws?oid=<OID>` to receive live state updat
 ### Connection
 
 ```javascript
-const ws = new WebSocket('ws://localhost:8080/api/v1/ws?oid=C-my-overlay');
+const ws = new WebSocket('ws://localhost:8080/api/v1/ws?oid=my-overlay');
 
 ws.onopen = () => {
   console.log('Connected! Initial state will arrive automatically.');
@@ -473,7 +473,7 @@ ws.onclose = (event) => {
 
   <script>
     const BASE = 'http://localhost:8080';
-    const OID = 'C-my-overlay';
+    const OID = 'my-overlay';
     // Set this if authentication is enabled:
     const API_KEY = null; // e.g. 'my-password'
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For the full endpoint reference, request/response schemas, and WebSocket protoco
 ### Built-In Overlay Engine
 *   **16 Overlay Styles**: Includes pre-built HTML overlay templates (esports, glass, compact, ribbon, shield, and more) rendered via Jinja2 and served directly to OBS/vMix browser sources.
 *   **Real-Time Updates**: OBS browser sources connect via WebSocket (`/ws/{overlay_id}`) and receive 50ms-debounced state pushes — no polling needed.
-*   **Zero Configuration**: Use any overlay ID starting with `C-` (e.g., `C-mybroadcast`) and the system auto-creates the overlay, persists state to disk, and serves it immediately.
+*   **Manage Overlays in One Place**: Create, copy and delete overlays from the `/manage` page (protected by `OVERLAY_MANAGER_PASSWORD`). Overlay IDs created there can be used directly as OIDs in the control UI; state is persisted to disk and served immediately.
 *   **Preset Themes**: Apply dark, light, esports, neo_jersey, split_jersey, or clear_jersey themes with one click.
 
 ### Single-App Deployment
@@ -61,7 +61,7 @@ For the full endpoint reference, request/response schemas, and WebSocket protoco
 
 *   **Python 3.x**
 *   **Node.js 20+** and **npm** (for building the frontend)
-*   *(Optional)* An account on **[overlays.uno](https://overlays.uno)** for cloud overlays. Not needed when using the built-in overlay engine (`C-` prefixed IDs).
+*   *(Optional)* An account on **[overlays.uno](https://overlays.uno)** for cloud overlays. Not needed when using the built-in overlay engine.
 
 ### Creating an Overlay
 
@@ -72,7 +72,9 @@ For the full endpoint reference, request/response schemas, and WebSocket protoco
 
 ### Using the Built-In Overlay Engine
 
-The fastest way to get started is with the built-in overlay engine. Simply use an overlay ID starting with `C-` (e.g., `C-mybroadcast`). The system automatically creates the overlay, serves 16 style templates at `/overlay/{id}`, and broadcasts state updates to OBS via WebSocket at `/ws/{id}`. No external server or account is required.
+The fastest way to get started is with the built-in overlay engine. Open the `/manage` page (protected by `OVERLAY_MANAGER_PASSWORD`) to create an overlay — say, `mybroadcast` — then use that ID directly as the OID in the control UI. The system serves 16 style templates at `/overlay/{id}` and broadcasts state updates to OBS via WebSocket at `/ws/{id}`. No external server or account is required.
+
+> **Backward compatibility:** the legacy `C-<id>` prefix (e.g. `C-mybroadcast`) is still accepted when the overlay already exists, but it is no longer required and is omitted from the documentation and UI from now on.
 
 ### Building a Custom External Overlay
 
@@ -109,7 +111,7 @@ If you need a fully custom overlay engine (e.g., built in React, Vue, or Godot),
     ```
     The FastAPI server starts on port 8080 (configurable via `APP_PORT`). The control UI is available at `http://localhost:8080/`.
 
-5.  **Use a Custom Overlay** — Set your overlay ID with the `C-` prefix (e.g., `C-mybroadcast`) to use the built-in overlay engine. The overlay is accessible at `http://localhost:8080/overlay/{id}` for OBS browser sources. If you want to use an *external* overlay server instead, additionally set `APP_CUSTOM_OVERLAY_URL`. See [CUSTOM_OVERLAY.md](CUSTOM_OVERLAY.md) for details.
+5.  **Use a Custom Overlay** — Create an overlay from the `/manage` page (set `OVERLAY_MANAGER_PASSWORD` first) and use its ID as the OID in the control UI. The overlay is accessible at `http://localhost:8080/overlay/{id}` for OBS browser sources. If you want to use an *external* overlay server instead, additionally set `APP_CUSTOM_OVERLAY_URL`. See [CUSTOM_OVERLAY.md](CUSTOM_OVERLAY.md) for details.
 
 > **Tip:** For frontend development with hot-reload, run `cd frontend && npm run dev` alongside `python main.py`. Vite serves on port 3000 and proxies API calls to the backend on port 8080.
 
@@ -138,7 +140,7 @@ Configure the application using the following environment variables:
 | :--- | :--- | :--- |
 | `UNO_OVERLAY_OID` | The control token for your overlays.uno overlay. | |
 | `APP_PORT` | The TCP port where the application will run. | `8080` |
-| `APP_CUSTOM_OVERLAY_URL` | *(Optional)* Base URL of an external custom overlay server. When set, `C-` overlays use the external server instead of the built-in engine. | *(unset — built-in engine)* |
+| `APP_CUSTOM_OVERLAY_URL` | *(Optional)* Base URL of an external custom overlay server. When set, custom overlays use the external server instead of the built-in engine. | *(unset — built-in engine)* |
 | `APP_CUSTOM_OVERLAY_OUTPUT_URL` | *(Optional)* Public-facing base URL for overlay links. Used to replace the host in output URLs when the overlay server is behind a proxy. | |
 | `OVERLAY_PUBLIC_URL` | *(Optional)* Public base URL for overlay output links served by the built-in engine. If unset, URLs are constructed from the request's host. | |
 | `MATCH_GAME_POINTS` | Points needed to win a set. | `25` |

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -36,8 +36,7 @@ _PAGE_PATH = os.path.join(os.path.dirname(__file__), "static", "overlays.html")
 
 # Custom overlay IDs are used as filenames and URL path components, so
 # only allow the characters that cannot collide with the filesystem or
-# HTTP path parsing. The ``C-`` prefix is added automatically when the
-# overlay is used as an OID.
+# HTTP path parsing. The bare ID is used directly as the OID.
 _OVERLAY_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
@@ -47,7 +46,7 @@ _OVERLAY_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
 class CustomOverlayCreate(BaseModel):
-    name: str = Field(..., min_length=1, description="Overlay id (without the C- prefix)")
+    name: str = Field(..., min_length=1, description="Overlay id used as OID")
     copy_from: Optional[str] = Field(
         None,
         description="Optional existing overlay id to clone configuration from",
@@ -146,15 +145,14 @@ def admin_login(_: None = Depends(require_admin)):
 def list_custom_overlays():
     """Return every custom overlay persisted on disk.
 
-    Each entry carries the overlay id (the part after the ``C-`` prefix),
-    its derived output key and the corresponding OID clients should use
-    when pointing the scoreboard at the overlay.
+    Each entry carries the overlay id (used directly as the OID) and its
+    derived output key.
     """
     store = _overlay_store()
     return [
         {
             "id": entry["id"],
-            "oid": f"C-{entry['id']}",
+            "oid": entry["id"],
             "output_key": entry["output_key"],
         }
         for entry in store.list_overlays()
@@ -185,7 +183,7 @@ def create_custom_overlay(payload: CustomOverlayCreate):
 
     return {
         "id": name,
-        "oid": f"C-{name}",
+        "oid": name,
         "output_key": store.get_output_key(name),
     }
 

--- a/app/admin/static/overlays.html
+++ b/app/admin/static/overlays.html
@@ -209,8 +209,7 @@
                  pattern="[A-Za-z0-9_.\-]+"
                  placeholder="mybroadcast" />
           <small class="muted">
-            Letters, digits, '-', '_' and '.' only. The overlay's OID will be
-            <code>C-&lt;name&gt;</code>.
+            Letters, digits, '-', '_' and '.' only. The name is used directly as the OID.
           </small>
         </div>
         <div class="field">

--- a/app/backend.py
+++ b/app/backend.py
@@ -7,7 +7,8 @@ from app.overlay_backends import (
     UnoOverlayBackend,
     CustomOverlayBackend,
     LocalOverlayBackend,
-    is_custom_overlay,
+    OverlayKind,
+    resolve_overlay_kind,
 )
 from app.env_vars_manager import EnvVarsManager
 
@@ -35,15 +36,25 @@ class Backend:
         self._customization_cache = None
         self._overlay = self._create_overlay_backend()
 
+    @staticmethod
+    def _local_overlay_exists(overlay_id: str) -> bool:
+        from app.overlay import overlay_state_store
+        return bool(overlay_id) and overlay_state_store.overlay_exists(overlay_id)
+
+    def _resolve_kind(self, oid=None) -> OverlayKind:
+        check_oid = oid if oid is not None else self.conf.oid
+        return resolve_overlay_kind(check_oid, self._local_overlay_exists)
+
     def _create_overlay_backend(self, oid=None):
         """Instantiate the right overlay backend for the given OID.
 
-        For custom overlays (``C-`` prefix), uses ``LocalOverlayBackend``
-        (in-process) by default.  If ``APP_CUSTOM_OVERLAY_URL`` is explicitly
-        set, falls back to ``CustomOverlayBackend`` (external server).
+        Custom overlays use ``LocalOverlayBackend`` (in-process) by default;
+        when ``APP_CUSTOM_OVERLAY_URL`` is set, ``CustomOverlayBackend``
+        (external server) is used instead. Anything else (including OIDs
+        that fail to resolve) falls back to ``UnoOverlayBackend`` so that
+        validation can later report INVALID via the cloud REST API.
         """
-        check_oid = oid if oid is not None else self.conf.oid
-        if is_custom_overlay(check_oid):
+        if self._resolve_kind(oid) == OverlayKind.CUSTOM:
             external_url = EnvVarsManager.get_env_var(
                 'APP_CUSTOM_OVERLAY_URL', None
             )
@@ -57,21 +68,19 @@ class Backend:
 
     def _ensure_overlay_backend(self, oid=None):
         """Re-create the overlay backend if the OID type changed."""
-        check_oid = oid if oid is not None else self.conf.oid
-        is_custom = is_custom_overlay(check_oid)
+        is_custom = self._resolve_kind(oid) == OverlayKind.CUSTOM
         if is_custom != self._overlay.is_custom:
             self._overlay.close_ws_client()
-            self._overlay = self._create_overlay_backend(check_oid)
+            self._overlay = self._create_overlay_backend(oid)
 
     # -- Public interface (used by GameManager, GameSession, routes, GUI) ----
 
     def is_custom_overlay(self, oid=None):
-        check_oid = oid if oid is not None else self.conf.oid
-        return is_custom_overlay(check_oid)
+        return self._resolve_kind(oid) == OverlayKind.CUSTOM
 
     def get_custom_overlay_id(self, oid=None):
         check_oid = oid if oid is not None else self.conf.oid
-        if is_custom_overlay(check_oid):
+        if self._resolve_kind(check_oid) == OverlayKind.CUSTOM:
             # Both LocalOverlayBackend and CustomOverlayBackend share
             # the same static get_overlay_id parser.
             return LocalOverlayBackend.get_overlay_id(check_oid)
@@ -81,7 +90,7 @@ class Backend:
 
     def init_ws_client(self, oid=None):
         check_oid = oid if oid is not None else self.conf.oid
-        if not is_custom_overlay(check_oid):
+        if self._resolve_kind(check_oid) != OverlayKind.CUSTOM:
             return
         self._ensure_overlay_backend(check_oid)
         self._overlay.init_ws_client(check_oid)
@@ -373,12 +382,11 @@ class Backend:
 
     def do_send_request(self, oid, jsonin):
         """Direct request to the Uno API (legacy compatibility)."""
-        if is_custom_overlay(oid):
-            from app.overlay_backends import _mock_response
+        from app.overlay_backends import _mock_response
+        if self._resolve_kind(oid) != OverlayKind.UNO:
             return _mock_response(200)
 
         if isinstance(self._overlay, UnoOverlayBackend):
             return self._overlay._do_request(oid, jsonin)
 
-        from app.overlay_backends import _mock_response
         return _mock_response(200)

--- a/app/overlay_backends/__init__.py
+++ b/app/overlay_backends/__init__.py
@@ -18,8 +18,13 @@ from app.overlay_backends.custom import CustomOverlayBackend
 from app.overlay_backends.local import LocalOverlayBackend
 from app.overlay_backends.utils import (
     _mock_response,
+    OverlayKind,
+    UNO_OID_LENGTH,
     is_custom_overlay,
+    matches_uno_format,
+    resolve_overlay_kind,
     split_custom_oid,
+    strip_legacy_prefix,
 )
 
 # Re-exported so ``@patch('app.overlay_backends.AppStorage.<method>')`` keeps
@@ -32,8 +37,13 @@ __all__ = [
     "UnoOverlayBackend",
     "CustomOverlayBackend",
     "LocalOverlayBackend",
+    "OverlayKind",
+    "UNO_OID_LENGTH",
     "is_custom_overlay",
+    "matches_uno_format",
+    "resolve_overlay_kind",
     "split_custom_oid",
+    "strip_legacy_prefix",
     "_mock_response",
     "AppStorage",
 ]

--- a/app/overlay_backends/local.py
+++ b/app/overlay_backends/local.py
@@ -131,7 +131,8 @@ class LocalOverlayBackend(OverlayBackend):
 
     def validate_oid(self, oid: str) -> State.OIDStatus:
         custom_id = self._custom_id(oid)
-        self._store().ensure_overlay(custom_id)
+        if not custom_id or not self._store().overlay_exists(custom_id):
+            return State.OIDStatus.INVALID
         return State.OIDStatus.VALID
 
     def fetch_and_update_overlay_id(self, oid: str) -> None:

--- a/app/overlay_backends/utils.py
+++ b/app/overlay_backends/utils.py
@@ -1,9 +1,91 @@
 """Small helpers shared by the overlay backend strategies."""
 
+import re
+from enum import Enum
+from typing import Callable
+
+# UNO overlay IDs are exactly 22 mixed-case alphanumeric characters
+# (e.g. ``2cIXk2IjHvMuva6Wwele8j``). The format is documented by overlays.uno
+# and is what we fall back to when an OID does not match a local custom
+# overlay.
+UNO_OID_LENGTH = 22
+_UNO_OID_PATTERN = re.compile(rf'^[A-Za-z0-9]{{{UNO_OID_LENGTH}}}$')
+
+_LEGACY_PREFIX = "C-"
+
+
+class OverlayKind(str, Enum):
+    """Result of resolving an OID against the available overlay sources."""
+
+    EMPTY = "empty"
+    CUSTOM = "custom"
+    UNO = "uno"
+    INVALID = "invalid"
+
 
 def is_custom_overlay(oid: str) -> bool:
-    """Check whether an OID refers to a custom (local) overlay."""
-    return oid is not None and str(oid).upper().startswith("C-")
+    """Return True when *oid* uses the legacy ``C-`` custom overlay prefix.
+
+    Kept for backward compatibility — new code should prefer
+    :func:`resolve_overlay_kind`.
+    """
+    return oid is not None and str(oid).upper().startswith(_LEGACY_PREFIX)
+
+
+def matches_uno_format(oid: str) -> bool:
+    """Whether *oid* matches the UNO format (22 alphanumeric characters)."""
+    return bool(oid) and bool(_UNO_OID_PATTERN.match(str(oid)))
+
+
+def strip_legacy_prefix(oid: str) -> str:
+    """Drop the leading ``C-`` prefix if present, otherwise return as-is."""
+    if oid is None:
+        return ""
+    s = str(oid)
+    if s.upper().startswith(_LEGACY_PREFIX):
+        return s[len(_LEGACY_PREFIX):]
+    return s
+
+
+def split_custom_oid(oid: str):
+    """Extract ``base_id`` and optional ``style`` from a custom overlay OID.
+
+    Accepts both the legacy ``C-id[/style]`` syntax and the bare
+    ``id[/style]`` form used by the new resolver.
+    """
+    raw_id = strip_legacy_prefix(oid)
+    parts = raw_id.split('/', 1)
+    return parts[0], (parts[1] if len(parts) > 1 else None)
+
+
+def resolve_overlay_kind(
+    oid: str,
+    local_overlay_exists: Callable[[str], bool],
+) -> OverlayKind:
+    """Decide whether *oid* refers to a custom (local) or UNO overlay.
+
+    Resolution order:
+      1. Empty/None -> ``EMPTY``
+      2. Legacy ``C-<id>[/style]`` syntax: ``CUSTOM`` iff the overlay
+         exists locally, otherwise ``INVALID`` (no auto-creation).
+      3. Bare id matching an existing local overlay -> ``CUSTOM``
+      4. Otherwise, UNO format (22 alphanumeric chars) -> ``UNO``
+      5. Anything else -> ``INVALID``
+    """
+    if oid is None or not str(oid).strip():
+        return OverlayKind.EMPTY
+    s = str(oid).strip()
+    if s.upper().startswith(_LEGACY_PREFIX):
+        bare = s[len(_LEGACY_PREFIX):].split('/', 1)[0]
+        if bare and local_overlay_exists(bare):
+            return OverlayKind.CUSTOM
+        return OverlayKind.INVALID
+    bare = s.split('/', 1)[0]
+    if bare and local_overlay_exists(bare):
+        return OverlayKind.CUSTOM
+    if matches_uno_format(s):
+        return OverlayKind.UNO
+    return OverlayKind.INVALID
 
 
 def _mock_response(status_code=200, payload=None):
@@ -14,10 +96,3 @@ def _mock_response(status_code=200, payload=None):
         'text': '',
         'json': lambda self: body,
     })()
-
-
-def split_custom_oid(oid: str):
-    """Extract base_id and optional style from a custom OID (``C-id[/style]``)."""
-    raw_id = str(oid)[2:]  # Strip the ``C-`` prefix
-    parts = raw_id.split('/', 1)
-    return parts[0], (parts[1] if len(parts) > 1 else None)

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -50,7 +50,7 @@
             "title": "Copy From"
           },
           "name": {
-            "description": "Overlay id (without the C- prefix)",
+            "description": "Overlay id used as OID",
             "minLength": 1,
             "title": "Name",
             "type": "string"
@@ -1060,7 +1060,7 @@
     },
     "/api/v1/admin/custom-overlays": {
       "get": {
-        "description": "Return every custom overlay persisted on disk.\n\nEach entry carries the overlay id (the part after the ``C-`` prefix),\nits derived output key and the corresponding OID clients should use\nwhen pointing the scoreboard at the overlay.",
+        "description": "Return every custom overlay persisted on disk.\n\nEach entry carries the overlay id (used directly as the OID) and its\nderived output key.",
         "operationId": "list_custom_overlays_api_v1_admin_custom_overlays_get",
         "parameters": [
           {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -101,9 +101,8 @@ export interface paths {
          * List Custom Overlays
          * @description Return every custom overlay persisted on disk.
          *
-         *     Each entry carries the overlay id (the part after the ``C-`` prefix),
-         *     its derived output key and the corresponding OID clients should use
-         *     when pointing the scoreboard at the overlay.
+         *     Each entry carries the overlay id (used directly as the OID) and its
+         *     derived output key.
          */
         get: operations["list_custom_overlays_api_v1_admin_custom_overlays_get"];
         put?: never;
@@ -675,7 +674,7 @@ export interface components {
             copy_from?: string | null;
             /**
              * Name
-             * @description Overlay id (without the C- prefix)
+             * @description Overlay id used as OID
              */
             name: string;
         };

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -7,7 +7,7 @@ const translations: Record<string, TranslationDict> = {
     // Init screen
     'app.title': 'Volley Scoreboard',
     'app.oidLabel': 'Overlay Control ID (OID)',
-    'app.oidPlaceholder': 'C-my-overlay',
+    'app.oidPlaceholder': 'my-overlay',
     'app.connect': 'Connect',
     'app.selectOverlay': 'Select Overlay',
     'app.selectOverlayPlaceholder': '— Select —',
@@ -128,7 +128,7 @@ const translations: Record<string, TranslationDict> = {
     // Init screen
     'app.title': 'Marcador',
     'app.oidLabel': 'ID de Control del Overlay (OID)',
-    'app.oidPlaceholder': 'C-mi-overlay',
+    'app.oidPlaceholder': 'mi-overlay',
     'app.connect': 'Conectar',
     'app.selectOverlay': 'Seleccionar Overlay',
     'app.selectOverlayPlaceholder': '— Elegir —',

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -48,7 +48,7 @@ describe('App', () => {
   it('renders OID entry screen initially', () => {
     renderWithI18n(<App />);
     expect(screen.getByText('Volley Scoreboard')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('C-my-overlay')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('my-overlay')).toBeInTheDocument();
   });
 
   it('connect button is disabled when OID input is empty', () => {
@@ -59,14 +59,14 @@ describe('App', () => {
 
   it('connect button is enabled when OID input has value', () => {
     renderWithI18n(<App />);
-    const input = screen.getByPlaceholderText('C-my-overlay');
+    const input = screen.getByPlaceholderText('my-overlay');
     fireEvent.change(input, { target: { value: 'test-oid' } });
     expect(screen.getByText('Connect')).not.toBeDisabled();
   });
 
   it('initializes session on form submit', async () => {
     renderWithI18n(<App />);
-    const input = screen.getByPlaceholderText('C-my-overlay');
+    const input = screen.getByPlaceholderText('my-overlay');
     fireEvent.change(input, { target: { value: 'my-oid' } });
     fireEvent.submit(input.closest('form')!);
 
@@ -78,7 +78,7 @@ describe('App', () => {
   it('shows error message when session init fails', async () => {
     vi.mocked(api.initSession).mockResolvedValue({ success: false, message: 'Invalid OID' });
     renderWithI18n(<App />);
-    const input = screen.getByPlaceholderText('C-my-overlay');
+    const input = screen.getByPlaceholderText('my-overlay');
     fireEvent.change(input, { target: { value: 'bad' } });
     fireEvent.submit(input.closest('form')!);
 
@@ -89,7 +89,7 @@ describe('App', () => {
 
   it('renders scoreboard after successful init', async () => {
     renderWithI18n(<App />);
-    const input = screen.getByPlaceholderText('C-my-overlay');
+    const input = screen.getByPlaceholderText('my-overlay');
     fireEvent.change(input, { target: { value: 'valid-oid' } });
     fireEvent.submit(input.closest('form')!);
 
@@ -114,7 +114,7 @@ describe('App', () => {
 
   it('switches to config tab when config button clicked', async () => {
     renderWithI18n(<App />);
-    const input = screen.getByPlaceholderText('C-my-overlay');
+    const input = screen.getByPlaceholderText('my-overlay');
     fireEvent.change(input, { target: { value: 'oid' } });
     fireEvent.submit(input.closest('form')!);
 
@@ -136,7 +136,7 @@ describe('App', () => {
 
   it('persists OID to localStorage on connect', async () => {
     renderWithI18n(<App />);
-    const input = screen.getByPlaceholderText('C-my-overlay');
+    const input = screen.getByPlaceholderText('my-overlay');
     fireEvent.change(input, { target: { value: 'persist-oid' } });
     fireEvent.submit(input.closest('form')!);
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def load_test_env(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def isolate_overlay_store(tmp_path):
+def isolate_overlay_store(tmp_path_factory):
     """Point the overlay state store at a per-test temp dir and seed
     ``test_overlay`` so the OID resolver classifies it as CUSTOM.
 
@@ -33,9 +33,14 @@ def isolate_overlay_store(tmp_path):
     developer-local fixture files. Without seeding, ``resolve_overlay_kind``
     falls through to UNO and the custom-overlay tests assert against the
     wrong backend.
+
+    Uses a dedicated tmp dir (not the per-test ``tmp_path``) so tests that
+    own their own data dir via ``tmp_path`` (e.g. ``test_admin.py``) are not
+    polluted by the seeded fixture file.
     """
     from app.overlay import overlay_state_store
 
+    seed_dir = tmp_path_factory.mktemp("overlay_seed")
     saved = {
         "_data_dir": overlay_state_store._data_dir,
         "_overlays": overlay_state_store._overlays,
@@ -43,7 +48,7 @@ def isolate_overlay_store(tmp_path):
         "_available_styles": overlay_state_store._available_styles,
         "_all_overlays_scanned": overlay_state_store._all_overlays_scanned,
     }
-    overlay_state_store._data_dir = str(tmp_path)
+    overlay_state_store._data_dir = str(seed_dir)
     overlay_state_store._overlays = {}
     overlay_state_store._output_key_cache = {}
     overlay_state_store._available_styles = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,41 @@ def load_test_env(monkeypatch):
     AppStorage.clear_user_storage()
 
 
+@pytest.fixture(autouse=True)
+def isolate_overlay_store(tmp_path):
+    """Point the overlay state store at a per-test temp dir and seed
+    ``test_overlay`` so the OID resolver classifies it as CUSTOM.
+
+    The repository's ``data/`` directory is gitignored, so CI never has the
+    developer-local fixture files. Without seeding, ``resolve_overlay_kind``
+    falls through to UNO and the custom-overlay tests assert against the
+    wrong backend.
+    """
+    from app.overlay import overlay_state_store
+
+    saved = {
+        "_data_dir": overlay_state_store._data_dir,
+        "_overlays": overlay_state_store._overlays,
+        "_output_key_cache": overlay_state_store._output_key_cache,
+        "_available_styles": overlay_state_store._available_styles,
+        "_all_overlays_scanned": overlay_state_store._all_overlays_scanned,
+    }
+    overlay_state_store._data_dir = str(tmp_path)
+    overlay_state_store._overlays = {}
+    overlay_state_store._output_key_cache = {}
+    overlay_state_store._available_styles = None
+    overlay_state_store._all_overlays_scanned = False
+    overlay_state_store.create_overlay("test_overlay")
+
+    yield
+
+    overlay_state_store._data_dir = saved["_data_dir"]
+    overlay_state_store._overlays = saved["_overlays"]
+    overlay_state_store._output_key_cache = saved["_output_key_cache"]
+    overlay_state_store._available_styles = saved["_available_styles"]
+    overlay_state_store._all_overlays_scanned = saved["_all_overlays_scanned"]
+
+
 def load_fixture(name):
     """Auxiliary function to load a JSON file from the fixtures folder."""
     path = os.path.join(os.path.dirname(__file__), 'fixtures', f'{name}.json')

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -107,7 +107,7 @@ def test_create_custom_overlay(client):
     assert res.status_code == 200
     body = res.json()
     assert body["id"] == "mybroadcast"
-    assert body["oid"] == "C-mybroadcast"
+    assert body["oid"] == "mybroadcast"
     assert body["output_key"]
 
     res = client.get("/api/v1/admin/custom-overlays", headers=_auth())

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -299,8 +299,11 @@ def test_custom_overlay_save_model(backend, mock_requests_session, conf):
 
 @patch.dict(os.environ, {"APP_CUSTOM_OVERLAY_URL": "http://localhost:8000"})
 def test_custom_overlay_lowercase_prefix(backend, mock_requests_session, conf):
-    """Tests that a lowercase c- prefixed OID still routes to custom local url."""
-    conf.oid = "c-test_overlay_lower"
+    """Tests that a lowercase c- prefixed OID still routes to a known custom overlay."""
+    # Uses the ``test_overlay`` fixture file present in ``data/`` so the
+    # resolver classifies it as CUSTOM. The legacy ``c-`` prefix is still
+    # accepted (case-insensitive) — see ``resolve_overlay_kind``.
+    conf.oid = "c-test_overlay"
     conf.multithread = False
 
     # Run the save
@@ -312,7 +315,7 @@ def test_custom_overlay_lowercase_prefix(backend, mock_requests_session, conf):
     # Ensure the local overlay IS hit via session.post
     state_calls = [c for c in mock_requests_session.post.call_args_list if '/api/state/' in str(c)]
     assert len(state_calls) == 1
-    assert state_calls[0][0][0] == "http://localhost:8000/api/state/test_overlay_lower"
+    assert state_calls[0][0][0] == "http://localhost:8000/api/state/test_overlay"
 
 @patch.dict(os.environ, {"APP_CUSTOM_OVERLAY_URL": "http://localhost:8000"})
 @patch('app.overlay_backends.AppStorage.load')
@@ -387,6 +390,50 @@ def test_validate_custom_overlay_oid_with_style_is_valid(backend, mock_requests_
     conf.oid = "C-test_overlay/line"
     result = backend.validate_and_store_model_for_oid("C-test_overlay/line")
     assert result == State.OIDStatus.VALID
+
+
+def test_validate_bare_existing_overlay_oid_is_valid(backend, mock_requests_session, conf):
+    """A bare overlay id (no ``C-`` prefix) resolves as a custom overlay when it
+    exists locally — this is the new preferred form."""
+    result = backend.validate_and_store_model_for_oid("test_overlay")
+    assert result == State.OIDStatus.VALID
+
+
+def test_validate_bare_existing_overlay_with_style_is_valid(backend, mock_requests_session, conf):
+    """The bare form also accepts a trailing ``/style`` constraint."""
+    result = backend.validate_and_store_model_for_oid("test_overlay/line")
+    assert result == State.OIDStatus.VALID
+
+
+def test_validate_legacy_prefix_missing_overlay_does_not_autocreate(
+    backend, mock_requests_session, conf,
+):
+    """Legacy ``C-`` prefix on a missing overlay must not auto-create — the
+    resolver returns INVALID and the call falls through to the UNO backend,
+    which rejects the format."""
+    from app.overlay import overlay_state_store
+    assert not overlay_state_store.overlay_exists("brand_new_local")
+
+    # Make the UNO validation endpoint reject the OID.
+    mock_requests_session.put.return_value.status_code = 404
+
+    result = backend.validate_and_store_model_for_oid("C-brand_new_local")
+    assert result == State.OIDStatus.INVALID
+    # And no overlay state file was created behind the scenes.
+    assert not overlay_state_store.overlay_exists("brand_new_local")
+
+
+def test_is_custom_overlay_recognises_bare_existing_overlay(backend, conf):
+    assert backend.is_custom_overlay("test_overlay") is True
+
+
+def test_is_custom_overlay_rejects_unknown_bare_oid(backend, conf):
+    assert backend.is_custom_overlay("nonexistent_overlay") is False
+
+
+def test_is_custom_overlay_rejects_uno_format_oid(backend, conf):
+    """22-char alphanumeric OID is treated as UNO, not custom."""
+    assert backend.is_custom_overlay("2cIXk2IjHvMuva6Wwele8j") is False
 
 
 def test_extract_oid_preserves_underscores_in_uno_url():

--- a/tests/test_overlay_resolver.py
+++ b/tests/test_overlay_resolver.py
@@ -1,0 +1,173 @@
+"""Tests for ``app.overlay_backends.utils.resolve_overlay_kind`` and helpers.
+
+The resolver is the new single source of truth that decides whether an OID
+points at a custom (local) overlay, an overlays.uno cloud overlay, or is
+invalid. The legacy ``C-`` prefix is still accepted for backward compatibility
+but never auto-creates a missing overlay.
+"""
+
+import pytest
+
+from app.overlay_backends.utils import (
+    OverlayKind,
+    UNO_OID_LENGTH,
+    is_custom_overlay,
+    matches_uno_format,
+    resolve_overlay_kind,
+    split_custom_oid,
+    strip_legacy_prefix,
+)
+
+
+# A representative UNO OID — mixed-case alphanumeric, exactly 22 chars.
+UNO_OID = "2cIXk2IjHvMuva6Wwele8j"
+
+
+@pytest.fixture
+def store_with(tmp_overlay_ids=None):
+    """Return a callable simulating a local overlay store."""
+    ids = set(tmp_overlay_ids or [])
+
+    def _exists(overlay_id: str) -> bool:
+        return overlay_id in ids
+
+    return _exists
+
+
+def make_store(*ids):
+    known = set(ids)
+    return lambda oid: oid in known
+
+
+# ---------------------------------------------------------------------------
+# matches_uno_format
+# ---------------------------------------------------------------------------
+
+
+def test_uno_oid_constant_matches_real_world_example():
+    assert UNO_OID_LENGTH == 22
+    assert len(UNO_OID) == 22
+    assert matches_uno_format(UNO_OID)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        None,
+        "short",
+        "x" * 21,                     # one char too few
+        "x" * 23,                     # one char too many
+        "abcdefghij-lmnopqrstuvw",    # 22 but contains '-'
+        "abcdefghij/lmnopqrstuvw",    # 22 but contains '/'
+        "C-mybroadcast",              # legacy prefix is not UNO
+    ],
+)
+def test_matches_uno_format_rejects_non_uno_inputs(value):
+    assert not matches_uno_format(value)
+
+
+# ---------------------------------------------------------------------------
+# is_custom_overlay (legacy helper) and strip_legacy_prefix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("C-foo", True),
+        ("c-foo", True),                 # case-insensitive
+        ("C-foo/style", True),
+        ("foo", False),
+        ("", False),
+        (None, False),
+        (UNO_OID, False),
+    ],
+)
+def test_is_custom_overlay(value, expected):
+    assert is_custom_overlay(value) is expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("C-foo", "foo"),
+        ("c-foo/style", "foo/style"),
+        ("foo", "foo"),
+        ("", ""),
+        (None, ""),
+    ],
+)
+def test_strip_legacy_prefix(value, expected):
+    assert strip_legacy_prefix(value) == expected
+
+
+def test_split_custom_oid_handles_legacy_and_bare_forms():
+    assert split_custom_oid("C-foo") == ("foo", None)
+    assert split_custom_oid("C-foo/line") == ("foo", "line")
+    assert split_custom_oid("foo") == ("foo", None)
+    assert split_custom_oid("foo/line") == ("foo", "line")
+
+
+# ---------------------------------------------------------------------------
+# resolve_overlay_kind
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_resolve_kind_empty(value):
+    assert resolve_overlay_kind(value, make_store()) == OverlayKind.EMPTY
+
+
+def test_resolve_kind_bare_existing_overlay_is_custom():
+    store = make_store("mybroadcast")
+    assert resolve_overlay_kind("mybroadcast", store) == OverlayKind.CUSTOM
+
+
+def test_resolve_kind_bare_existing_overlay_with_style_is_custom():
+    store = make_store("mybroadcast")
+    assert (
+        resolve_overlay_kind("mybroadcast/line", store) == OverlayKind.CUSTOM
+    )
+
+
+def test_resolve_kind_legacy_prefix_existing_overlay_is_custom():
+    store = make_store("mybroadcast")
+    assert resolve_overlay_kind("C-mybroadcast", store) == OverlayKind.CUSTOM
+    assert (
+        resolve_overlay_kind("c-mybroadcast/line", store) == OverlayKind.CUSTOM
+    )
+
+
+def test_resolve_kind_legacy_prefix_missing_overlay_is_invalid():
+    """Legacy syntax must not auto-create — missing overlay -> INVALID."""
+    store = make_store()  # nothing exists
+    assert resolve_overlay_kind("C-missing", store) == OverlayKind.INVALID
+    # Even when the OID would otherwise look like a UNO OID, the explicit
+    # legacy prefix forces the custom path and disables UNO fallback.
+    legacy_uno_shaped = "C-" + ("a" * UNO_OID_LENGTH)
+    assert (
+        resolve_overlay_kind(legacy_uno_shaped, store) == OverlayKind.INVALID
+    )
+
+
+def test_resolve_kind_bare_uno_format_falls_back_to_uno():
+    store = make_store()  # not a known custom overlay
+    assert resolve_overlay_kind(UNO_OID, store) == OverlayKind.UNO
+
+
+def test_resolve_kind_local_overlay_wins_over_uno_format():
+    """A 22-char alphanumeric id that also exists locally is CUSTOM."""
+    store = make_store(UNO_OID)
+    assert resolve_overlay_kind(UNO_OID, store) == OverlayKind.CUSTOM
+
+
+def test_resolve_kind_unknown_short_id_is_invalid():
+    store = make_store()
+    assert resolve_overlay_kind("nonexistent", store) == OverlayKind.INVALID
+
+
+def test_resolve_kind_strips_surrounding_whitespace():
+    store = make_store("foo")
+    assert resolve_overlay_kind("  foo  ", store) == OverlayKind.CUSTOM
+    assert resolve_overlay_kind(f"  {UNO_OID}  ", store) == OverlayKind.UNO


### PR DESCRIPTION
## Summary

- Custom overlay IDs can now be used as-is in the control UI (e.g. `mybroadcast`), exactly like overlays.uno IDs. The legacy `C-<id>[/style]` syntax keeps working when the overlay already exists, but it is no longer required and is removed from the documentation, UI placeholder and admin output.
- New resolver in `app/overlay_backends/utils.py::resolve_overlay_kind` decides between `CUSTOM` (local overlay file exists), `UNO` (matches the 22-char alphanumeric UNO format) and `INVALID`. The local store is consulted *first*, so an existing custom overlay always wins over the UNO fallback.
- **No auto-creation**, ever — overlays must be created up-front from `/manage` (or `POST /api/v1/admin/custom-overlays`). `LocalOverlayBackend.validate_oid` now returns `INVALID` for unknown ids instead of silently writing a fresh state file.

## Behavior matrix

| OID | Local overlay file exists? | Result |
|-----|----------------------------|--------|
| empty / whitespace | n/a | `EMPTY` |
| `mybroadcast` | yes | `CUSTOM` (in-process or external if `APP_CUSTOM_OVERLAY_URL` is set) |
| `mybroadcast` | no | `INVALID` (unless 22-char UNO format) |
| `C-mybroadcast` | yes | `CUSTOM` (legacy compat) |
| `C-mybroadcast` | no | `INVALID` (legacy prefix never auto-creates and disables UNO fallback) |
| `2cIXk2IjHvMuva6Wwele8j` | no | `UNO` |
| `2cIXk2IjHvMuva6Wwele8j` | yes (rare) | `CUSTOM` (local wins) |
| `nonexistent` | no | `INVALID` |

## Files touched

- `app/overlay_backends/utils.py` — new `OverlayKind`, `UNO_OID_LENGTH`, `matches_uno_format`, `strip_legacy_prefix`, `resolve_overlay_kind`. Legacy `is_custom_overlay` and `split_custom_oid` kept for back-compat (the latter now also accepts the bare form).
- `app/backend.py` — backend selection, `is_custom_overlay`, `init_ws_client`, `do_send_request` all delegate to the resolver via `_resolve_kind()`.
- `app/overlay_backends/local.py::validate_oid` — returns `INVALID` when the overlay does not exist.
- `app/admin/routes.py` — `list_custom_overlays` and `create_custom_overlay` return the bare id as the OID (no `C-` prefix).
- `app/admin/static/overlays.html`, `frontend/src/i18n.tsx`, `frontend/src/test/App.test.tsx` — placeholders/text updated.
- `README.md`, `AGENTS.md`, `DEVELOPER_GUIDE.md`, `CUSTOM_OVERLAY.md`, `CUSTOM_OVERLAY_API.yaml`, `FRONTEND_DEVELOPMENT.md` — docs updated; backward-compatibility note added where the `C-` prefix used to appear.
- `tests/test_overlay_resolver.py` (new, 33 tests) — covers all resolver branches.
- `tests/test_backend.py` — adds bare-id and no-autocreation integration tests; updates the lowercase-prefix test to point at an existing fixture overlay.
- `tests/test_admin.py` — admin response now reports the bare `oid`.

## Test plan

- [x] `python -m pytest tests/ --ignore=tests/test_admin.py --ignore=tests/test_auth_coverage.py` → 201 passed (the two skipped files require `httpx`, which is not installable in this sandbox under PEP 668)
- [x] `cd frontend && npm test -- --run` → 162 passed
- [ ] Smoke-test `/manage` (create overlay, copy it, delete it) on a real instance
- [ ] Smoke-test the control UI: connect with a bare custom OID, with `C-<id>` (back-compat), and with a 22-char UNO OID
- [ ] Verify that `C-doesnotexist` is reported as INVALID instead of silently creating the overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)