### PR TITLE
feat(api): phase-1 hardening — set_score validation, WS broadcast resilience, opt-in strict OID auth

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -23,6 +23,13 @@ The `check_oid_access` helper is a second-level check layered on top of
 `SCOREBOARD_USERS`) against the OID in the request and returns `403`
 when they differ.
 
+By default a user entry without a `control` field is allowed on every
+OID (backward-compatible "open inside authenticated" behavior). Setting
+the **opt-in** env var `STRICT_OID_ACCESS=true` flips that default so
+any authenticated user without an explicit `control` is denied
+(`403`). Use this on multi-tenant deployments where each user must be
+scoped to a specific OID.
+
 ## 2. Route inventory
 
 Legend: `Y` = authenticated when the corresponding env var is set;

--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -2,8 +2,20 @@ import logging
 from fastapi import Header, Query, HTTPException, Request
 from app.authentication import PasswordAuthenticator
 from app.api.session_manager import SessionManager, GameSession
+from app.env_vars_manager import EnvVarsManager
 
 logger = logging.getLogger(__name__)
+
+
+def _strict_oid_access_enabled() -> bool:
+    """Return True when ``STRICT_OID_ACCESS`` is set to a truthy value.
+
+    Opt-in hardening: when enabled, a user configured in ``SCOREBOARD_USERS``
+    without an explicit ``control`` field is denied access to every OID
+    rather than allowed everywhere. Default off for backward compatibility.
+    """
+    raw = EnvVarsManager.get_env_var('STRICT_OID_ACCESS', 'false')
+    return str(raw).strip().lower() in ('1', 'true', 't', 'yes', 'on')
 
 async def verify_api_key(authorization: str = Header(None)):
     """Validate the Bearer token when user authentication is enabled.
@@ -48,6 +60,12 @@ def check_oid_access(authorization: str, oid: str):
     if userconf:
         allowed_oid = userconf.get("control")
         if allowed_oid and allowed_oid != oid:
+            raise HTTPException(status_code=403, detail="Not authorized for this OID.")
+        if not allowed_oid and _strict_oid_access_enabled():
+            logger.warning(
+                "Strict OID access: user %s has no 'control' field; denying",
+                username,
+            )
             raise HTTPException(status_code=403, detail="Not authorized for this OID.")
 
 async def get_session(

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -138,6 +138,15 @@ class GameService:
 
     @staticmethod
     def set_score(session, team: int, set_number: int, value: int) -> ActionResponse:
+        if set_number > session.sets_limit:
+            return ActionResponse(
+                success=False,
+                state=GameService.get_state(session),
+                message=(
+                    f"set_number {set_number} exceeds sets_limit "
+                    f"{session.sets_limit}."
+                ),
+            )
         session.game_manager.set_game_value(team, value, set_number)
         set_won = session.game_manager.check_set_won(
             team, set_number,

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -138,13 +138,13 @@ class GameService:
 
     @staticmethod
     def set_score(session, team: int, set_number: int, value: int) -> ActionResponse:
-        if set_number > session.sets_limit:
+        if not (1 <= set_number <= session.sets_limit):
             return ActionResponse(
                 success=False,
                 state=GameService.get_state(session),
                 message=(
-                    f"set_number {set_number} exceeds sets_limit "
-                    f"{session.sets_limit}."
+                    f"set_number {set_number} is out of range "
+                    f"(1-{session.sets_limit})."
                 ),
             )
         session.game_manager.set_game_value(team, value, set_number)

--- a/app/api/ws_hub.py
+++ b/app/api/ws_hub.py
@@ -34,23 +34,43 @@ class WSHub:
                 del cls._connections[oid]
         logger.info("WS client disconnected for OID=%s", oid)
 
+    # Per-socket send timeout. A slow/hung client must not stall broadcasts
+    # to the rest of the subscribers (nor the main state-update path).
+    _BROADCAST_SEND_TIMEOUT = 2.0
+
     @classmethod
     async def broadcast(cls, oid: str, data: dict):
-        """Send a JSON message to every WebSocket client subscribed to *oid*."""
+        """Send a JSON message to every WebSocket client subscribed to *oid*.
+
+        Sends run concurrently with a per-socket timeout so a single stuck
+        client cannot delay updates to the rest or leak memory by keeping
+        a dead socket in the registry.
+        """
         conns = cls._connections.get(oid)
         if not conns:
             return
 
         message = json.dumps({"type": "state_update", "data": data})
-        stale = []
-        for ws in list(conns):
-            try:
-                await ws.send_text(message)
-            except Exception:
-                stale.append(ws)
+        targets = list(conns)
 
-        for ws in stale:
-            conns.discard(ws)
+        async def _send(ws):
+            try:
+                await asyncio.wait_for(
+                    ws.send_text(message),
+                    timeout=cls._BROADCAST_SEND_TIMEOUT,
+                )
+                return None
+            except Exception:
+                return ws
+
+        results = await asyncio.gather(
+            *(_send(ws) for ws in targets),
+            return_exceptions=False,
+        )
+
+        for ws in results:
+            if ws is not None:
+                conns.discard(ws)
         if not conns:
             cls._connections.pop(oid, None)
 

--- a/app/api/ws_hub.py
+++ b/app/api/ws_hub.py
@@ -71,7 +71,11 @@ class WSHub:
         for ws in results:
             if ws is not None:
                 conns.discard(ws)
-        if not conns:
+        # Only drop the OID entry if the registry still holds *our* set.
+        # A concurrent ``disconnect`` could have removed it and a concurrent
+        # ``connect`` could have installed a new set in the meantime; popping
+        # in that case would silently lose the new client.
+        if not conns and cls._connections.get(oid) is conns:
             cls._connections.pop(oid, None)
 
     @classmethod

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -129,8 +129,15 @@ class TestGameService:
         # Default mock_conf has sets_limit=5; 6 must be rejected.
         result = GameService.set_score(session, team=1, set_number=6, value=10)
         assert result.success is False
-        assert 'sets_limit' in (result.message or '')
+        assert 'out of range' in (result.message or '')
         # State must be unchanged.
+        assert result.state.team_1.scores['set_1'] == 0
+
+    def test_set_score_rejects_set_number_below_one(self, session):
+        # Sets use 1-based indexing; 0 and negative values are invalid.
+        result = GameService.set_score(session, team=1, set_number=0, value=10)
+        assert result.success is False
+        assert 'out of range' in (result.message or '')
         assert result.state.team_1.scores['set_1'] == 0
 
     def test_set_sets_value(self, session):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -125,6 +125,14 @@ class TestGameService:
         assert result.success is True
         assert result.state.team_1.scores['set_1'] == 10
 
+    def test_set_score_rejects_set_number_over_limit(self, session):
+        # Default mock_conf has sets_limit=5; 6 must be rejected.
+        result = GameService.set_score(session, team=1, set_number=6, value=10)
+        assert result.success is False
+        assert 'sets_limit' in (result.message or '')
+        # State must be unchanged.
+        assert result.state.team_1.scores['set_1'] == 0
+
     def test_set_sets_value(self, session):
         result = GameService.set_sets_value(session, team=1, value=2)
         assert result.success is True

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -183,6 +183,42 @@ class TestWSHubResilience:
         assert healthy in WSHub._connections.get("oid1", set())
         WSHub.clear()
 
+    def test_broadcast_preserves_reconnected_oid(self):
+        """If a new client installs a fresh set under the same OID while
+        broadcast was awaiting, the final cleanup must not pop that new set."""
+        import asyncio as _asyncio
+        from unittest.mock import AsyncMock
+
+        from app.api.ws_hub import WSHub
+
+        WSHub.clear()
+        old_ws = AsyncMock()
+        old_ws.send_text.side_effect = RuntimeError("peer gone")
+        old_set = {old_ws}
+        WSHub._connections["oid1"] = old_set
+
+        async def _run():
+            # Start broadcast; the failing send will empty ``old_set``.
+            task = _asyncio.create_task(
+                WSHub.broadcast("oid1", {"current_set": 1}),
+            )
+            # Simulate a concurrent disconnect+reconnect: the old set is
+            # replaced in the registry by a brand-new set with a new client.
+            await _asyncio.sleep(0)
+            new_ws = AsyncMock()
+            WSHub._connections["oid1"] = {new_ws}
+            await task
+            return new_ws
+
+        new_ws = _asyncio.run(_run())
+
+        # The newly-connected client must still be in the registry — the
+        # cleanup should only pop the OID if the same set instance is still
+        # there.
+        assert "oid1" in WSHub._connections
+        assert new_ws in WSHub._connections["oid1"]
+        WSHub.clear()
+
     def test_broadcast_times_out_slow_socket(self, monkeypatch):
         """A socket that never finishes send is dropped via the timeout."""
         import asyncio as _asyncio

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -161,3 +161,47 @@ class TestWSHubBroadcast:
                 msg = ws.receive_json()
                 assert msg["type"] == "state_update"
                 assert msg["data"]["team_1"]["scores"]["set_1"] == 1
+
+
+class TestWSHubResilience:
+    def test_broadcast_evicts_failing_socket(self):
+        """A send that raises is treated as stale and removed from the hub."""
+        import asyncio as _asyncio
+        from unittest.mock import AsyncMock
+
+        from app.api.ws_hub import WSHub
+
+        WSHub.clear()
+        healthy = AsyncMock()
+        broken = AsyncMock()
+        broken.send_text.side_effect = RuntimeError("peer gone")
+        WSHub._connections["oid1"] = {healthy, broken}
+
+        _asyncio.run(WSHub.broadcast("oid1", {"current_set": 1}))
+
+        assert broken not in WSHub._connections.get("oid1", set())
+        assert healthy in WSHub._connections.get("oid1", set())
+        WSHub.clear()
+
+    def test_broadcast_times_out_slow_socket(self, monkeypatch):
+        """A socket that never finishes send is dropped via the timeout."""
+        import asyncio as _asyncio
+        from unittest.mock import AsyncMock
+
+        from app.api.ws_hub import WSHub
+
+        # Shrink the timeout so the test is quick.
+        monkeypatch.setattr(WSHub, "_BROADCAST_SEND_TIMEOUT", 0.05)
+        WSHub.clear()
+
+        async def _never(_msg):
+            await _asyncio.sleep(1.0)
+
+        slow = AsyncMock()
+        slow.send_text.side_effect = _never
+        WSHub._connections["oid1"] = {slow}
+
+        _asyncio.run(WSHub.broadcast("oid1", {"current_set": 1}))
+
+        assert "oid1" not in WSHub._connections
+        WSHub.clear()

--- a/tests/test_auth_coverage.py
+++ b/tests/test_auth_coverage.py
@@ -152,6 +152,43 @@ def test_scoreboard_api_rejects_invalid_token(api_client_with_users, method, pat
     )
 
 
+def test_strict_oid_access_denies_user_without_control(monkeypatch):
+    """With STRICT_OID_ACCESS=true, users lacking 'control' are rejected."""
+    users = json.dumps({"alice": {"password": API_USER_PASSWORD}})
+    monkeypatch.setenv("SCOREBOARD_USERS", users)
+    monkeypatch.setenv("STRICT_OID_ACCESS", "true")
+
+    app = FastAPI()
+    app.include_router(api_router)
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/v1/session/init",
+        json={"oid": "anything"},
+        headers={"Authorization": f"Bearer {API_USER_PASSWORD}"},
+    )
+    assert response.status_code == 403
+
+
+def test_strict_oid_access_off_preserves_open_default(monkeypatch):
+    """Without STRICT_OID_ACCESS, users lacking 'control' still pass auth
+    (they may still fail downstream for other reasons)."""
+    users = json.dumps({"alice": {"password": API_USER_PASSWORD}})
+    monkeypatch.setenv("SCOREBOARD_USERS", users)
+    monkeypatch.delenv("STRICT_OID_ACCESS", raising=False)
+
+    app = FastAPI()
+    app.include_router(api_router)
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/v1/state?oid=anything",
+        headers={"Authorization": f"Bearer {API_USER_PASSWORD}"},
+    )
+    # Auth must not be the reason for rejection; 404 (no session) is expected.
+    assert response.status_code != 403
+
+
 # ---------------------------------------------------------------------------
 # Admin API (/api/v1/admin/*) — require_admin
 # ---------------------------------------------------------------------------

--- a/tests/test_auth_coverage.py
+++ b/tests/test_auth_coverage.py
@@ -189,6 +189,26 @@ def test_strict_oid_access_off_preserves_open_default(monkeypatch):
     assert response.status_code != 403
 
 
+def test_strict_oid_access_allows_user_with_matching_control(monkeypatch):
+    """Strict mode must still let a properly-scoped user through."""
+    users = json.dumps({
+        "alice": {"password": API_USER_PASSWORD, "control": "alice-oid"},
+    })
+    monkeypatch.setenv("SCOREBOARD_USERS", users)
+    monkeypatch.setenv("STRICT_OID_ACCESS", "true")
+
+    app = FastAPI()
+    app.include_router(api_router)
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/v1/state?oid=alice-oid",
+        headers={"Authorization": f"Bearer {API_USER_PASSWORD}"},
+    )
+    # Auth must pass; 404 (no session yet) is the expected downstream result.
+    assert response.status_code != 403
+
+
 # ---------------------------------------------------------------------------
 # Admin API (/api/v1/admin/*) — require_admin
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

First slice of a multi-phase project audit (see `/root/.claude/plans/analiza-el-proyecto-y-curried-lamport.md`). This PR delivers **Phase 1 — correctness & security**, branched from `origin/dev`. Three targeted, backward-compatible fixes the dev-branch exploration flagged as the highest-impact gaps.

- **`GameService.set_score` validates `set_number` against `sets_limit`** (`app/api/game_service.py:140`). Before: `POST /game/set-score` with `set_number=10` on a best-of-5 match silently wrote past the configured match length. Now: returns `ActionResponse(success=False)` with an explanatory message, matching the existing "match finished" error style.
- **`WSHub.broadcast` is resilient to slow/hung clients** (`app/api/ws_hub.py:38`). Sends now run concurrently via `asyncio.gather` with a per-socket `asyncio.wait_for` (2 s). A stuck OBS browser source can no longer stall state updates to the rest of the subscribers, and timed-out sockets are evicted from the registry.
- **Opt-in `STRICT_OID_ACCESS` deny-by-default auth** (`app/api/dependencies.py:44`). When the env var is truthy, an authenticated user whose `SCOREBOARD_USERS` entry lacks a `control` field is denied (`403`) instead of silently allowed everywhere. Default off → fully backward compatible. Documented in `AUTHENTICATION.md` §1.

## Notes for the reviewer

- `set_score` returns `ActionResponse(success=False)` rather than `HTTPException(422)` to stay consistent with the in-band error style used for `add_point` / `add_set` when the match is over. Happy to switch if preferred.
- `_BROADCAST_SEND_TIMEOUT = 2.0` is a class attribute so tests can shrink it.
- `_strict_oid_access_enabled()` reads the env var each call; `EnvVarsManager` caches remote config, and auth is not on the hot path, so no measurable overhead.
- During exploration I confirmed `app/api/routes/lifespan.py` already uses a `WeakValueDictionary` for `_init_locks`, so the "init-lock leak" concern from the audit was already resolved — no change needed there.

## Test plan

- [x] `python -m pytest -q` — 395 passed locally
- [x] New tests: `test_set_score_rejects_set_number_over_limit`, `TestWSHubResilience::test_broadcast_evicts_failing_socket` + `::test_broadcast_times_out_slow_socket`, `test_strict_oid_access_{denies_user_without_control,off_preserves_open_default,allows_user_with_matching_control}`
- [ ] CI green on this PR
- [ ] Manual smoke: two OBS tabs on same OID, kill one abruptly → remaining tab keeps receiving state updates within the 2 s timeout window

## Follow-ups (separate PRs)

Phases 2–4 from the plan — observability (`/readyz`, `/metrics`, security workflow, hardened Dockerfile), perf (httpx async backend, lazy-loaded config sections, PWA caching), and DX (mypy/ruff scope expansion, ErrorBoundary, CI matrix, CHANGELOG). Sequenced to avoid conflicts on `app/api/routes/*` and `pyproject.toml`.

https://claude.ai/code/session_01KwEn6jQdqrHoZRVLFszZKm