### PR TITLE
feat(config): make application title configurable via APP_TITLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Configure the application using the following environment variables:
 | :--- | :--- | :--- |
 | `UNO_OVERLAY_OID` | The control token for your overlays.uno overlay. | |
 | `APP_PORT` | The TCP port where the application will run. | `8080` |
+| `APP_TITLE` | Application title shown in the browser tab, the init screen heading and the PWA manifest. | `Volley Scoreboard` |
 | `APP_CUSTOM_OVERLAY_URL` | *(Optional)* Base URL of an external custom overlay server. When set, custom overlays use the external server instead of the built-in engine. | *(unset — built-in engine)* |
 | `APP_CUSTOM_OVERLAY_OUTPUT_URL` | *(Optional)* Public-facing base URL for overlay links. Used to replace the host in output URLs when the overlay server is behind a proxy. | |
 | `OVERLAY_PUBLIC_URL` | *(Optional)* Public base URL for overlay output links served by the built-in engine. If unset, URLs are constructed from the request's host. | |

--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -9,6 +9,7 @@ api_router``) keep working.
 from fastapi import APIRouter
 
 from app.api.routes import (
+    app_config,
     customization,
     display,
     game,
@@ -25,6 +26,7 @@ api_router = APIRouter(
     lifespan=router_lifespan,
 )
 
+api_router.include_router(app_config.router)
 api_router.include_router(session.router)
 api_router.include_router(state.router)
 api_router.include_router(game.router)

--- a/app/api/routes/app_config.py
+++ b/app/api/routes/app_config.py
@@ -1,0 +1,14 @@
+"""GET /app-config — runtime configuration for the SPA."""
+
+from fastapi import APIRouter
+
+from app.app_config import get_app_title
+from app.api.schemas import AppConfigResponse
+
+router = APIRouter()
+
+
+@router.get("/app-config", response_model=AppConfigResponse)
+async def app_config() -> AppConfigResponse:
+    """Return runtime app configuration consumed by the SPA on boot."""
+    return AppConfigResponse(title=get_app_title())

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -91,3 +91,7 @@ class ActionResponse(BaseModel):
     success: bool
     state: Optional[GameStateResponse] = None
     message: Optional[str] = None
+
+
+class AppConfigResponse(BaseModel):
+    title: str

--- a/app/app_config.py
+++ b/app/app_config.py
@@ -1,0 +1,19 @@
+"""Runtime app-level configuration exposed to the frontend.
+
+Currently only the application title is configurable via the ``APP_TITLE``
+environment variable. The value is consumed both by the FastAPI app
+(injected into the served ``index.html`` and PWA manifest) and by the SPA
+(via ``GET /api/v1/app-config``).
+"""
+
+from app.env_vars_manager import EnvVarsManager
+
+DEFAULT_APP_TITLE = "Volley Scoreboard"
+
+
+def get_app_title() -> str:
+    """Return the configured application title, falling back to the default."""
+    value = EnvVarsManager.get_env_var("APP_TITLE", DEFAULT_APP_TITLE)
+    if isinstance(value, str):
+        value = value.strip()
+    return value or DEFAULT_APP_TITLE

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -6,11 +6,13 @@ instances in tests (``TestClient(create_app())``) without triggering the
 side-effects of module import.
 """
 
+import html
 import json
 import logging
 import os
 import re
 from contextlib import asynccontextmanager
+from functools import lru_cache
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
@@ -31,15 +33,40 @@ OVERLAY_TEMPLATES_DIR = Path("overlay_templates")
 OVERLAY_STATIC_DIR = Path("overlay_static")
 
 
-_TITLE_PATTERN = re.compile(r"<title>.*?</title>", re.IGNORECASE | re.DOTALL)
+# Matches the first ``<title>`` element, including any attributes
+# (e.g. ``<title lang="en">``).
+_TITLE_PATTERN = re.compile(
+    r"<title(?:\s+[^>]*)?>.*?</title>", re.IGNORECASE | re.DOTALL,
+)
 
 
-def _inject_title_into_html(html: str, title: str) -> str:
-    """Replace ``<title>...</title>`` (and Apple PWA title) with *title*."""
-    escaped = (
-        title.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+def _inject_title_into_html(html_content: str, title: str) -> str:
+    """Replace the first ``<title>...</title>`` with the escaped *title*."""
+    return _TITLE_PATTERN.sub(
+        f"<title>{html.escape(title)}</title>", html_content, count=1,
     )
-    return _TITLE_PATTERN.sub(f"<title>{escaped}</title>", html, count=1)
+
+
+@lru_cache(maxsize=8)
+def _render_index_html(path: str, mtime: float, title: str) -> str:
+    """Memoize the rewritten ``index.html``.
+
+    Cache key includes ``mtime`` so a rebuilt frontend invalidates the
+    entry, and ``title`` so a changed ``APP_TITLE`` (e.g. via remote config)
+    is reflected without a restart.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    return _inject_title_into_html(text, title)
+
+
+@lru_cache(maxsize=8)
+def _render_manifest(path: str, mtime: float, title: str) -> dict:
+    """Memoize the rewritten PWA manifest. See :func:`_render_index_html`."""
+    with Path(path).open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    data["name"] = title
+    data["short_name"] = title
+    return data
 
 
 class SPAStaticFiles(StaticFiles):
@@ -47,7 +74,9 @@ class SPAStaticFiles(StaticFiles):
 
     The served ``index.html`` has its ``<title>`` rewritten to the value of
     the ``APP_TITLE`` env var so the browser tab matches the configured app
-    name without rebuilding the frontend.
+    name without rebuilding the frontend. The rewritten HTML is memoized
+    by ``(path, mtime, title)`` so steady-state requests do no disk I/O
+    beyond a single ``stat()``.
     """
 
     async def get_response(self, path, scope):
@@ -65,8 +94,9 @@ class SPAStaticFiles(StaticFiles):
         index_path = Path(self.directory) / "index.html"
         if not index_path.is_file():
             return await super().get_response("index.html", scope)
-        html = index_path.read_text(encoding="utf-8")
-        rewritten = _inject_title_into_html(html, get_app_title())
+        rewritten = _render_index_html(
+            str(index_path), index_path.stat().st_mtime, get_app_title(),
+        )
         return HTMLResponse(rewritten)
 
 
@@ -151,28 +181,21 @@ def _register_system_endpoints(application: FastAPI) -> None:
             headers={"Cache-Control": "no-cache, no-store, must-revalidate"},
         )
 
-    def _load_manifest(path: Path) -> dict:
-        with path.open("r", encoding="utf-8") as f:
-            data = json.load(f)
-        title = get_app_title()
-        data["name"] = title
-        data["short_name"] = title
-        return data
-
     @application.get("/manifest.webmanifest")
     def serve_webmanifest():
         manifest = FRONTEND_DIR / "manifest.webmanifest"
         source = manifest if manifest.is_file() else Path("app/pwa/manifest.json")
         return JSONResponse(
-            content=_load_manifest(source),
+            content=_render_manifest(str(source), source.stat().st_mtime, get_app_title()),
             media_type="application/manifest+json",
             headers={"Cache-Control": "no-cache"},
         )
 
     @application.get("/manifest.json")
     def serve_manifest():
+        source = Path("app/pwa/manifest.json")
         return JSONResponse(
-            content=_load_manifest(Path("app/pwa/manifest.json")),
+            content=_render_manifest(str(source), source.stat().st_mtime, get_app_title()),
             media_type="application/json",
         )
 

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -6,18 +6,21 @@ instances in tests (``TestClient(create_app())``) without triggering the
 side-effects of module import.
 """
 
+import json
 import logging
 import os
+import re
 from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.admin import admin_page_router, admin_router
 from app.api import api_router
+from app.app_config import get_app_title
 from app.authentication import PasswordAuthenticator
 
 logger = logging.getLogger("Bootstrap")
@@ -28,16 +31,43 @@ OVERLAY_TEMPLATES_DIR = Path("overlay_templates")
 OVERLAY_STATIC_DIR = Path("overlay_static")
 
 
+_TITLE_PATTERN = re.compile(r"<title>.*?</title>", re.IGNORECASE | re.DOTALL)
+
+
+def _inject_title_into_html(html: str, title: str) -> str:
+    """Replace ``<title>...</title>`` (and Apple PWA title) with *title*."""
+    escaped = (
+        title.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    )
+    return _TITLE_PATTERN.sub(f"<title>{escaped}</title>", html, count=1)
+
+
 class SPAStaticFiles(StaticFiles):
-    """StaticFiles with SPA fallback: serves index.html for unknown paths."""
+    """StaticFiles with SPA fallback: serves index.html for unknown paths.
+
+    The served ``index.html`` has its ``<title>`` rewritten to the value of
+    the ``APP_TITLE`` env var so the browser tab matches the configured app
+    name without rebuilding the frontend.
+    """
 
     async def get_response(self, path, scope):
         try:
-            return await super().get_response(path, scope)
+            response = await super().get_response(path, scope)
         except StarletteHTTPException as exc:
             if exc.status_code == 404:
-                return await super().get_response("index.html", scope)
+                return await self._index_response(scope)
             raise
+        if path in ("", "index.html"):
+            return await self._index_response(scope)
+        return response
+
+    async def _index_response(self, scope):
+        index_path = Path(self.directory) / "index.html"
+        if not index_path.is_file():
+            return await super().get_response("index.html", scope)
+        html = index_path.read_text(encoding="utf-8")
+        rewritten = _inject_title_into_html(html, get_app_title())
+        return HTMLResponse(rewritten)
 
 
 @asynccontextmanager
@@ -121,20 +151,30 @@ def _register_system_endpoints(application: FastAPI) -> None:
             headers={"Cache-Control": "no-cache, no-store, must-revalidate"},
         )
 
+    def _load_manifest(path: Path) -> dict:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        title = get_app_title()
+        data["name"] = title
+        data["short_name"] = title
+        return data
+
     @application.get("/manifest.webmanifest")
     def serve_webmanifest():
         manifest = FRONTEND_DIR / "manifest.webmanifest"
-        if manifest.is_file():
-            return FileResponse(
-                manifest,
-                media_type="application/manifest+json",
-                headers={"Cache-Control": "no-cache"},
-            )
-        return FileResponse("app/pwa/manifest.json", media_type="application/json")
+        source = manifest if manifest.is_file() else Path("app/pwa/manifest.json")
+        return JSONResponse(
+            content=_load_manifest(source),
+            media_type="application/manifest+json",
+            headers={"Cache-Control": "no-cache"},
+        )
 
     @application.get("/manifest.json")
     def serve_manifest():
-        return FileResponse("app/pwa/manifest.json", media_type="application/json")
+        return JSONResponse(
+            content=_load_manifest(Path("app/pwa/manifest.json")),
+            media_type="application/json",
+        )
 
     @application.get("/health")
     def health_check():

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -35,6 +35,19 @@
         "title": "ActionResponse",
         "type": "object"
       },
+      "AppConfigResponse": {
+        "properties": {
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "title": "AppConfigResponse",
+        "type": "object"
+      },
       "CustomOverlayCreate": {
         "properties": {
           "copy_from": {
@@ -1256,6 +1269,28 @@
         "summary": "Admin Status",
         "tags": [
           "Admin"
+        ]
+      }
+    },
+    "/api/v1/app-config": {
+      "get": {
+        "description": "Return runtime app configuration consumed by the SPA on boot.",
+        "operationId": "app_config_api_v1_app_config_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppConfigResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "App Config",
+        "tags": [
+          "Scoreboard API v1"
         ]
       }
     },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef, FormEvent } from 'react';
 import { useI18n } from './i18n';
+import { useAppConfig } from './hooks/useAppConfig';
 import { useGameState } from './hooks/useGameState';
 import { useSettings } from './hooks/useSettings';
 import { useOrientation } from './hooks/useOrientation';
@@ -46,6 +47,7 @@ function getInitialOid(): string {
 
 export default function App() {
   const { t } = useI18n();
+  const appConfig = useAppConfig();
   const { settings, setSetting } = useSettings();
   const { isPortrait, buttonSize } = useOrientation();
 
@@ -309,6 +311,7 @@ export default function App() {
         onSubmit={handleInit}
         onSelect={setOid}
         error={error}
+        title={appConfig.title}
       />
     );
   }

--- a/frontend/src/PreviewApp.tsx
+++ b/frontend/src/PreviewApp.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import OverlayPreview from './components/OverlayPreview';
+import { useAppConfig } from './hooks/useAppConfig';
 import { I18nProvider, useI18n } from './i18n';
 
 const SCALE_MIN = 0.5;
@@ -15,6 +16,7 @@ function readNumberParam(params: URLSearchParams, key: string, fallback: number)
 
 function PreviewPageInner() {
   const { t } = useI18n();
+  useAppConfig();
 
   const queryParams = new URLSearchParams(window.location.search);
   const overlayUrl = queryParams.get('output') || '';

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -14,6 +14,7 @@ export type Team = 1 | 2;
 
 export type GameState = Schemas['GameStateResponse'];
 export type ActionResponse = Schemas['ActionResponse'];
+export type AppConfig = Schemas['AppConfigResponse'];
 export type InitRequest = Schemas['InitRequest'];
 export type OverlayPayload = Schemas['OverlayPayload'];
 
@@ -172,4 +173,8 @@ export function getStyles(oid: string): Promise<string[]> {
 
 export function getOverlays(): Promise<OverlayPayload[]> {
   return request<OverlayPayload[]>('GET', '/overlays');
+}
+
+export function getAppConfig(): Promise<AppConfig> {
+  return request<AppConfig>('GET', '/app-config');
 }

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -177,6 +177,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/app-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * App Config
+         * @description Return runtime app configuration consumed by the SPA on boot.
+         */
+        get: operations["app_config_api_v1_app_config_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/config": {
         parameters: {
             query?: never;
@@ -664,6 +684,11 @@ export interface components {
             state?: components["schemas"]["GameStateResponse"] | null;
             /** Success */
             success: boolean;
+        };
+        /** AppConfigResponse */
+        AppConfigResponse: {
+            /** Title */
+            title: string;
         };
         /** CustomOverlayCreate */
         CustomOverlayCreate: {
@@ -1248,6 +1273,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    app_config_api_v1_app_config_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AppConfigResponse"];
                 };
             };
         };

--- a/frontend/src/components/InitScreen.tsx
+++ b/frontend/src/components/InitScreen.tsx
@@ -8,6 +8,7 @@ export interface InitScreenProps {
   onSubmit: (e: FormEvent<HTMLFormElement>) => void;
   onSelect: (oid: string) => void;
   error?: string | null;
+  title?: string;
 }
 
 interface PredefinedOverlay {
@@ -38,7 +39,7 @@ function normalizeOverlays(data: unknown): PredefinedOverlay[] {
   return [];
 }
 
-export default function InitScreen({ oidInput, setOidInput, onSubmit, onSelect, error }: InitScreenProps) {
+export default function InitScreen({ oidInput, setOidInput, onSubmit, onSelect, error, title }: InitScreenProps) {
   const { t } = useI18n();
   const [predefinedOverlays, setPredefinedOverlays] = useState<PredefinedOverlay[]>([]);
 
@@ -59,7 +60,7 @@ export default function InitScreen({ oidInput, setOidInput, onSubmit, onSelect, 
 
   return (
     <div className="init-screen">
-      <h1 className="init-title">{t('app.title')}</h1>
+      <h1 className="init-title">{title || t('app.title')}</h1>
       {predefinedOverlays.length > 0 && (
         <div className="init-overlay-selector">
           <label className="init-label">{t('app.selectOverlay')}</label>

--- a/frontend/src/hooks/useAppConfig.ts
+++ b/frontend/src/hooks/useAppConfig.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import * as api from '../api/client';
+import type { AppConfig } from '../api/client';
+
+const DEFAULT_TITLE = 'Volley Scoreboard';
+
+/**
+ * Fetch runtime app configuration from the backend on mount and set
+ * ``document.title`` to the configured app title. The returned ``title``
+ * lets callers render the same value in the UI without a flash of the
+ * default while the request is in flight.
+ */
+export function useAppConfig(): AppConfig {
+  const [config, setConfig] = useState<AppConfig>({ title: DEFAULT_TITLE });
+
+  useEffect(() => {
+    let cancelled = false;
+    api.getAppConfig().then((cfg) => {
+      if (cancelled) return;
+      setConfig(cfg);
+      if (cfg.title) document.title = cfg.title;
+    }).catch((err: unknown) => {
+      console.warn('Failed to fetch app config:', err);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  return config;
+}

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -9,6 +9,7 @@ vi.mock('../api/client', () => ({
   getCustomization: vi.fn(),
   getLinks: vi.fn(),
   getOverlays: vi.fn(),
+  getAppConfig: vi.fn(),
   addPoint: vi.fn(),
   addSet: vi.fn(),
   addTimeout: vi.fn(),
@@ -40,6 +41,7 @@ describe('App', () => {
       writable: true,
     });
     vi.mocked(api.getOverlays).mockResolvedValue([]);
+    vi.mocked(api.getAppConfig).mockResolvedValue({ title: 'Volley Scoreboard' });
     vi.mocked(api.initSession).mockResolvedValue({ success: true, state: mockGameState });
     vi.mocked(api.getCustomization).mockResolvedValue(mockCustomization);
     vi.mocked(api.getLinks).mockResolvedValue({ control: '', overlay: '', preview: '' });

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -1,0 +1,58 @@
+"""Tests for the runtime app-config plumbing (APP_TITLE env var).
+
+Covers both the small ``GET /api/v1/app-config`` endpoint and the helper
+that rewrites ``<title>`` inside the served SPA ``index.html``.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api import api_router
+from app.bootstrap import _inject_title_into_html
+from app.app_config import DEFAULT_APP_TITLE, get_app_title
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(api_router)
+    return TestClient(app)
+
+
+def test_app_config_returns_default_title(client, monkeypatch):
+    monkeypatch.delenv("APP_TITLE", raising=False)
+    res = client.get("/api/v1/app-config")
+    assert res.status_code == 200
+    assert res.json() == {"title": DEFAULT_APP_TITLE}
+
+
+def test_app_config_returns_env_title(client, monkeypatch):
+    monkeypatch.setenv("APP_TITLE", "My Liga Volley")
+    res = client.get("/api/v1/app-config")
+    assert res.status_code == 200
+    assert res.json() == {"title": "My Liga Volley"}
+
+
+def test_app_config_falls_back_when_env_is_blank(monkeypatch):
+    monkeypatch.setenv("APP_TITLE", "   ")
+    assert get_app_title() == DEFAULT_APP_TITLE
+
+
+def test_inject_title_replaces_tag():
+    html = "<html><head><title>Old</title></head><body/></html>"
+    result = _inject_title_into_html(html, "New Title")
+    assert "<title>New Title</title>" in result
+    assert "Old" not in result
+
+
+def test_inject_title_escapes_html_special_chars():
+    html = "<html><head><title>x</title></head></html>"
+    result = _inject_title_into_html(html, "A & <B>")
+    assert "<title>A &amp; &lt;B&gt;</title>" in result
+
+
+def test_inject_title_only_replaces_first_match():
+    html = "<title>a</title>...<title>b</title>"
+    result = _inject_title_into_html(html, "Z")
+    assert result == "<title>Z</title>...<title>b</title>"

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -9,7 +9,11 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.api import api_router
-from app.bootstrap import _inject_title_into_html
+from app.bootstrap import (
+    _inject_title_into_html,
+    _render_index_html,
+    _render_manifest,
+)
 from app.app_config import DEFAULT_APP_TITLE, get_app_title
 
 
@@ -56,3 +60,41 @@ def test_inject_title_only_replaces_first_match():
     html = "<title>a</title>...<title>b</title>"
     result = _inject_title_into_html(html, "Z")
     assert result == "<title>Z</title>...<title>b</title>"
+
+
+def test_inject_title_handles_attributes_on_title_tag():
+    html = '<head><title lang="en">Old</title></head>'
+    result = _inject_title_into_html(html, "New")
+    assert "<title>New</title>" in result
+    assert "Old" not in result
+
+
+def test_render_index_html_caches_disk_reads(tmp_path):
+    """Repeat calls with the same (path, mtime, title) read disk only once."""
+    index = tmp_path / "index.html"
+    index.write_text("<title>Old</title>", encoding="utf-8")
+    mtime = index.stat().st_mtime
+
+    _render_index_html.cache_clear()
+    first = _render_index_html(str(index), mtime, "Hello")
+    info_before = _render_index_html.cache_info()
+    # Mutate the file but pass the same mtime so the cache key is unchanged.
+    index.write_text("<title>Mutated</title>", encoding="utf-8")
+    second = _render_index_html(str(index), mtime, "Hello")
+    info_after = _render_index_html.cache_info()
+
+    assert first == second == "<title>Hello</title>"
+    assert info_after.hits == info_before.hits + 1
+
+
+def test_render_manifest_injects_title_into_name_fields(tmp_path):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        '{"name": "Old", "short_name": "Old", "icons": []}',
+        encoding="utf-8",
+    )
+    _render_manifest.cache_clear()
+    data = _render_manifest(str(manifest), manifest.stat().st_mtime, "MyApp")
+    assert data["name"] == "MyApp"
+    assert data["short_name"] == "MyApp"
+    assert data["icons"] == []


### PR DESCRIPTION
## Summary
- Adds an `APP_TITLE` env var (default `Volley Scoreboard`) consumed in three places without rebuilding the SPA:
  - `<title>` in the served `index.html` is rewritten by `SPAStaticFiles`.
  - PWA `manifest.webmanifest` and `manifest.json` have `name`/`short_name` injected on the fly.
  - Frontend fetches `GET /api/v1/app-config` on boot, sets `document.title`, and uses the value for the init screen heading.

## Test plan
- [x] Backend: 201 pytest tests pass locally; new `tests/test_app_config.py` covers the endpoint, env precedence, blank fallback, and the title-injection helper (special-char escaping, single replacement).
- [x] Frontend: 162 vitest tests pass; `tsc --noEmit` clean.
- [x] OpenAPI schema and TS types regenerated.
- [ ] Manual: set `APP_TITLE=My Liga`, restart, confirm browser tab, init heading and PWA install all show the new name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)