### PR TITLE
refactor(sprint-a): logger hygiene — unify names, kill f-strings, redact PII

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -30,7 +30,7 @@ from starlette.concurrency import run_in_threadpool
 
 from app.env_vars_manager import EnvVarsManager
 
-logger = logging.getLogger("AdminRoutes")
+logger = logging.getLogger(__name__)
 
 _PAGE_PATH = os.path.join(os.path.dirname(__file__), "static", "overlays.html")
 

--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -3,7 +3,7 @@ from fastapi import Header, Query, HTTPException, Request
 from app.authentication import PasswordAuthenticator
 from app.api.session_manager import SessionManager, GameSession
 
-logger = logging.getLogger("APIDeps")
+logger = logging.getLogger(__name__)
 
 async def verify_api_key(authorization: str = Header(None)):
     """Validate the Bearer token when user authentication is enabled.

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -3,7 +3,7 @@ from app.api.schemas import GameStateResponse, TeamState, ActionResponse, ALLOWE
 from app.api.ws_hub import WSHub
 from app.state import State
 
-logger = logging.getLogger("GameService")
+logger = logging.getLogger(__name__)
 
 
 class MatchFinishedError(Exception):

--- a/app/api/routes/lifespan.py
+++ b/app/api/routes/lifespan.py
@@ -7,7 +7,7 @@ from weakref import WeakValueDictionary
 
 from app.api.session_manager import SessionManager
 
-logger = logging.getLogger("APIRoutes")
+logger = logging.getLogger(__name__)
 
 _cleanup_task: asyncio.Task | None = None
 # WeakValueDictionary auto-evicts entries once all strong refs to the lock are

--- a/app/api/routes/overlays.py
+++ b/app/api/routes/overlays.py
@@ -15,7 +15,7 @@ from app.customization import Customization
 from app.env_vars_manager import EnvVarsManager
 from app.oid_utils import compose_output, extract_oid
 
-logger = logging.getLogger("APIRoutes")
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 

--- a/app/api/routes/websocket.py
+++ b/app/api/routes/websocket.py
@@ -8,8 +8,9 @@ from app.api.dependencies import check_oid_access
 from app.api.game_service import GameService
 from app.api.session_manager import SessionManager
 from app.api.ws_hub import WSHub
+from app.logging_utils import redact_oid
 
-logger = logging.getLogger("APIRoutes")
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -42,7 +43,7 @@ async def websocket_endpoint(ws: WebSocket, oid: str = Query(...)):
                 await ws.send_text("pong")
     except WebSocketDisconnect:
         pass
-    except Exception as e:
-        logger.error(f"WebSocket error for OID {oid}: {e}")
+    except Exception:
+        logger.exception("WebSocket error for OID %s", redact_oid(oid))
     finally:
         WSHub.disconnect(ws, oid)

--- a/app/api/session_manager.py
+++ b/app/api/session_manager.py
@@ -7,7 +7,7 @@ from app.backend import Backend
 from app.game_manager import GameManager
 from app.customization import Customization
 
-logger = logging.getLogger("SessionManager")
+logger = logging.getLogger(__name__)
 
 # Sessions expire after 24 hours of inactivity
 SESSION_TTL_SECONDS = 24 * 60 * 60

--- a/app/api/ws_hub.py
+++ b/app/api/ws_hub.py
@@ -3,7 +3,7 @@ import json
 import logging
 from fastapi import WebSocket
 
-logger = logging.getLogger("WSHub")
+logger = logging.getLogger(__name__)
 
 
 class WSHub:

--- a/app/app_storage.py
+++ b/app/app_storage.py
@@ -26,7 +26,7 @@ class AppStorage:
         ('LOCK_TEAM_B_COLORS', 'lock_team_b_colors'),
     ])
 
-    logger = logging.getLogger("Storage")
+    logger = logging.getLogger(__name__)
 
     def _get_storage():
         return _memory_storage
@@ -65,5 +65,5 @@ class AppStorage:
 
     def clear_user_storage():
         storage = AppStorage._get_storage()
-        logging.info('Clearing storage')
+        AppStorage.logger.info('Clearing storage')
         storage.clear()

--- a/app/authentication.py
+++ b/app/authentication.py
@@ -4,7 +4,7 @@ import secrets
 from app.env_vars_manager import EnvVarsManager
 from app.oid_utils import UNO_OUTPUT_BASE_URL
 
-logger = logging.getLogger("Authenticator")
+logger = logging.getLogger(__name__)
 
 
 class PasswordAuthenticator:

--- a/app/backend.py
+++ b/app/backend.py
@@ -394,8 +394,8 @@ class Backend:
                 show_only_current_set=show_only_current_set,
             )
             self._overlay.send_overlay_state(payload)
-        except Exception as e:
-            Backend.logger.error("Error updating local overlay: %s", e)
+        except Exception:
+            Backend.logger.exception("Error updating local overlay")
 
     # -- Uno-specific pass-through (used by legacy code paths) ----
 

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -25,7 +25,7 @@ from app.api import api_router
 from app.app_config import get_app_title
 from app.authentication import PasswordAuthenticator
 
-logger = logging.getLogger("Bootstrap")
+logger = logging.getLogger(__name__)
 
 
 FRONTEND_DIR = Path("frontend/dist")
@@ -107,7 +107,7 @@ async def _lifespan(application: FastAPI):
         from app.overlay import obs_broadcast_hub
         obs_broadcast_hub.capture_event_loop()
     except Exception:
-        pass
+        logger.exception("Failed to capture event loop for OBS broadcast hub")
     yield
 
 

--- a/app/config_validator.py
+++ b/app/config_validator.py
@@ -2,13 +2,14 @@ import os
 import json
 import logging
 
+logger = logging.getLogger(__name__)
+
+
 def validate_config():
     """
     Validates critical environment variables on startup.
     Logs warnings and sets safe defaults in os.environ for invalid configurations.
     """
-    logger = logging.getLogger("ConfigValidator")
-
     # Positive integer validation
     int_vars = [
         ('MATCH_GAME_POINTS', '25'),
@@ -22,7 +23,7 @@ def validate_config():
             if int_val <= 0:
                 raise ValueError("Must be a positive integer")
         except ValueError:
-            logger.warning(f"Invalid {var} '{val}': must be a positive integer. Defaulting to {default}.")
+            logger.warning("Invalid %s '%s': must be a positive integer. Defaulting to %s.", var, val, default)
             os.environ[var] = default
 
     # JSON validation
@@ -33,7 +34,7 @@ def validate_config():
             try:
                 json.loads(val)
             except json.JSONDecodeError:
-                logger.warning(f"Invalid JSON in {var}. Defaulting to empty/None behavior.")
+                logger.warning("Invalid JSON in %s. Defaulting to empty/None behavior.", var)
                 # We simply remove invalid JSON from environment to prevent runtime crashes
                 del os.environ[var]
 
@@ -44,7 +45,7 @@ def validate_config():
         if not (1 <= port_int <= 65535):
             raise ValueError("Out of valid port range")
     except ValueError:
-        logger.warning(f"Invalid APP_PORT '{port_val}': must be an integer between 1 and 65535. Defaulting to 8080.")
+        logger.warning("Invalid APP_PORT '%s': must be an integer between 1 and 65535. Defaulting to 8080.", port_val)
         os.environ['APP_PORT'] = '8080'
 
     timeout_val = os.environ.get('DEFAULT_HIDE_TIMEOUT', '5')
@@ -53,16 +54,16 @@ def validate_config():
         if timeout_int <= 0:
             raise ValueError("Must be a positive integer")
     except ValueError:
-        logger.warning(f"Invalid DEFAULT_HIDE_TIMEOUT '{timeout_val}': must be a positive integer. Defaulting to 5.")
+        logger.warning("Invalid DEFAULT_HIDE_TIMEOUT '%s': must be a positive integer. Defaulting to 5.", timeout_val)
         os.environ['DEFAULT_HIDE_TIMEOUT'] = '5'
 
     # Enums validation
     dark_mode = os.environ.get('APP_DARK_MODE', 'auto').lower()
     if dark_mode not in ['on', 'off', 'auto']:
-        logger.warning(f"Invalid APP_DARK_MODE '{dark_mode}'. Must be 'on', 'off', or 'auto'. Defaulting to 'auto'.")
+        logger.warning("Invalid APP_DARK_MODE '%s'. Must be 'on', 'off', or 'auto'. Defaulting to 'auto'.", dark_mode)
         os.environ['APP_DARK_MODE'] = 'auto'
 
     log_level = os.environ.get('LOGGING_LEVEL', 'info').lower()
     if log_level not in ['debug', 'info', 'warning', 'error']:
-        logger.warning(f"Invalid LOGGING_LEVEL '{log_level}'. Must be 'debug', 'info', 'warning', or 'error'. Defaulting to 'info'.")
+        logger.warning("Invalid LOGGING_LEVEL '%s'. Must be 'debug', 'info', 'warning', or 'error'. Defaulting to 'info'.", log_level)
         os.environ['LOGGING_LEVEL'] = 'info'

--- a/app/customization.py
+++ b/app/customization.py
@@ -1,6 +1,10 @@
 from app.messages import Messages
 import json
+import logging
 from app.env_vars_manager import EnvVarsManager
+
+logger = logging.getLogger(__name__)
+
 
 class Customization:
 
@@ -87,7 +91,7 @@ class Customization:
             try:
                 Customization.predefined_teams = json.loads(provided_teams_json)
             except json.JSONDecodeError:
-                print(f"Error decoding TEAMS from environment variable: {provided_teams_json}")
+                logger.warning("Malformed APP_TEAMS env var; ignoring value")
                 Customization.predefined_teams = {}
 
 
@@ -97,7 +101,7 @@ class Customization:
             try:
                 Customization.THEMES = json.loads(provided_themes_json)
             except json.JSONDecodeError:
-                print(f"Error decoding THEMES from environment variable: {provided_themes_json}")
+                logger.warning("Malformed APP_THEMES env var; ignoring value")
 
 
 

--- a/app/env_vars_manager.py
+++ b/app/env_vars_manager.py
@@ -4,12 +4,15 @@ import json
 import time
 import logging
 
+from app.logging_utils import redact_url
+
+logger = logging.getLogger(__name__)
+
+
 class EnvVarsManager:
     _remote_config_cache = {}
     _cache_timestamp = 0
     _CACHE_EXPIRATION_SECONDS = 10
-
-    logger = logging.getLogger("EnvVarsManager")
 
     @classmethod
     def get_env_var(cls, key, default=None):
@@ -41,11 +44,11 @@ class EnvVarsManager:
             if now - cls._cache_timestamp > cls._CACHE_EXPIRATION_SECONDS:
                 cls._cache_timestamp = now
                 try:
-                    EnvVarsManager.logger.info(f"Fetching remote config to {remote_config_url}")
+                    logger.info("Fetching remote config from %s", redact_url(remote_config_url))
                     response = requests.get(remote_config_url, timeout=5)
-                    EnvVarsManager.logger.debug(f"Remote config response: {response.status_code}")
+                    logger.debug("Remote config response status: %s", response.status_code)
                     response.raise_for_status()
                     cls._remote_config_cache = response.json()
-                except (requests.exceptions.RequestException, json.JSONDecodeError) as e:
-                    EnvVarsManager.logger.error(f"Error loading remote configuration: {e}")
+                except (requests.exceptions.RequestException, json.JSONDecodeError):
+                    logger.exception("Error loading remote configuration")
                     cls._remote_config_cache = {}

--- a/app/game_manager.py
+++ b/app/game_manager.py
@@ -3,38 +3,40 @@ from app.state import State
 from app.backend import Backend
 from app.conf import Conf
 
+logger = logging.getLogger(__name__)
+
+
 class GameManager:
     """
     Manages the game logic, state, and backend communication.
     """
 
     def __init__(self, conf: Conf, backend: Backend):
-        self.logger = logging.getLogger("GameManager")
-        self.logger.debug("Initializing GameManager")
+        logger.debug("Initializing GameManager")
         self.conf = conf
         self.backend = backend
         self.main_state = State(backend.get_current_model())
 
     def get_current_state(self) -> State:
         """Returns the current state of the game."""
-        self.logger.debug("Getting current state")
+        logger.debug("Getting current state")
         return self.main_state
 
     def reset(self):
         """Resets the game state."""
-        self.logger.debug("Resetting game state")
+        logger.debug("Resetting game state")
         self.backend.reset(self.main_state)
         self.main_state = State(self.backend.get_current_model())
 
     def save(self, simple: bool, current_set: int):
         """Saves the current game state."""
-        self.logger.debug(f"Saving state, simple mode: {simple}, current set: {current_set}")
+        logger.debug("Saving state, simple mode: %s, current set: %s", simple, current_set)
         self.main_state.set_current_set(current_set)
         self.backend.save(self.main_state, simple)
 
     def change_serve(self, team: int, force: bool = False):
         """Changes the serving team."""
-        self.logger.debug(f"Changing serve to team {team}, force: {force}")
+        logger.debug("Changing serve to team %s, force: %s", team, force)
         current_serve = self.main_state.get_current_serve()
         new_serve = State.SERVE_NONE
         if team == 1:
@@ -47,7 +49,7 @@ class GameManager:
 
     def add_timeout(self, team: int, undo: bool):
         """Adds or removes a timeout for a team."""
-        self.logger.debug(f"Adding timeout for team {team}, undo: {undo}")
+        logger.debug("Adding timeout for team %s, undo: %s", team, undo)
         current_timeouts = self.main_state.get_timeout(team)
         if undo:
             if current_timeouts > 0:
@@ -58,12 +60,12 @@ class GameManager:
 
     def set_game_value(self, team: int, value: int, current_set: int):
         """Directly sets the game score for a team."""
-        self.logger.debug(f"Setting game value for team {team} to {value} in set {current_set}")
+        logger.debug("Setting game value for team %s to %s in set %s", team, value, current_set)
         self.main_state.set_game(current_set, team, value)
 
     def set_sets_value(self, team: int, value: int):
         """Directly sets the sets won for a team."""
-        self.logger.debug(f"Setting sets value for team {team} to {value}")
+        logger.debug("Setting sets value for team %s to %s", team, value)
         self.main_state.set_sets(team, value)
 
     def _is_winning_score(self, score: int, rival_score: int, limit: int) -> bool:
@@ -72,9 +74,9 @@ class GameManager:
 
     def add_game(self, team: int, current_set: int, points_limit: int, points_limit_last_set: int, sets_limit: int, undo: bool) -> bool:
         """Adds or removes a point to a team and checks if the set or match is won."""
-        self.logger.debug(f"Adding game point for team {team} in set {current_set}, undo: {undo}")
+        logger.debug("Adding game point for team %s in set %s, undo: %s", team, current_set, undo)
         if not undo and self.match_finished():
-             self.logger.debug("Match finished, not adding point.")
+             logger.debug("Match finished, not adding point.")
              return False
 
         self.change_serve(team, True)
@@ -96,7 +98,7 @@ class GameManager:
                 is_still_a_win = self._is_winning_score(new_score, rival_score, game_limit)
 
                 if was_a_win and not is_still_a_win:
-                    self.logger.debug(f"Team {team} 'un-won' set {current_set} due to undo.")
+                    logger.debug("Team %s 'un-won' set %s due to undo.", team, current_set)
                     self.add_set(team, undo=True)
                     return True # Signal that the set state changed
         else:
@@ -104,16 +106,16 @@ class GameManager:
             current_score += 1
 
             if self._is_winning_score(current_score, rival_score, game_limit):
-                self.logger.debug(f"Team {team} won set {current_set}")
+                logger.debug("Team %s won set %s", team, current_set)
                 self.add_set(team, undo)
                 return True
         return False
 
     def add_set(self, team: int, undo: bool):
         """Adds or removes a set to a team."""
-        self.logger.debug(f"Adding set for team {team}, undo: {undo}")
+        logger.debug("Adding set for team %s, undo: %s", team, undo)
         if not undo and self.match_finished():
-            self.logger.debug("Match finished, not adding set.")
+            logger.debug("Match finished, not adding set.")
             return
 
         current_sets = self.main_state.get_sets(team)
@@ -130,27 +132,27 @@ class GameManager:
 
     def match_finished(self) -> bool:
         """Checks if the match has finished."""
-        self.logger.debug("Checking if match is finished")
+        logger.debug("Checking if match is finished")
         t1_sets = self.main_state.get_sets(1)
         t2_sets = self.main_state.get_sets(2)
         limit = self.conf.sets
         soft_limit = int(limit / 2) + 1
         if t1_sets >= soft_limit or t2_sets >= soft_limit:
-            self.logger.debug(f"Match finished. Score: {t1_sets}-{t2_sets}, required: {soft_limit}")
+            logger.debug("Match finished. Score: %s-%s, required: %s", t1_sets, t2_sets, soft_limit)
             return True
-        self.logger.debug(f"Match not finished. Score: {t1_sets}-{t2_sets}, required: {soft_limit}")
+        logger.debug("Match not finished. Score: %s-%s, required: %s", t1_sets, t2_sets, soft_limit)
         return False
 
     def check_set_won(self, team: int, current_set: int, points_limit: int, points_limit_last_set: int, sets_limit: int) -> bool:
         """Checks if a team has won the current set after a direct score update."""
-        self.logger.debug(f"Checking if team {team} won set {current_set}")
+        logger.debug("Checking if team %s won set %s", team, current_set)
         current_score = self.main_state.get_game(team, current_set)
         rival_team = 2 if team == 1 else 1
         rival_score = self.main_state.get_game(rival_team, current_set)
         game_limit = points_limit_last_set if current_set == sets_limit else points_limit
 
         if self._is_winning_score(current_score, rival_score, game_limit):
-            self.logger.debug(f"Team {team} won set {current_set}")
+            logger.debug("Team %s won set %s", team, current_set)
             self.add_set(team, False)
             return True
         return False

--- a/app/logging_utils.py
+++ b/app/logging_utils.py
@@ -37,9 +37,7 @@ def redact_url(url: str | None) -> str:
         parts = urlparse(url)
     except ValueError:
         return "<unparseable-url>"
-    netloc = parts.hostname or ""
-    if parts.port:
-        netloc = f"{netloc}:{parts.port}"
+    netloc = parts.netloc.rpartition("@")[-1]
     return urlunparse((parts.scheme, netloc, parts.path, "", "", ""))
 
 

--- a/app/logging_utils.py
+++ b/app/logging_utils.py
@@ -1,0 +1,58 @@
+"""Helpers for redacting PII/secret-bearing values before they reach the log."""
+import os
+from urllib.parse import urlparse, urlunparse
+
+_REDACT_ENABLED_CACHE: bool | None = None
+
+
+def _redact_enabled() -> bool:
+    """Return True when redaction should run.
+
+    Controlled by ``LOG_REDACT`` (default: on). Set to ``0``/``false``/``no``
+    in local dev to see raw values.
+    """
+    global _REDACT_ENABLED_CACHE
+    if _REDACT_ENABLED_CACHE is None:
+        raw = os.environ.get("LOG_REDACT", "1").strip().lower()
+        _REDACT_ENABLED_CACHE = raw not in ("0", "false", "no", "off", "")
+    return _REDACT_ENABLED_CACHE
+
+
+def _reset_cache_for_tests() -> None:
+    global _REDACT_ENABLED_CACHE
+    _REDACT_ENABLED_CACHE = None
+
+
+def redact_url(url: str | None) -> str:
+    """Strip credentials, query, and fragment from *url*.
+
+    Signed URLs (S3, GCS, auth tokens in query string) are common in the
+    remote-config path and must not hit the log.
+    """
+    if not url:
+        return "<none>"
+    if not _redact_enabled():
+        return url
+    try:
+        parts = urlparse(url)
+    except ValueError:
+        return "<unparseable-url>"
+    netloc = parts.hostname or ""
+    if parts.port:
+        netloc = f"{netloc}:{parts.port}"
+    return urlunparse((parts.scheme, netloc, parts.path, "", "", ""))
+
+
+def redact_oid(oid: str | None) -> str:
+    """Preserve the first 4 characters of *oid* and mask the rest.
+
+    Enough to disambiguate sessions in a log search without exposing the
+    full identifier to anyone who gains read access to the logs.
+    """
+    if not oid:
+        return "<none>"
+    if not _redact_enabled():
+        return oid
+    if len(oid) <= 4:
+        return "***"
+    return f"{oid[:4]}***"

--- a/app/overlay_backends/custom.py
+++ b/app/overlay_backends/custom.py
@@ -70,8 +70,8 @@ class CustomOverlayBackend(OverlayBackend):
                     json=payload, timeout=2.0,
                     headers=self._auth_headers(),
                 )
-            except Exception as e:
-                logger.error("Failed to save raw_config remote: %s", e)
+            except Exception:
+                logger.exception("Failed to save raw_config remote")
 
     # -- WebSocket lifecycle --
 
@@ -176,11 +176,11 @@ class CustomOverlayBackend(OverlayBackend):
                 if data:
                     return data
             return State().get_reset_model()
-        except requests.exceptions.RequestException as e:
-            logger.error("Network error fetching custom overlay model: %s", e)
+        except requests.exceptions.RequestException:
+            logger.exception("Network error fetching custom overlay model")
             return None
-        except Exception as e:
-            logger.error("Failed to fetch custom overlay model: %s", e)
+        except Exception:
+            logger.exception("Failed to fetch custom overlay model")
             return None
 
     def _get_default_customization(self, style, custom_id):
@@ -224,8 +224,8 @@ class CustomOverlayBackend(OverlayBackend):
                     except Exception as e:
                         logger.warning("Failed to persist preferredStyle: %s", e)
                 return data
-        except Exception as e:
-            logger.error("Failed to fetch custom overlay customization: %s", e)
+        except Exception:
+            logger.exception("Failed to fetch custom overlay customization")
 
         return self._get_default_customization(style, custom_id)
 
@@ -241,8 +241,8 @@ class CustomOverlayBackend(OverlayBackend):
             )
             if response.status_code == 200:
                 return response.json().get('availableStyles', [])
-        except Exception as e:
-            logger.error("Error fetching available styles: %s", e)
+        except Exception:
+            logger.exception("Error fetching available styles")
         return []
 
     def fetch_output_token(self, oid: str = None) -> str | None:
@@ -260,8 +260,8 @@ class CustomOverlayBackend(OverlayBackend):
                         output_path = urlparse(output_url).path
                         output_url = f"{output_base}{output_path}"
                     return output_url
-        except Exception as e:
-            logger.error("Error fetching local output token: %s", e)
+        except Exception:
+            logger.exception("Error fetching local output token")
         return None
 
     def validate_oid(self, oid: str) -> State.OIDStatus:
@@ -287,8 +287,8 @@ class CustomOverlayBackend(OverlayBackend):
                 json=payload, timeout=2.0,
                 headers=self._auth_headers(),
             )
-        except Exception as e:
-            logger.error("Error updating local overlay: %s", e)
+        except Exception:
+            logger.exception("Error updating local overlay")
 
     def send_json_model(self, to_save: dict) -> None:
         pass  # Custom overlays don't use Uno's SetOverlayContent

--- a/app/overlay_backends/uno.py
+++ b/app/overlay_backends/uno.py
@@ -39,8 +39,8 @@ class UnoOverlayBackend(OverlayBackend):
             if response.status_code >= 300:
                 logger.warning("response %s: '%s'", response.status_code, response.text)
             return response
-        except requests.exceptions.RequestException as e:
-            logger.error("Network error in _do_request: %s", e)
+        except requests.exceptions.RequestException:
+            logger.exception("Network error in _do_request")
             return _mock_response(500)
 
     # -- OverlayBackend interface --
@@ -98,10 +98,10 @@ class UnoOverlayBackend(OverlayBackend):
             else:
                 logger.warning("Failed to fetch output token for OID %s: %s",
                                target_oid, response.status_code)
-        except requests.exceptions.RequestException as e:
-            logger.error("Network error fetching output token: %s", e)
-        except Exception as e:
-            logger.error("Error fetching output token: %s", e)
+        except requests.exceptions.RequestException:
+            logger.exception("Network error fetching output token")
+        except Exception:
+            logger.exception("Error fetching output token")
         return None
 
     def validate_oid(self, oid: str) -> State.OIDStatus:

--- a/app/ws_client.py
+++ b/app/ws_client.py
@@ -259,5 +259,5 @@ class WSControlClient:
         if self._on_event:
             try:
                 self._on_event(msg)
-            except Exception as e:
-                logger.error("Event callback error: %s", e)
+            except Exception:
+                logger.exception("Event callback error")


### PR DESCRIPTION
## Summary

Sprint A (P0) of the logging-architecture plan at
`/root/.claude/plans/logging-architecture.md`. No behaviour changes —
pure observability hygiene across `app/`.

- **Unify logger names** to `getLogger(__name__)` everywhere (replaces a
  mix of hardcoded strings like `"Storage"`, `"APIRoutes"`,
  `"Bootstrap"`, `"GameManager"`). Enables module-level filtering and
  makes future `dictConfig` per-package levels actually work.
- **Lazy `%`-style log args** across the codebase — message formatting
  is now skipped when the level is disabled, and log records carry
  structured args for downstream handlers.
- **Tracebacks in except blocks** — replace
  `logger.error("…: %s", e)` with `logger.exception(…)` so stack
  traces land in the log. Also fixes a silent
  `except Exception: pass` in `bootstrap._lifespan`.
- **Drop two `print()` calls** in `customization.refresh()` that dumped
  the malformed `APP_TEAMS` / `APP_THEMES` payload (secrets leak
  vector). Replaced with a single warning that does not echo the
  payload.
- **PII redaction** — new `app/logging_utils.py` with `redact_url` and
  `redact_oid` helpers: strips `userinfo`/`query`/`fragment` from URLs
  and masks OIDs to `abcd***`. Toggled by `LOG_REDACT` (default on).
  Applied at the three high-signal sites identified in the plan;
  broader rollout lives in Sprint B.

## Test plan

- [x] `python -m pytest tests/ -q` → 333 passed
- [x] `python -m ruff check app/` → clean
- [ ] Gemini code review on this PR
- [ ] Manual smoke: start app, confirm no stray `print()` output, OID/URL logs are masked when `LOG_REDACT=1`.

https://claude.ai/code/session_01EbJ1GBjstofWUo2mk8EU8m