### PR TITLE
feat(overlay): enable mosaic preview grid via ?style=mosaic

### DIFF
--- a/CUSTOM_OVERLAY.md
+++ b/CUSTOM_OVERLAY.md
@@ -12,6 +12,18 @@ The overlay's name is used directly as the OID in the control UI.
 
 > **Backward compatibility:** the legacy `C-<id>` syntax (e.g. `C-mybroadcast`) is still accepted when the overlay already exists, but it is no longer the recommended form and is omitted from the documentation and UI.
 
+### 🖼️ Style Preview Grid (`?style=mosaic`)
+
+To compare every overlay style side-by-side — useful when deciding which layout fits your broadcast — open:
+
+```
+/overlay/{id}?style=mosaic
+```
+
+The page renders every selectable style in a responsive grid of iframes, each cropped to the actual overlay bounds, so differences in layout and color are easy to spot. Live state changes propagate to every cell via the same WebSocket used by individual overlays.
+
+`mosaic` is a **meta-style**: it is never returned in `availableStyles` from `/api/config/{id}`, so it cannot be selected as an overlay's `preferredStyle` and does not appear in the style picker. It is only reachable via the explicit `?style=mosaic` query parameter.
+
 ---
 
 ## Building a Custom External Overlay Server

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -218,7 +218,8 @@ Three overlay backend implementations share the `OverlayBackend` abstract interf
 In-memory + JSON file persistence for overlay state.
 
 - **Responsibility**: Manages overlay state with lazy-loading from disk, deep merge, normalization, CRUD, raw config pass-through, output key generation, and style enumeration.
-- **Key Methods**: `get_state()`, `update_state()`, `set_raw_config()`, `get_raw_config()`, `create_overlay()`, `ensure_overlay()`, `get_available_styles_list()`.
+- **Key Methods**: `get_state()`, `update_state()`, `set_raw_config()`, `get_raw_config()`, `create_overlay()`, `ensure_overlay()`, `get_available_styles_list()`, `get_renderable_styles()`.
+- **Style enumeration** distinguishes two lists: `get_available_styles_list()` returns user-selectable styles (what `/api/config/{id}` exposes in `availableStyles` and what the picker UI shows); `get_renderable_styles()` is a superset that also includes meta-styles like `mosaic` — valid as a `?style=` URL parameter but hidden from the picker so users cannot accidentally adopt them as a broadcast layout. See [CUSTOM_OVERLAY.md](CUSTOM_OVERLAY.md) for the mosaic preview grid.
 
 #### `app/overlay/broadcast.py` — class `ObsBroadcastHub`
 

--- a/app/overlay/routes.py
+++ b/app/overlay/routes.py
@@ -207,6 +207,7 @@ def create_overlay_router(
         overlay_id = resolved
 
         available = store.get_available_styles_list()
+        renderable = store.get_renderable_styles()
 
         if not style:
             state = await store.load_persisted_state_async(overlay_id)
@@ -218,8 +219,10 @@ def create_overlay_router(
             else:
                 style = "default"
 
-        # Validate style against known templates to prevent path traversal
-        if style not in available:
+        # Validate style against known templates to prevent path traversal.
+        # `renderable` is a superset of `available` that includes meta-styles
+        # like `mosaic` (hidden from the picker but valid as a URL param).
+        if style not in renderable:
             raise HTTPException(
                 status_code=404,
                 detail=f"Overlay style '{style}' not found.",
@@ -234,6 +237,7 @@ def create_overlay_router(
                 "target_id": overlay_id,
                 "output_key": OverlayStateStore.get_output_key(overlay_id),
                 "style": style,
+                "available_styles": available,
                 "v": int(time.time()),
             },
         )

--- a/app/overlay/state_store.py
+++ b/app/overlay/state_store.py
@@ -123,6 +123,7 @@ class OverlayStateStore:
         self._lock = threading.RLock()
         self._broadcast_callback: Optional[Callable] = None
         self._available_styles: Optional[list] = None
+        self._renderable_styles: Optional[list] = None
         # Maps any accepted URL token (output_key or raw overlay_id) to the
         # real overlay id. Populated lazily by resolve_overlay_id and kept
         # in sync by create/copy/delete.
@@ -292,13 +293,18 @@ class OverlayStateStore:
 
         Extends :meth:`get_available_styles_list` with meta-styles like
         ``mosaic`` that can be rendered but should not appear in the UI
-        picker.
+        picker. Cached after first scan — the templates directory is
+        static at runtime and this is called on every overlay request.
         """
-        styles = list(self.get_available_styles_list())
-        for meta in self._META_STYLES:
-            if os.path.isfile(os.path.join(self._templates_dir, f"{meta}.html")):
-                styles.append(meta)
-        return styles
+        with self._lock:
+            if self._renderable_styles is not None:
+                return self._renderable_styles
+            styles = list(self.get_available_styles_list())
+            for meta in self._META_STYLES:
+                if os.path.isfile(os.path.join(self._templates_dir, f"{meta}.html")):
+                    styles.append(meta)
+            self._renderable_styles = styles
+            return self._renderable_styles
 
     # -- CRUD --------------------------------------------------------------
 

--- a/app/overlay/state_store.py
+++ b/app/overlay/state_store.py
@@ -264,22 +264,41 @@ class OverlayStateStore:
 
     # -- Available styles --------------------------------------------------
 
+    # Meta-styles are renderable via /overlay/{id}?style=... but hidden from
+    # the style picker. `mosaic` shows every style side-by-side (a preview
+    # grid); `base` is an abstract Jinja parent and never directly served.
+    _META_STYLES = {"mosaic"}
+    _NEVER_RENDERED = {"base"}
+
     def get_available_styles_list(self) -> list:
-        """Return available overlay styles (cached after first scan)."""
+        """Return user-selectable overlay styles (cached after first scan)."""
         with self._lock:
             if self._available_styles is not None:
                 return self._available_styles
-            excluded = {"mosaic", "base"}
+            hidden = self._META_STYLES | self._NEVER_RENDERED
             styles = []
             if os.path.isdir(self._templates_dir):
                 for f in os.listdir(self._templates_dir):
                     if f.endswith(".html"):
                         name = f[:-5]
                         label = "default" if name == "index" else name
-                        if label not in excluded:
+                        if label not in hidden:
                             styles.append(label)
             self._available_styles = sorted(styles)
             return self._available_styles
+
+    def get_renderable_styles(self) -> list:
+        """Styles valid for ``/overlay/{id}?style=...``, including meta-styles.
+
+        Extends :meth:`get_available_styles_list` with meta-styles like
+        ``mosaic`` that can be rendered but should not appear in the UI
+        picker.
+        """
+        styles = list(self.get_available_styles_list())
+        for meta in self._META_STYLES:
+            if os.path.isfile(os.path.join(self._templates_dir, f"{meta}.html")):
+                styles.append(meta)
+        return styles
 
     # -- CRUD --------------------------------------------------------------
 

--- a/overlay_templates/mosaic.html
+++ b/overlay_templates/mosaic.html
@@ -15,22 +15,13 @@
     <script>
         const OVERLAY_ID = "{{ target_id }}";
         window.OVERLAY_STYLE = "{{ style }}";
-        const EXCLUDED = new Set(["mosaic"]);
+        // Server-rendered from the overlay router's template context so the
+        // page does not need to call /api/config/ (which is gated by
+        // OVERLAY_SERVER_TOKEN).
+        const AVAILABLE_STYLES = {{ available_styles | tojson }};
 
         // Track render bounds reported by each iframe (style → bounds)
         const iframeBounds = new Map();
-
-        async function loadStyles() {
-            try {
-                const resp = await fetch(`/api/config/${OVERLAY_ID}`);
-                const data = await resp.json();
-                const styles = (data.availableStyles || []).filter(s => !EXCLUDED.has(s));
-                buildGrid(styles);
-            } catch (e) {
-                console.error("Failed to load styles:", e);
-                buildGrid(["default", "split", "esports", "diagonal", "glass", "pill", "ribbon", "shield", "vertical"]);
-            }
-        }
 
         function buildGrid(styles) {
             const grid = document.getElementById("mosaic-grid");
@@ -116,7 +107,7 @@
             });
         });
 
-        loadStyles();
+        buildGrid(AVAILABLE_STYLES);
     </script>
 </body>
 </html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,12 +47,14 @@ def isolate_overlay_store(tmp_path_factory):
         "_overlays": overlay_state_store._overlays,
         "_output_key_cache": overlay_state_store._output_key_cache,
         "_available_styles": overlay_state_store._available_styles,
+        "_renderable_styles": overlay_state_store._renderable_styles,
         "_all_overlays_scanned": overlay_state_store._all_overlays_scanned,
     }
     overlay_state_store._data_dir = str(seed_dir)
     overlay_state_store._overlays = {}
     overlay_state_store._output_key_cache = {}
     overlay_state_store._available_styles = None
+    overlay_state_store._renderable_styles = None
     overlay_state_store._all_overlays_scanned = False
     overlay_state_store.create_overlay("test_overlay")
 
@@ -62,6 +64,7 @@ def isolate_overlay_store(tmp_path_factory):
     overlay_state_store._overlays = saved["_overlays"]
     overlay_state_store._output_key_cache = saved["_output_key_cache"]
     overlay_state_store._available_styles = saved["_available_styles"]
+    overlay_state_store._renderable_styles = saved["_renderable_styles"]
     overlay_state_store._all_overlays_scanned = saved["_all_overlays_scanned"]
 
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -21,6 +21,7 @@ def _reset_store(tmp_path, monkeypatch):
     overlay_state_store._overlays = {}
     overlay_state_store._output_key_cache = {}
     overlay_state_store._available_styles = None
+    overlay_state_store._renderable_styles = None
     monkeypatch.delenv("PREDEFINED_OVERLAYS", raising=False)
     monkeypatch.delenv("SCOREBOARD_USERS", raising=False)
     monkeypatch.delenv("OVERLAY_MANAGER_PASSWORD", raising=False)

--- a/tests/test_auth_coverage.py
+++ b/tests/test_auth_coverage.py
@@ -409,8 +409,6 @@ def test_mosaic_style_renders_but_is_not_selectable(tmp_path):
     in ``availableStyles`` (the style picker) — otherwise users could pick
     a meta-style as their broadcast layout.
     """
-    from app.overlay.state_store import OverlayStateStore
-
     app, store = _make_overlay_app_with_real_templates(tmp_path)
     raw_id = "mosaic-preview"
     store.create_overlay(raw_id)

--- a/tests/test_auth_coverage.py
+++ b/tests/test_auth_coverage.py
@@ -401,3 +401,26 @@ def test_overlay_page_accepts_raw_id(tmp_path):
     response = TestClient(app).get(f"/overlay/{raw_id}")
     assert response.status_code == 200
     assert 'OUTPUT_KEY' in response.text
+
+
+def test_mosaic_style_renders_but_is_not_selectable(tmp_path):
+    """The `mosaic` meta-style must be renderable via ``?style=mosaic`` so
+    users can preview every overlay side-by-side, but it must not appear
+    in ``availableStyles`` (the style picker) — otherwise users could pick
+    a meta-style as their broadcast layout.
+    """
+    from app.overlay.state_store import OverlayStateStore
+
+    app, store = _make_overlay_app_with_real_templates(tmp_path)
+    raw_id = "mosaic-preview"
+    store.create_overlay(raw_id)
+
+    assert "mosaic" not in store.get_available_styles_list()
+    assert "mosaic" in store.get_renderable_styles()
+
+    response = TestClient(app).get(f"/overlay/{raw_id}?style=mosaic")
+    assert response.status_code == 200, response.text
+    # Server-rendered styles list (avoids a browser fetch to the
+    # token-gated /api/config/ endpoint).
+    assert "AVAILABLE_STYLES" in response.text
+    assert "mosaic-grid" in response.text


### PR DESCRIPTION
## Summary

- Enables `/overlay/{id}?style=mosaic` so users can preview every overlay layout side-by-side in a responsive grid of iframes, making it easy to pick the right style for a broadcast. The template and CSS were already present in the repo but unreachable — `serve_overlay` was rejecting `mosaic` because the validator used the user-selectable style list only.
- Introduces a second list, `OverlayStateStore.get_renderable_styles()`, as a superset of `get_available_styles_list()` that includes meta-styles. `/api/config/{id}` keeps returning the selectable list, so `mosaic` still never appears in the picker UI or as a `preferredStyle`.
- Switches `mosaic.html` to consume a server-rendered `AVAILABLE_STYLES` list instead of fetching `/api/config/{id}` — that endpoint is gated by `OVERLAY_SERVER_TOKEN` in this project and would otherwise 401 silently from the browser.
- Updates `CUSTOM_OVERLAY.md` with a "Style Preview Grid" subsection and notes the available-vs-renderable split in `DEVELOPER_GUIDE.md`.

## Test plan

- [x] `pytest` — all 389 tests pass (new regression test `test_mosaic_style_renders_but_is_not_selectable` included).
- [ ] Manual: open `/overlay/{id}?style=mosaic` on a running instance and confirm every overlay style renders cropped to its bounds.
- [ ] Manual with `OVERLAY_SERVER_TOKEN` set: confirm the mosaic page still builds its grid (no `/api/config` dependency).
- [ ] Manual: confirm the "Preferred Style" dropdown in the control UI does **not** list `mosaic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)