### PR TITLE
Sprint 3: dedupe neumorphic CSS tokens into jersey_shared.css

### DIFF
--- a/overlay_static/css/clear_jersey.css
+++ b/overlay_static/css/clear_jersey.css
@@ -24,7 +24,7 @@
     --logo-size:  70px;   /* taller than bar → protrudes 4px each side */
     --logo-skew:  12px;   /* parallelogram slant (matches compact) */
 
-    /* Collapse transition (easing from jersey_shared.css) */
+    /* Collapse transition */
     --collapse-dur:    0.44s;
 }
 

--- a/overlay_static/css/clear_jersey.css
+++ b/overlay_static/css/clear_jersey.css
@@ -16,15 +16,6 @@
     --away-primary:   #0047AB;
     --away-secondary: #FFD700;
 
-    /* Neumorphic palette */
-    --nm-bg:          #e0e5ec;
-    --nm-shadow-dark: rgba(163, 177, 198, 0.60);
-    --nm-shadow-lite: rgba(255, 255, 255, 0.85);
-    --nm-inset-dark:  rgba(163, 177, 198, 0.50);
-    --nm-inset-lite:  rgba(255, 255, 255, 0.80);
-    --nm-text:        #31344b;
-    --nm-text-dim:    #777b96;
-
     /* Bar geometry */
     --bar-h:      62px;
     --bar-radius: 31px;
@@ -33,8 +24,7 @@
     --logo-size:  70px;   /* taller than bar → protrudes 4px each side */
     --logo-skew:  12px;   /* parallelogram slant (matches compact) */
 
-    /* Collapse transition */
-    --collapse-easing: cubic-bezier(0.4, 0, 0.2, 1);
+    /* Collapse transition (easing from jersey_shared.css) */
     --collapse-dur:    0.44s;
 }
 

--- a/overlay_static/css/jersey_shared.css
+++ b/overlay_static/css/jersey_shared.css
@@ -1,6 +1,5 @@
 /* ── Shared jersey tokens and icon styles ────────────────────
-   Imported by clear_jersey.css, neo_jersey.css, split_jersey.css.
-   Theme-specific properties stay in each theme's own :root.
+   Imported by jersey-family themes; override via each theme's :root.
 ──────────────────────────────────────────────────────────── */
 :root {
     --nm-bg:          #e0e5ec;

--- a/overlay_static/css/jersey_shared.css
+++ b/overlay_static/css/jersey_shared.css
@@ -1,8 +1,18 @@
-/* ── Shared jersey icon styles ───────────────────────────────
-   Imported by neo_jersey.css and split_jersey.css.
-   Theme-specific properties (width, height, outline) stay in
-   each theme file.
+/* ── Shared jersey tokens and icon styles ────────────────────
+   Imported by clear_jersey.css, neo_jersey.css, split_jersey.css.
+   Theme-specific properties stay in each theme's own :root.
 ──────────────────────────────────────────────────────────── */
+:root {
+    --nm-bg:          #e0e5ec;
+    --nm-shadow-dark: rgba(163, 177, 198, 0.60);
+    --nm-shadow-lite: rgba(255, 255, 255, 0.85);
+    --nm-inset-dark:  rgba(163, 177, 198, 0.50);
+    --nm-inset-lite:  rgba(255, 255, 255, 0.80);
+    --nm-text:        #31344b;
+    --nm-text-dim:    #777b96;
+    --collapse-easing: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 .jersey-icon {
     flex-shrink: 0;
     /* T-shirt silhouette */

--- a/overlay_static/css/neo_jersey.css
+++ b/overlay_static/css/neo_jersey.css
@@ -20,7 +20,7 @@
     --sets-w:  42px;
     --points-w: 82px;
 
-    /* Compact-mode transition (easing from jersey_shared.css) */
+    /* Compact-mode transition timing */
     --collapse-dur:    0.48s;
 }
 

--- a/overlay_static/css/neo_jersey.css
+++ b/overlay_static/css/neo_jersey.css
@@ -16,25 +16,11 @@
     --away-primary:   #0047AB;
     --away-secondary: #FFD700;
 
-    /* Neumorphic palette */
-    --nm-bg:          #e0e5ec;
-    --nm-shadow-dark: rgba(163, 177, 198, 0.60);
-    --nm-shadow-lite: rgba(255, 255, 255, 0.85);
-
-    /* Inset shadow (score block & history strip) */
-    --nm-inset-dark:  rgba(163, 177, 198, 0.50);
-    --nm-inset-lite:  rgba(255, 255, 255, 0.80);
-
-    /* Text */
-    --nm-text:        #31344b;
-    --nm-text-dim:    #777b96;
-
     /* Score area dimensions */
     --sets-w:  42px;
     --points-w: 82px;
 
-    /* Compact-mode transition timing */
-    --collapse-easing: cubic-bezier(0.4, 0, 0.2, 1);
+    /* Compact-mode transition (easing from jersey_shared.css) */
     --collapse-dur:    0.48s;
 }
 

--- a/overlay_static/css/split_jersey.css
+++ b/overlay_static/css/split_jersey.css
@@ -26,7 +26,7 @@
     --bar-h:      62px;
     --bar-radius: 31px;   /* = bar-h / 2  → perfect semicircle on left */
 
-    /* Collapse transition (easing from jersey_shared.css) */
+    /* Collapse transition */
     --collapse-dur:    0.44s;
 }
 

--- a/overlay_static/css/split_jersey.css
+++ b/overlay_static/css/split_jersey.css
@@ -22,21 +22,11 @@
     --home-gradient:  var(--home-primary);
     --away-gradient:  var(--away-primary);
 
-    /* Neumorphic palette (shared with neo_jersey) */
-    --nm-bg:          #e0e5ec;
-    --nm-shadow-dark: rgba(163, 177, 198, 0.60);
-    --nm-shadow-lite: rgba(255, 255, 255, 0.85);
-    --nm-inset-dark:  rgba(163, 177, 198, 0.50);
-    --nm-inset-lite:  rgba(255, 255, 255, 0.80);
-    --nm-text:        #31344b;
-    --nm-text-dim:    #777b96;
-
     /* Bar geometry */
     --bar-h:      62px;
     --bar-radius: 31px;   /* = bar-h / 2  → perfect semicircle on left */
 
-    /* Collapse transition */
-    --collapse-easing: cubic-bezier(0.4, 0, 0.2, 1);
+    /* Collapse transition (easing from jersey_shared.css) */
     --collapse-dur:    0.44s;
 }
 


### PR DESCRIPTION
## Summary

Sprint 3 kickoff (base branch `dev`, follows #167).

After surveying the Sprint 3 plan items:
- **P2-5 (typed state model)** is already on `dev` — `app/state.py` exposes a `GameState` dataclass with typed getters (`get_sets`, `get_game`, `set_current_serve`, etc.) and `GameManager` consumes it. The legacy `to_dict()` path is intentionally kept because overlay backends (UNO in particular) serialise with literal string keys. No code change needed.
- **P2-12 (unified WS client)** turns out to conflate two different endpoints: `/api/v1/ws` (control API consumed by React) and `/ws/{output_key}` (overlay broadcast consumed by `overlay_static/js/app.js`). They don't share a protocol, so a single shared client can't replace both without bigger packaging decisions — deferring to a follow-up.
- **P2-13 (shared overlay base + CSS variables)** is the concrete remaining win. `base.html` already exists and templates already `@extends` it, so the template side is covered. This PR knocks out the CSS half.

## What changed

Hoist the duplicated neumorphic tokens (`--nm-bg`, `--nm-shadow-*`, `--nm-inset-*`, `--nm-text*`) and the `--collapse-easing` cubic-bezier into `overlay_static/css/jersey_shared.css` (already `@import`ed by the three jersey themes). `clear_jersey.css`, `neo_jersey.css`, and `split_jersey.css` drop their copies. Theme-specific values (`--collapse-dur`, `--bar-h`, `--sets-w`, etc.) stay per-theme and continue to override via CSS cascade.

Net **−24 lines**; no runtime behaviour change.

## Test plan
- [x] `pytest tests/` → **333 passed**
- [ ] Manual OBS smoke: load `clear_jersey`, `neo_jersey`, `split_jersey` overlays and confirm they render identically to `dev` (neumorphic surface color, shadows, collapse timing)

https://claude.ai/code/session_01EbJ1GBjstofWUo2mk8EU8m