### PR TITLE
chore: phase-4 — ruff B/I + mypy expansion, ErrorBoundary + a11y, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+once a first tagged release ships.
+
+## [Unreleased]
+
+### Added
+
+- **DX**: `ruff` lint set expanded to include `I` (isort) and `B` (flake8-bugbear);
+  `mypy` checks now cover `app/api/routes` and `app/api/middleware` in addition to
+  the original `app/api` service layer (`pyproject.toml`).
+- **Frontend a11y**: top-level `ErrorBoundary` wraps `ScoreboardView` and
+  `ConfigPanel`, forwarding React-caught errors through the existing
+  `errorReporter` so they land in the same backend log stream as
+  `window.onerror`. Score buttons gained `aria-label` / `aria-live="polite"`
+  so assistive tech announces score changes.
+- **Docs**: this `CHANGELOG.md`.
+
+### Changed
+
+- **Frontend `ConfigPanel`**: the six config sections (Teams / Overlay /
+  Position / Buttons / Behavior / Links) are now `React.lazy` chunks behind
+  a `Suspense` boundary with a shimmer skeleton fallback. Production build
+  emits a separate JS bundle per section (~14 kB deferred from initial open).
+- **Fonts**: all 10 scoreboard `@font-face` rules use `font-display: swap` so
+  scores stay visible during font fetch instead of hiding under FOIT.
+  `index.html` gets `<link rel="preconnect">` hints for the Google Fonts
+  origins the Material Icons stylesheet uses.
+- **Backend customization cache**: `GameService.refresh_customization` now
+  has a 5 s TTL read-through cache per session, coalescing bursts of
+  identical fetches when the React UI reopens the config panel. Writes
+  prime the timestamp so the next read is immediately consistent.
+
+### Fixed
+
+- **Backend**: `GameService.set_score` rejects `set_number` values below 1 or
+  above `sets_limit` (was upper-bound-only before).
+- **Backend WSHub**: concurrent broadcast with per-socket timeout
+  (`_BROADCAST_SEND_TIMEOUT`) so a stuck subscriber can't stall updates to
+  the rest; the cleanup pass no longer pops an OID whose set was replaced
+  by a concurrent reconnect.
+- **Backend customization cache**: initial call always hits the backend even
+  on systems where `time.monotonic()` starts close to zero (sentinel-`None`
+  default instead of `0.0`).
+
+### Security
+
+- **Auth**: new `STRICT_OID_ACCESS=true` env var flips the default so any
+  authenticated user without an explicit `control` field is denied (`403`).
+  Off by default to preserve single-tenant setups; see
+  [AUTHENTICATION.md](AUTHENTICATION.md) for details.

--- a/app/admin/__init__.py
+++ b/app/admin/__init__.py
@@ -10,7 +10,7 @@ unset or empty, the admin routes return HTTP 503 and the page shows a
 helpful error message.
 """
 
-from app.admin.routes import admin_router, admin_page_router
+from app.admin.routes import admin_page_router, admin_router
 
 __all__ = [
     "admin_router",

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -17,9 +17,9 @@ variable to be set and the request to include a matching
 ``Authorization: Bearer <password>`` header.
 """
 
+import logging
 import os
 import re
-import logging
 import secrets
 from typing import Optional
 

--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -1,7 +1,9 @@
 import logging
-from fastapi import Header, Query, HTTPException, Request
+
+from fastapi import Header, HTTPException, Query, Request
+
+from app.api.session_manager import GameSession, SessionManager
 from app.authentication import PasswordAuthenticator
-from app.api.session_manager import SessionManager, GameSession
 from app.env_vars_manager import EnvVarsManager
 
 logger = logging.getLogger(__name__)

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -1,6 +1,7 @@
 import logging
 import time
-from app.api.schemas import GameStateResponse, TeamState, ActionResponse, ALLOWED_CUSTOMIZATION_KEYS
+
+from app.api.schemas import ALLOWED_CUSTOMIZATION_KEYS, ActionResponse, GameStateResponse, TeamState
 from app.api.ws_hub import WSHub
 from app.state import State
 

--- a/app/api/middleware/errors.py
+++ b/app/api/middleware/errors.py
@@ -14,7 +14,6 @@ import logging
 
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/app/api/routes/app_config.py
+++ b/app/api/routes/app_config.py
@@ -2,8 +2,8 @@
 
 from fastapi import APIRouter
 
-from app.app_config import get_app_title
 from app.api.schemas import AppConfigResponse
+from app.app_config import get_app_title
 
 router = APIRouter()
 

--- a/app/api/routes/overlays.py
+++ b/app/api/routes/overlays.py
@@ -63,7 +63,7 @@ async def get_overlays(authorization: str = Header(None)):
         for name, config in env_overlays.items()
         if isinstance(config, dict)
         and (config.get('allowed_users') is None
-             or (current_user and current_user in config.get('allowed_users')))
+             or (current_user and current_user in (config.get('allowed_users') or [])))
     ]
 
 

--- a/app/api/routes/session.py
+++ b/app/api/routes/session.py
@@ -7,9 +7,9 @@ from starlette.concurrency import run_in_threadpool
 
 from app.api.dependencies import check_oid_access, verify_api_key
 from app.api.game_service import GameService
+from app.api.routes.lifespan import get_init_lock
 from app.api.schemas import ActionResponse, InitRequest
 from app.api.session_manager import SessionManager
-from app.api.routes.lifespan import get_init_lock
 from app.backend import Backend
 from app.conf import Conf
 from app.logging_utils import redact_oid

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1,7 +1,7 @@
-from pydantic import BaseModel, Field, field_validator
-from typing import Literal, Optional
 import re
+from typing import Literal, Optional
 
+from pydantic import BaseModel, Field, field_validator
 
 # ---------------------------------------------------------------------------
 # Request models

--- a/app/api/session_manager.py
+++ b/app/api/session_manager.py
@@ -2,10 +2,11 @@ import asyncio
 import logging
 import threading
 import time
-from app.conf import Conf
+
 from app.backend import Backend
-from app.game_manager import GameManager
+from app.conf import Conf
 from app.customization import Customization
+from app.game_manager import GameManager
 
 logger = logging.getLogger(__name__)
 

--- a/app/api/ws_hub.py
+++ b/app/api/ws_hub.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+
 from fastapi import WebSocket
 
 logger = logging.getLogger(__name__)

--- a/app/authentication.py
+++ b/app/authentication.py
@@ -1,6 +1,7 @@
-import logging
 import json
+import logging
 import secrets
+
 from app.env_vars_manager import EnvVarsManager
 from app.oid_utils import UNO_OUTPUT_BASE_URL
 

--- a/app/backend.py
+++ b/app/backend.py
@@ -3,17 +3,17 @@ import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-from app.state import State
+import requests
+
+from app.env_vars_manager import EnvVarsManager
 from app.overlay_backends import (
-    UnoOverlayBackend,
     CustomOverlayBackend,
     LocalOverlayBackend,
     OverlayKind,
+    UnoOverlayBackend,
     resolve_overlay_kind,
 )
-from app.env_vars_manager import EnvVarsManager
-
-import requests
+from app.state import State
 
 # TTL for the in-memory customization cache. Overlay customization (team names,
 # colors, geometry) rarely changes during a match, but if an operator edits it

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -16,8 +16,8 @@ from functools import lru_cache
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.admin import admin_page_router, admin_router
@@ -135,6 +135,7 @@ def _register_overlay_routes(application: FastAPI) -> None:
         return
 
     from fastapi.templating import Jinja2Templates
+
     from app.overlay import obs_broadcast_hub, overlay_state_store
     from app.overlay.routes import create_overlay_router
 

--- a/app/config_validator.py
+++ b/app/config_validator.py
@@ -1,6 +1,6 @@
-import os
 import json
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 

--- a/app/customization.py
+++ b/app/customization.py
@@ -1,7 +1,8 @@
-from app.messages import Messages
 import json
 import logging
+
 from app.env_vars_manager import EnvVarsManager
+from app.messages import Messages
 
 logger = logging.getLogger(__name__)
 

--- a/app/env_vars_manager.py
+++ b/app/env_vars_manager.py
@@ -1,8 +1,9 @@
-import os
-import requests
 import json
-import time
 import logging
+import os
+import time
+
+import requests
 
 from app.logging_utils import redact_url
 

--- a/app/game_manager.py
+++ b/app/game_manager.py
@@ -1,7 +1,8 @@
 import logging
-from app.state import State
+
 from app.backend import Backend
 from app.conf import Conf
+from app.state import State
 
 logger = logging.getLogger(__name__)
 

--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -18,7 +18,6 @@ import logging
 import logging.config
 import re
 
-
 _ANSI_COLORS = {
     "DEBUG": "\033[39m",
     "INFO": "\033[1;33m",

--- a/app/logging_context.py
+++ b/app/logging_context.py
@@ -12,7 +12,6 @@ import uuid
 
 from app.logging_utils import redact_oid
 
-
 request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
     "request_id", default="-",
 )

--- a/app/overlay/__init__.py
+++ b/app/overlay/__init__.py
@@ -9,8 +9,8 @@ and the LocalOverlayBackend.
 
 import os
 
-from app.overlay.state_store import OverlayStateStore
 from app.overlay.broadcast import ObsBroadcastHub
+from app.overlay.state_store import OverlayStateStore
 
 _base_dir = os.path.dirname(os.path.abspath(__file__))
 _data_dir = os.path.join(_base_dir, "..", "..", "data")

--- a/app/overlay_backends/__init__.py
+++ b/app/overlay_backends/__init__.py
@@ -12,25 +12,24 @@ The public symbols below are re-exported so existing imports such as
 split into submodules.
 """
 
+# Re-exported so ``@patch('app.overlay_backends.AppStorage.<method>')`` keeps
+# working in existing tests — patching a class attribute resolves the class
+# via this namespace.
+from app.app_storage import AppStorage  # noqa: F401  (re-export)
 from app.overlay_backends.base import OverlayBackend
-from app.overlay_backends.uno import UnoOverlayBackend
 from app.overlay_backends.custom import CustomOverlayBackend
 from app.overlay_backends.local import LocalOverlayBackend
+from app.overlay_backends.uno import UnoOverlayBackend
 from app.overlay_backends.utils import (
-    _mock_response,
-    OverlayKind,
     UNO_OID_LENGTH,
+    OverlayKind,
+    _mock_response,
     is_custom_overlay,
     matches_uno_format,
     resolve_overlay_kind,
     split_custom_oid,
     strip_legacy_prefix,
 )
-
-# Re-exported so ``@patch('app.overlay_backends.AppStorage.<method>')`` keeps
-# working in existing tests — patching a class attribute resolves the class
-# via this namespace.
-from app.app_storage import AppStorage  # noqa: F401  (re-export)
 
 __all__ = [
     "OverlayBackend",

--- a/app/overlay_backends/custom.py
+++ b/app/overlay_backends/custom.py
@@ -8,10 +8,9 @@ import requests
 import requests.exceptions
 
 from app.env_vars_manager import EnvVarsManager
-from app.state import State
-
 from app.overlay_backends.base import OverlayBackend
 from app.overlay_backends.utils import split_custom_oid
+from app.state import State
 
 logger = logging.getLogger(__name__)
 

--- a/app/overlay_backends/local.py
+++ b/app/overlay_backends/local.py
@@ -4,10 +4,9 @@ import copy
 import logging
 
 from app.env_vars_manager import EnvVarsManager
-from app.state import State
-
 from app.overlay_backends.base import OverlayBackend
 from app.overlay_backends.utils import split_custom_oid
+from app.state import State
 
 logger = logging.getLogger(__name__)
 

--- a/app/overlay_backends/uno.py
+++ b/app/overlay_backends/uno.py
@@ -7,10 +7,9 @@ import requests
 import requests.exceptions
 
 from app.app_storage import AppStorage
-from app.state import State
-
 from app.overlay_backends.base import OverlayBackend
 from app.overlay_backends.utils import _mock_response
+from app.state import State
 
 logger = logging.getLogger(__name__)
 

--- a/app/ws_client.py
+++ b/app/ws_client.py
@@ -8,7 +8,7 @@ import json
 import logging
 import threading
 import time
-from typing import Optional, Callable
+from typing import Callable, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -994,6 +994,38 @@ body {
   100% { background-position: -200% 0; }
 }
 
+/* ── Error boundary fallback ────────────────────────────────────────── */
+
+.error-boundary {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  text-align: center;
+  color: var(--text-primary, #eee);
+}
+
+.error-boundary h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.error-boundary p {
+  margin: 0;
+  max-width: 40ch;
+  opacity: 0.85;
+}
+
+.error-boundary button {
+  padding: 0.5rem 1.25rem;
+  border-radius: 6px;
+  border: 1px solid currentColor;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
 /* ── Save error banner ──────────────────────────────────────────────── */
 
 .config-save-error {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -994,6 +994,20 @@ body {
   100% { background-position: -200% 0; }
 }
 
+/* ── Screen-reader-only utility ─────────────────────────────────────── */
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* ── Error boundary fallback ────────────────────────────────────────── */
 
 .error-boundary {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import InitScreen from './components/InitScreen';
 import ScoreboardView from './components/ScoreboardView';
 import ConfigPanel from './components/ConfigPanel';
 import SetValueDialog from './components/SetValueDialog';
+import ErrorBoundary from './components/ErrorBoundary';
 import type { GameState } from './api/client';
 import type { ConfigModel } from './components/TeamCard';
 import type { ScoreButtonFontStyle } from './components/ScoreButton';
@@ -321,6 +322,7 @@ export default function App() {
   return (
     <div className="app-container">
       {activeTab === 'scoreboard' && (
+        <ErrorBoundary>
         <ScoreboardView
           state={state}
           customization={customization}
@@ -361,19 +363,22 @@ export default function App() {
           onTogglePreview={handleTogglePreview}
           onOpenConfig={() => setActiveTab('config')}
         />
+        </ErrorBoundary>
       )}
 
       {activeTab === 'config' && (
-        <ConfigPanel
-          oid={oid}
-          customization={customization}
-          actions={actions}
-          onBack={() => setActiveTab('scoreboard')}
-          onReset={handleReset}
-          onLogout={handleLogout}
-          onCustomizationSaved={refreshCustomization}
-          onCustomizationRefreshed={setCustomization}
-        />
+        <ErrorBoundary>
+          <ConfigPanel
+            oid={oid}
+            customization={customization}
+            actions={actions}
+            onBack={() => setActiveTab('scoreboard')}
+            onReset={handleReset}
+            onLogout={handleLogout}
+            onCustomizationSaved={refreshCustomization}
+            onCustomizationRefreshed={setCustomization}
+          />
+        </ErrorBoundary>
       )}
 
       <SetValueDialog

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import { Component, ReactNode, ErrorInfo } from 'react';
+import { reportClientError } from '../utils/errorReporter';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  message: string;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, message: '' };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, message: error.message || 'Unexpected error' };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Surface React-caught errors through the same channel as window.onerror.
+    reportClientError({
+      level: 'error',
+      message: error.message || 'React error boundary',
+      stack: `${error.stack ?? ''}\n${info.componentStack ?? ''}`.trim(),
+    });
+  }
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+    if (this.props.fallback) return this.props.fallback;
+    return (
+      <div className="error-boundary" role="alert" aria-live="assertive">
+        <h2>Something went wrong</h2>
+        <p>{this.state.message}</p>
+        <button type="button" onClick={this.handleReload}>
+          Reload
+        </button>
+      </div>
+    );
+  }
+}

--- a/frontend/src/components/ScoreButton.tsx
+++ b/frontend/src/components/ScoreButton.tsx
@@ -25,6 +25,7 @@ export interface ScoreButtonProps {
   className?: string;
   style?: CSSProperties;
   'aria-label'?: string;
+  'aria-describedby'?: string;
   'data-testid'?: string;
 }
 
@@ -51,6 +52,7 @@ function ScoreButton({
   className = '',
   style = {},
   'aria-label': ariaLabel,
+  'aria-describedby': ariaDescribedBy,
   'data-testid': testId,
 }: ScoreButtonProps) {
   const pressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -172,6 +174,7 @@ function ScoreButton({
       onTouchCancel={cancelPress}
       aria-label={ariaLabel}
       aria-live={ariaLabel ? 'polite' : undefined}
+      aria-describedby={ariaDescribedBy}
       data-testid={testId}
     >
       {text}

--- a/frontend/src/components/ScoreButton.tsx
+++ b/frontend/src/components/ScoreButton.tsx
@@ -24,6 +24,7 @@ export interface ScoreButtonProps {
   onLongPress?: () => void;
   className?: string;
   style?: CSSProperties;
+  'aria-label'?: string;
   'data-testid'?: string;
 }
 
@@ -49,6 +50,7 @@ function ScoreButton({
   onLongPress,
   className = '',
   style = {},
+  'aria-label': ariaLabel,
   'data-testid': testId,
 }: ScoreButtonProps) {
   const pressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -168,6 +170,8 @@ function ScoreButton({
       onTouchEnd={endPress}
       onTouchMove={cancelPress}
       onTouchCancel={cancelPress}
+      aria-label={ariaLabel}
+      aria-live={ariaLabel ? 'polite' : undefined}
       data-testid={testId}
     >
       {text}

--- a/frontend/src/components/TeamPanel.tsx
+++ b/frontend/src/components/TeamPanel.tsx
@@ -142,6 +142,7 @@ export default function TeamPanel({
           onClick={handleAddPoint}
           onDoubleTap={handleDoubleTap}
           onLongPress={handleLongPress}
+          aria-label={`Team ${teamId === 1 ? 'A' : 'B'} score ${score}. Tap to add point, double-tap to undo, long-press to set value.`}
           data-testid={`team-${teamId}-score`}
         />
         <div className={isPortrait ? 'team-side-col' : 'team-side-row'}>

--- a/frontend/src/components/TeamPanel.tsx
+++ b/frontend/src/components/TeamPanel.tsx
@@ -78,6 +78,17 @@ export default function TeamPanel({
 
   const scoreText = String(score).padStart(2, '0');
 
+  // A concise live-region label: only the team name + current score are
+  // announced on every update. The long-form instructions live in a
+  // separate description node referenced via aria-describedby so they are
+  // read once on focus rather than every time the score changes.
+  const teamNameLabel =
+    asString(customization?.[`Team ${teamId} Name`]) ||
+    asString(customization?.[`Team ${teamId} Text Name`]) ||
+    `Team ${teamId === 1 ? 'A' : 'B'}`;
+  const scoreAriaLabel = `${teamNameLabel} score ${score}`;
+  const scoreDescId = `team-${teamId}-score-help`;
+
   const timeoutDots: ReactElement[] = [];
   for (let i = 0; i < timeouts; i++) {
     timeoutDots.push(
@@ -142,9 +153,13 @@ export default function TeamPanel({
           onClick={handleAddPoint}
           onDoubleTap={handleDoubleTap}
           onLongPress={handleLongPress}
-          aria-label={`Team ${teamId === 1 ? 'A' : 'B'} score ${score}. Tap to add point, double-tap to undo, long-press to set value.`}
+          aria-label={scoreAriaLabel}
+          aria-describedby={scoreDescId}
           data-testid={`team-${teamId}-score`}
         />
+        <span id={scoreDescId} className="visually-hidden">
+          Tap to add point, double-tap to undo, long-press to set value.
+        </span>
         <div className={isPortrait ? 'team-side-col' : 'team-side-row'}>
           <div className={isPortrait ? 'team-side-group-col' : 'team-side-group-row'}>
             <button

--- a/frontend/src/test/ErrorBoundary.test.tsx
+++ b/frontend/src/test/ErrorBoundary.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ErrorBoundary from '../components/ErrorBoundary';
+
+function Boom({ when }: { when: boolean }) {
+  if (when) throw new Error('kaboom');
+  return <div>ok</div>;
+}
+
+describe('ErrorBoundary', () => {
+  let originalConsoleError: typeof console.error;
+
+  beforeEach(() => {
+    // React 19 still prints the caught error; silence the noise in tests.
+    originalConsoleError = console.error;
+    console.error = vi.fn();
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  it('renders children when no error', () => {
+    render(
+      <ErrorBoundary>
+        <Boom when={false} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('ok')).toBeInTheDocument();
+  });
+
+  it('shows the fallback and error message when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Boom when={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('kaboom')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reload/i })).toBeInTheDocument();
+  });
+
+  it('reload button calls window.location.reload', () => {
+    const reload = vi.fn();
+    const origLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...origLocation, reload },
+    });
+
+    render(
+      <ErrorBoundary>
+        <Boom when={true} />
+      </ErrorBoundary>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /reload/i }));
+    expect(reload).toHaveBeenCalled();
+
+    Object.defineProperty(window, 'location', { configurable: true, value: origLocation });
+  });
+});

--- a/main.py
+++ b/main.py
@@ -13,10 +13,10 @@ from dotenv import load_dotenv
 if "PYTEST_CURRENT_TEST" not in os.environ:
     load_dotenv()
 
-from app.logging_config import get_uvicorn_log_config, setup_logging
+from app.bootstrap import create_app
 from app.config_validator import validate_config
 from app.env_vars_manager import EnvVarsManager
-from app.bootstrap import create_app
+from app.logging_config import get_uvicorn_log_config, setup_logging
 
 validate_config()
 setup_logging()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,16 +16,48 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
-# Close to ruff defaults (E, F) plus whitespace (W). Expand progressively.
-select = ["E", "F", "W"]
+# Close to ruff defaults (E, F) plus whitespace (W), import order (I), and
+# the bugbear ruleset (B) for likely-bug patterns. E501 stays off because long
+# URLs/fixture strings are common in tests and overlay payloads.
+select = ["E", "F", "W", "I", "B"]
 ignore = [
-    # Long strings/URLs are common in tests and overlay payloads.
     "E501",
 ]
 
+[tool.ruff.lint.flake8-bugbear]
+# FastAPI's dependency-injection helpers are intentionally called in default
+# arguments — that's the framework contract, not a bug. Whitelist them so B008
+# keeps catching genuine mistakes elsewhere.
+extend-immutable-calls = [
+    "fastapi.Depends",
+    "fastapi.Query",
+    "fastapi.Header",
+    "fastapi.Path",
+    "fastapi.Cookie",
+    "fastapi.Body",
+    "fastapi.File",
+    "fastapi.Form",
+    "fastapi.Security",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Empty default hooks on OverlayBackend are deliberately no-ops, not abstract.
+"app/overlay_backends/base.py" = ["B027"]
+# ``pytest.raises(Exception)`` is used in a websocket-close smoke test where
+# the exact Starlette exception is an implementation detail.
+"tests/test_api_routes.py" = ["B017"]
+
 [tool.mypy]
-# Narrow scope for Sprint 1. Expand `files` / `packages` as modules become clean.
-files = ["app/api/session_manager.py", "app/api/game_service.py", "app/api/schemas.py", "app/api/ws_hub.py"]
+# Core API + routes + middleware are now clean; keep the list explicit so we
+# stay in control of what gets type-checked and expand module-by-module.
+files = [
+    "app/api/session_manager.py",
+    "app/api/game_service.py",
+    "app/api/schemas.py",
+    "app/api/ws_hub.py",
+    "app/api/routes",
+    "app/api/middleware",
+]
 python_version = "3.11"
 follow_imports = "silent"
 ignore_missing_imports = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
-import pytest
-import os
 import json
+import os
 from unittest.mock import MagicMock
+
+import pytest
 from dotenv import load_dotenv
+
 from app.app_storage import AppStorage
 
 os.environ['PYTEST_CURRENT_TEST'] = 'true'

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -10,7 +10,6 @@ from app.admin import admin_page_router, admin_router
 from app.api import api_router
 from app.overlay import overlay_state_store
 
-
 ADMIN_PASSWORD = "s3cret"
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,13 +4,13 @@ Shared fixtures (``mock_conf``, ``api_backend``, ``api_session``,
 ``clean_sessions``) live in ``tests/conftest.py``.
 """
 import json
+
 import pytest
 
-from app.api.session_manager import SessionManager, GameSession
 from app.api.game_service import GameService
 from app.api.schemas import GameStateResponse
+from app.api.session_manager import GameSession, SessionManager
 from app.state import State
-
 
 # Apply clean_sessions to every test in this module.
 pytestmark = pytest.mark.usefixtures("clean_sessions")

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -9,12 +9,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from app.bootstrap import create_app
 from app.api.session_manager import SessionManager
+from app.bootstrap import create_app
 from app.state import State
-
 from tests.conftest import load_fixture
-
 
 pytestmark = pytest.mark.usefixtures("clean_sessions")
 

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -9,12 +9,12 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.api import api_router
+from app.app_config import DEFAULT_APP_TITLE, get_app_title
 from app.bootstrap import (
     _inject_title_into_html,
     _render_index_html,
     _render_manifest,
 )
-from app.app_config import DEFAULT_APP_TITLE, get_app_title
 
 
 @pytest.fixture

--- a/tests/test_auth_coverage.py
+++ b/tests/test_auth_coverage.py
@@ -14,14 +14,13 @@ import os
 
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 from fastapi.templating import Jinja2Templates
+from fastapi.testclient import TestClient
 
 from app.admin import admin_page_router, admin_router
 from app.api import api_router
 from app.overlay.routes import create_overlay_router
 from app.overlay.state_store import OverlayStateStore
-
 
 API_USER_PASSWORD = "user-secret"
 ADMIN_PASSWORD = "admin-secret"

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,16 +1,17 @@
 # tests/test_backend.py
-import pytest
-import sys
 import os
-from unittest.mock import patch, MagicMock
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 # Add the project's root directory to the Python path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+from app.app_storage import AppStorage
 from app.backend import Backend
 from app.conf import Conf
 from app.state import State
-from app.app_storage import AppStorage
 
 # The autouse fixture that was here has been moved to conftest.py
 # to be applied globally to all tests, ensuring UI tests are also isolated.

--- a/tests/test_config_validator.py
+++ b/tests/test_config_validator.py
@@ -1,7 +1,10 @@
 import os
-import pytest
 from unittest.mock import patch
+
+import pytest
+
 from app.config_validator import validate_config
+
 
 @pytest.fixture
 def clean_env():

--- a/tests/test_coverage_proposals.py
+++ b/tests/test_coverage_proposals.py
@@ -2,8 +2,9 @@
 Tests for WSControlClient message handling and send methods.
 """
 import json
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 from app.ws_client import WSControlClient
 

--- a/tests/test_customization.py
+++ b/tests/test_customization.py
@@ -1,12 +1,14 @@
-import pytest
-import sys
-import os
 import json
+import os
+import sys
+
+import pytest
 
 # Add the project's root directory to the Python path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from app.customization import Customization
+
 
 @pytest.fixture
 def customization():
@@ -155,6 +157,7 @@ def test_predefined_teams_loading(monkeypatch):
     # The teams are loaded at class level, so we need to reload the module
     # to see the change. This is an advanced technique.
     import importlib
+
     import app.customization as cust_module
     importlib.reload(cust_module)
     cust_module.Customization.refresh()
@@ -171,6 +174,7 @@ def test_predefined_themes_loading(monkeypatch):
     monkeypatch.setenv("APP_THEMES", themes_json)
 
     import importlib
+
     import app.customization as cust_module
     importlib.reload(cust_module)
     cust_module.Customization.refresh()

--- a/tests/test_env_vars_manager.py
+++ b/tests/test_env_vars_manager.py
@@ -1,9 +1,12 @@
-import unittest
-from unittest.mock import patch, Mock
-import os
 import json
+import os
+import unittest
+from unittest.mock import Mock, patch
+
 import requests
+
 from app.env_vars_manager import EnvVarsManager
+
 
 class TestEnvVarsManager(unittest.TestCase):
 

--- a/tests/test_game_manager.py
+++ b/tests/test_game_manager.py
@@ -1,15 +1,18 @@
-import pytest
-import sys
 import os
+import sys
+
+import pytest
 
 # Add the project's root directory to the Python path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from app.game_manager import GameManager
-from app.conf import Conf
-from app.backend import Backend
-from app.state import State
 from unittest.mock import MagicMock
+
+from app.backend import Backend
+from app.conf import Conf
+from app.game_manager import GameManager
+from app.state import State
+
 
 # Mock the Backend class to avoid actual API calls during tests
 @pytest.fixture
@@ -337,7 +340,7 @@ def test_add_game_in_different_sets(game_manager):
 
 def test_add_set_after_match_finished(game_manager):
     """Tests that a set is not added if the match is already finished."""
-    for i in range(1, 4):
+    for _ in range(1, 4):
         game_manager.add_set(1, False)
     game_manager.add_set(1, False)
     state = game_manager.get_current_state()

--- a/tests/test_overlay_resolver.py
+++ b/tests/test_overlay_resolver.py
@@ -9,15 +9,14 @@ but never auto-creates a missing overlay.
 import pytest
 
 from app.overlay_backends.utils import (
-    OverlayKind,
     UNO_OID_LENGTH,
+    OverlayKind,
     is_custom_overlay,
     matches_uno_format,
     resolve_overlay_kind,
     split_custom_oid,
     strip_legacy_prefix,
 )
-
 
 # A representative UNO OID — mixed-case alphanumeric, exactly 22 chars.
 UNO_OID = "2cIXk2IjHvMuva6Wwele8j"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,12 +1,14 @@
-import pytest
-import sys
-import os
 import copy
+import os
+import sys
+
+import pytest
 
 # Add the project's root directory to the Python path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from app.state import State
+
 
 @pytest.fixture
 def state():

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -1,17 +1,17 @@
 # tests/test_ws_client.py
 """Tests for WebSocket client and Backend WS integration."""
-import pytest
-import sys
 import os
+import sys
 import time
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from app.backend import Backend
 from app.conf import Conf
 from app.ws_client import WSControlClient
-
 
 # --- WSControlClient unit tests ---
 


### PR DESCRIPTION
## Summary

Phase 4 of the improvements plan — developer experience, a11y, and release hygiene. No user-visible behavior changes except the new error boundary fallback.

### Tooling (backend)
- **Ruff**: `select` now includes `I` (isort) and `B` (bugbear). Auto-sort fixed 48 unordered import blocks. FastAPI's dependency helpers (`Depends`, `Query`, `Header`, `Path`, `Cookie`, `Body`, `File`, `Form`, `Security`) are whitelisted as `extend-immutable-calls` so B008 keeps flagging genuine default-arg mistakes elsewhere. `OverlayBackend`'s empty default hooks get a per-file B027 ignore (those are deliberately no-ops, not abstract); `test_api_routes.py` gets a targeted B017 ignore for the one `pytest.raises(Exception)` used in a websocket-close smoke.
- **MyPy**: `files` expanded to also cover `app/api/routes` and `app/api/middleware`. Fixes a latent `Any | None` operand issue in `overlays.py` that was only visible under the wider scope.
- **Bug cleanup**: one real B007 (unused loop variable `i` → `_`) in `test_game_manager.py`.

### Frontend — ErrorBoundary + a11y
- New `ErrorBoundary` wraps `ScoreboardView` and `ConfigPanel` at the App root. Caught React errors are forwarded through the existing `errorReporter` so they land in the same backend log stream as `window.onerror`. Fallback UI has `role="alert"` + `aria-live="assertive"` and a reload button.
- `ScoreButton` gets an optional `aria-label` pass-through and sets `aria-live="polite"` when labelled, so assistive tech announces score changes. `TeamPanel` supplies a descriptive label per side ("Team A score 12. Tap to add point, double-tap to undo, long-press to set value.").

### Docs
- New `CHANGELOG.md` (Keep-a-Changelog) consolidating phases 1–4 under **[Unreleased]**.

### Deliberately deferred
- **Python 3.12 CI matrix**: CI already runs `ruff check`, `mypy`, `pytest` on 3.11 and the full frontend pipeline. Adding 3.12 deserves its own small PR so dep compatibility is validated independently.
- **Release-drafter workflow**: nice-to-have, out of scope here.

## Test plan

- [x] `ruff check app/ tests/` — all checks passed.
- [x] `mypy` — clean across 18 source files on the expanded scope.
- [x] `pytest -q` — 401 passed.
- [x] `cd frontend && npm run typecheck` — clean.
- [x] `cd frontend && npm test -- --run` — 170 passed (was 167 + 3 new `ErrorBoundary.test.tsx`).
- [ ] Manual smoke: trigger a render error in the tree (e.g. temporarily `throw` in a component); ErrorBoundary shows its fallback and the error is POSTed to `/api/v1/_log`.
- [ ] Manual smoke with screen reader: score change on either team panel is announced as the `aria-label` text.

https://claude.ai/code/session_01KwEn6jQdqrHoZRVLFszZKm