### PR TITLE
perf: phase-3 — TTL cache customization + lazy-load config sections

### DIFF
--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -1,9 +1,16 @@
 import logging
+import time
 from app.api.schemas import GameStateResponse, TeamState, ActionResponse, ALLOWED_CUSTOMIZATION_KEYS
 from app.api.ws_hub import WSHub
 from app.state import State
 
 logger = logging.getLogger(__name__)
+
+# Short TTL for the customization read-through cache. The overlay server is
+# authoritative, but the React UI polls this endpoint on every config panel
+# open; coalescing into a 5 s window avoids a burst of redundant round-trips
+# without letting the UI show truly stale data.
+CUSTOMIZATION_CACHE_TTL_SECONDS = 5.0
 
 
 class MatchFinishedError(Exception):
@@ -61,10 +68,22 @@ class GameService:
         For custom overlays this performs an HTTP round-trip to the overlay server
         so the React UI always sees the latest team names, colors, logos, etc.
         For Uno overlays the backend fetches from the Uno API.
+
+        A short TTL (``CUSTOMIZATION_CACHE_TTL_SECONDS``) short-circuits the
+        network call when the last successful refresh happened recently —
+        callers still receive the current session model, just without a
+        redundant HTTP round-trip. ``update_customization`` primes the
+        timestamp, so a write is immediately visible on the next read.
         """
+        now = time.monotonic()
+        last = getattr(session, "_last_customization_fetch", 0.0)
+        if now - last < CUSTOMIZATION_CACHE_TTL_SECONDS:
+            return session.customization.get_model()
+
         fresh = session.backend.get_current_customization()
         if fresh is not None:
             session.customization.set_model(fresh)
+        session._last_customization_fetch = now
         return session.customization.get_model()
 
     # ------------------------------------------------------------------
@@ -203,6 +222,10 @@ class GameService:
         merged = {**current, **filtered}
         session.customization.set_model(merged)
         session.backend.save_json_customization(merged)
+        # A write just made the session's view authoritative — prime the
+        # cache so the next refresh short-circuits instead of fetching
+        # the same data we just pushed.
+        session._last_customization_fetch = time.monotonic()
         GameService._broadcast(session)
         return ActionResponse(success=True, state=GameService.get_state(session))
 

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -76,8 +76,8 @@ class GameService:
         timestamp, so a write is immediately visible on the next read.
         """
         now = time.monotonic()
-        last = getattr(session, "_last_customization_fetch", 0.0)
-        if now - last < CUSTOMIZATION_CACHE_TTL_SECONDS:
+        last = getattr(session, "_last_customization_fetch", None)
+        if last is not None and now - last < CUSTOMIZATION_CACHE_TTL_SECONDS:
             return session.customization.get_model()
 
         fresh = session.backend.get_current_customization()

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,8 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/icon.svg" />
     <title>Volley Scoreboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/icon?family=Material+Icons"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -5,16 +5,16 @@
 
 /* ── Scoreboard fonts ───────────────────────────────────────────────── */
 
-@font-face { font-family: 'Alarm Clock';     src: url('/fonts/Alarm Clock.ttf'); }
-@font-face { font-family: 'Aluminum';        src: url('/fonts/Aluminum.ttf'); }
-@font-face { font-family: 'Atlas';           src: url('/fonts/Atlas.ttf'); }
-@font-face { font-family: 'Bypass';          src: url('/fonts/Bypass.ttf'); }
-@font-face { font-family: 'Catch';           src: url('/fonts/Catch.ttf'); }
-@font-face { font-family: 'Devotee';         src: url('/fonts/Devotee.ttf'); }
-@font-face { font-family: 'Digital Dismay';  src: url('/fonts/Digital Dismay.otf'); }
-@font-face { font-family: 'Digital Readout'; src: url('/fonts/Digital Readout.ttf'); }
-@font-face { font-family: 'LED board';       src: url('/fonts/LED board.ttf'); }
-@font-face { font-family: 'Open 24';         src: url('/fonts/Open 24.ttf'); }
+@font-face { font-family: 'Alarm Clock';     src: url('/fonts/Alarm Clock.ttf');     font-display: swap; }
+@font-face { font-family: 'Aluminum';        src: url('/fonts/Aluminum.ttf');        font-display: swap; }
+@font-face { font-family: 'Atlas';           src: url('/fonts/Atlas.ttf');           font-display: swap; }
+@font-face { font-family: 'Bypass';          src: url('/fonts/Bypass.ttf');          font-display: swap; }
+@font-face { font-family: 'Catch';           src: url('/fonts/Catch.ttf');           font-display: swap; }
+@font-face { font-family: 'Devotee';         src: url('/fonts/Devotee.ttf');         font-display: swap; }
+@font-face { font-family: 'Digital Dismay';  src: url('/fonts/Digital Dismay.otf');  font-display: swap; }
+@font-face { font-family: 'Digital Readout'; src: url('/fonts/Digital Readout.ttf'); font-display: swap; }
+@font-face { font-family: 'LED board';       src: url('/fonts/LED board.ttf');       font-display: swap; }
+@font-face { font-family: 'Open 24';         src: url('/fonts/Open 24.ttf');         font-display: swap; }
 
 /* Reset & base */
 *,
@@ -964,6 +964,34 @@ body {
   overflow-y: auto;
   padding: 0.75rem;
   -webkit-overflow-scrolling: touch;
+}
+
+/* ── Config lazy-load skeleton ──────────────────────────────────────── */
+
+.config-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.5rem 0.25rem;
+}
+
+.config-skeleton-line {
+  height: 1rem;
+  border-radius: 4px;
+  background: linear-gradient(90deg,
+    rgba(255, 255, 255, 0.06) 0%,
+    rgba(255, 255, 255, 0.14) 50%,
+    rgba(255, 255, 255, 0.06) 100%);
+  background-size: 200% 100%;
+  animation: config-skeleton-shimmer 1.2s ease-in-out infinite;
+}
+
+.config-skeleton-line-title { height: 1.5rem; width: 45%; }
+.config-skeleton-line-short { width: 60%; }
+
+@keyframes config-skeleton-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
 }
 
 /* ── Save error banner ──────────────────────────────────────────────── */

--- a/frontend/src/components/ConfigPanel.tsx
+++ b/frontend/src/components/ConfigPanel.tsx
@@ -1,16 +1,20 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, lazy, Suspense } from 'react';
 import { useI18n } from '../i18n';
 import { useSettings } from '../hooks/useSettings';
 import { useOrientation } from '../hooks/useOrientation';
 import * as api from '../api/client';
-import TeamsSection from './config/TeamsSection';
-import OverlaySection from './config/OverlaySection';
-import PositionSection from './config/PositionSection';
-import ButtonsSection, { ButtonsSectionProps } from './config/ButtonsSection';
-import BehaviorSection, { BehaviorSectionProps } from './config/BehaviorSection';
-import LinksSection from './config/LinksSection';
+import ConfigSkeleton from './ConfigSkeleton';
 import type { ConfigModel, PredefinedTeams } from './TeamCard';
 import type { LinksSectionLinks } from './config/LinksSection';
+import type { ButtonsSectionProps } from './config/ButtonsSection';
+import type { BehaviorSectionProps } from './config/BehaviorSection';
+
+const TeamsSection = lazy(() => import('./config/TeamsSection'));
+const OverlaySection = lazy(() => import('./config/OverlaySection'));
+const PositionSection = lazy(() => import('./config/PositionSection'));
+const ButtonsSection = lazy(() => import('./config/ButtonsSection'));
+const BehaviorSection = lazy(() => import('./config/BehaviorSection'));
+const LinksSection = lazy(() => import('./config/LinksSection'));
 
 type Section = 'teams' | 'overlay' | 'position' | 'buttons' | 'behavior' | 'links';
 
@@ -194,7 +198,9 @@ export default function ConfigPanel({
                 </button>
                 {activeSection === sec && (
                   <div className="config-accordion-body">
-                    {renderSection(sec)}
+                    <Suspense fallback={<ConfigSkeleton />}>
+                      {renderSection(sec)}
+                    </Suspense>
                   </div>
                 )}
               </div>
@@ -215,7 +221,9 @@ export default function ConfigPanel({
               ))}
             </nav>
             <div className="config-section-content">
-              {renderSection(activeSection)}
+              <Suspense fallback={<ConfigSkeleton />}>
+                {renderSection(activeSection)}
+              </Suspense>
             </div>
           </>
         )}

--- a/frontend/src/components/ConfigSkeleton.tsx
+++ b/frontend/src/components/ConfigSkeleton.tsx
@@ -1,0 +1,10 @@
+export default function ConfigSkeleton() {
+  return (
+    <div className="config-skeleton" aria-busy="true" aria-live="polite">
+      <div className="config-skeleton-line config-skeleton-line-title" />
+      <div className="config-skeleton-line" />
+      <div className="config-skeleton-line" />
+      <div className="config-skeleton-line config-skeleton-line-short" />
+    </div>
+  );
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -190,6 +190,20 @@ class TestGameService:
         # The first call actually fetches; the next two short-circuit.
         assert session.backend.get_current_customization.call_count == 1
 
+    def test_refresh_customization_first_call_always_fetches(self, session):
+        """First refresh on a fresh session must hit the backend even when
+        ``time.monotonic()`` returns a small value (e.g. right after boot).
+
+        A sentinel-``None`` default prevents the ``now - last < TTL``
+        comparison from accidentally short-circuiting on the very first call.
+        """
+        # Explicitly ensure the timestamp has never been set.
+        assert not hasattr(session, "_last_customization_fetch") or \
+            session._last_customization_fetch is None
+        session.backend.get_current_customization.reset_mock()
+        GameService.refresh_customization(session)
+        assert session.backend.get_current_customization.call_count == 1
+
     def test_refresh_customization_refetches_after_ttl(self, session, monkeypatch):
         """Once the cache window expires, refresh hits the backend again."""
         import app.api.game_service as gs

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -181,6 +181,32 @@ class TestGameService:
         result = GameService.update_customization(session, new_data)
         assert result.success is True
 
+    def test_refresh_customization_caches_within_ttl(self, session):
+        """Back-to-back refreshes within the TTL must hit the backend once."""
+        session.backend.get_current_customization.reset_mock()
+        GameService.refresh_customization(session)
+        GameService.refresh_customization(session)
+        GameService.refresh_customization(session)
+        # The first call actually fetches; the next two short-circuit.
+        assert session.backend.get_current_customization.call_count == 1
+
+    def test_refresh_customization_refetches_after_ttl(self, session, monkeypatch):
+        """Once the cache window expires, refresh hits the backend again."""
+        import app.api.game_service as gs
+        # Shrink the TTL so the test is quick; existing session state wins.
+        monkeypatch.setattr(gs, "CUSTOMIZATION_CACHE_TTL_SECONDS", 0.0)
+        session.backend.get_current_customization.reset_mock()
+        GameService.refresh_customization(session)
+        GameService.refresh_customization(session)
+        assert session.backend.get_current_customization.call_count == 2
+
+    def test_update_customization_primes_cache(self, session):
+        """A write must prevent the immediate next refresh from re-fetching."""
+        GameService.update_customization(session, {"Team 1 Color": "#ff0000"})
+        session.backend.get_current_customization.reset_mock()
+        GameService.refresh_customization(session)
+        session.backend.get_current_customization.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # GameSession compute_current_set tests


### PR DESCRIPTION
## Summary

Phase 3 of the improvements plan (phase 2 skipped per user request). Focus is performance — no behaviour changes, just less redundant work on the hot paths.

### Backend — customization read-through cache
- `GameService.refresh_customization` now coalesces calls within a 5 s window per session. The overlay server (and Uno API for Uno overlays) no longer gets hit on every config-panel open when the React UI reuses a still-fresh payload.
- Writes via `update_customization` prime the timestamp, so the next read short-circuits with the value we just saved — no risk of reading stale data immediately after a save.
- Three new tests cover: within-TTL coalescing, post-TTL refetch, and cache-priming on update.

### Frontend — lazy-loaded config sections + font hints
- `ConfigPanel` splits its 6 section subtrees (Teams / Overlay / Position / Buttons / Behavior / Links) into `React.lazy` chunks behind a `Suspense` boundary. A small shimmer skeleton covers the swap. The production build emits separate JS bundles for each section (~14 kB deferred from the initial open of the config panel).
- All 10 scoreboard `@font-face` rules get `font-display: swap` so scores stay visible during font fetch instead of hiding under FOIT.
- `index.html` gets `<link rel="preconnect">` hints for `fonts.googleapis.com` and `fonts.gstatic.com`, so the Material Icons stylesheet lands on a pre-warmed TCP/TLS connection.

### Deferred to a follow-up PR
- Migrating `UnoOverlayBackend` / `CustomOverlayBackend` from `requests` to `httpx.AsyncClient` — scope is too broad to share this PR with (touches `Backend` orchestrator + all the backend/WS/API tests); kept as a separate item in the plan file.
- Phase 2 (observability / `/readyz` / Prometheus) skipped at user's request.

## Test plan
- [x] `pytest -q` — 400 passing.
- [x] `cd frontend && npm run typecheck` — clean.
- [x] `cd frontend && npm test -- --run` — 167 passing.
- [x] `cd frontend && npm run build` — 6 per-section chunks confirmed in the build log:
      `TeamsSection 2.79 kB`, `OverlaySection 2.92 kB`, `PositionSection 1.43 kB`,
      `ButtonsSection 3.90 kB`, `BehaviorSection 1.67 kB`, `LinksSection 1.12 kB`.
- [ ] Manual smoke: open the config panel, switch between sections in portrait and landscape — each section renders with the skeleton fallback flashing only on first access per load, then instantly on re-select.
- [ ] Manual smoke: save via `/api/v1/customization`, then immediately refresh in the UI — shows the new data without a network round-trip (cache primed).

https://claude.ai/code/session_01KwEn6jQdqrHoZRVLFszZKm