### PR TITLE
perf: gzip, static cache headers, session pooling, measurement

### DIFF
--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -29,6 +29,7 @@ class GameService:
     @staticmethod
     def get_state(session) -> GameStateResponse:
         """Build a ``GameStateResponse`` from the current session state."""
+        t0 = time.perf_counter()
         state = session.game_manager.get_current_state()
         serve = state.get_current_serve()
 
@@ -43,7 +44,7 @@ class GameService:
                 serving=(serve == State.SERVE_1 if team == 1 else serve == State.SERVE_2),
             )
 
-        return GameStateResponse(
+        response = GameStateResponse(
             current_set=session.current_set,
             visible=session.visible,
             simple_mode=session.simple,
@@ -57,6 +58,16 @@ class GameService:
                 "sets_limit": session.sets_limit,
             },
         )
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        if elapsed_ms > 50:
+            logger.warning(
+                'get_state slow: %.1fms sets_limit=%s', elapsed_ms, session.sets_limit,
+            )
+        else:
+            logger.debug(
+                'get_state took %.1fms sets_limit=%s', elapsed_ms, session.sets_limit,
+            )
+        return response
 
     @staticmethod
     def get_customization(session) -> dict:

--- a/app/backend.py
+++ b/app/backend.py
@@ -2,6 +2,7 @@ import copy
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 
 import requests
 
@@ -21,6 +22,24 @@ from app.state import State
 # for the duration of the match. 60s balances freshness against the cost of
 # extra GET round-trips on every save.
 _CUSTOMIZATION_CACHE_TTL_SECONDS = 60.0
+
+# Warn when a single remote overlay call exceeds this duration. Conservative so
+# it only fires on real slowdowns, not on a cold-start connection setup.
+_REMOTE_CALL_WARN_MS = 500.0
+
+
+@contextmanager
+def _timed(label: str, logger: logging.Logger):
+    """Log perf_counter-based duration at DEBUG, or WARNING above the threshold."""
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        if elapsed_ms > _REMOTE_CALL_WARN_MS:
+            logger.warning('%s slow: %.1fms', label, elapsed_ms)
+        else:
+            logger.debug('%s took %.1fms', label, elapsed_ms)
 
 
 class Backend:
@@ -267,39 +286,39 @@ class Backend:
     # -- Model persistence --------------------------------------------------
 
     def save_model(self, current_model, simple):
-        Backend.logger.info('saving model...')
-        self._ensure_overlay_backend()
-        self._overlay.save_model(current_model)
+        Backend.logger.debug('saving model...')
+        with _timed('save_model', Backend.logger):
+            self._ensure_overlay_backend()
+            self._overlay.save_model(current_model)
 
-        to_save = copy.copy(current_model)
-        if simple:
-            to_save = State.simplify_model(to_save)
+            to_save = copy.copy(current_model)
+            if simple:
+                to_save = State.simplify_model(to_save)
 
-        if self.conf.id == State.CHAMPIONSHIP_LAYOUT_ID:
-            to_save["Sets Display"] = str(to_save.get(State.CURRENT_SET_INT, "1"))
+            if self.conf.id == State.CHAMPIONSHIP_LAYOUT_ID:
+                to_save["Sets Display"] = str(to_save.get(State.CURRENT_SET_INT, "1"))
 
-        if self.conf.multithread:
-            self.executor.submit(
-                self._overlay.push_model_update, current_model, to_save,
-                show_only_current_set=simple,
-            )
-        else:
-            self._overlay.push_model_update(
-                current_model, to_save, show_only_current_set=simple,
-            )
-        Backend.logger.info('saved')
+            if self.conf.multithread:
+                self.executor.submit(
+                    self._overlay.push_model_update, current_model, to_save,
+                    show_only_current_set=simple,
+                )
+            else:
+                self._overlay.push_model_update(
+                    current_model, to_save, show_only_current_set=simple,
+                )
 
     def reduce_games_to_one(self):
         self._ensure_overlay_backend()
         self._overlay.reduce_games_to_one()
 
     def save_json_model(self, to_save):
-        Backend.logger.info('saving JSON model...')
+        Backend.logger.debug('saving JSON model...')
         self._ensure_overlay_backend()
         self._overlay.send_json_model(to_save)
 
     def save_json_customization(self, to_save):
-        Backend.logger.info('saving JSON customization...')
+        Backend.logger.debug('saving JSON customization...')
         self._ensure_overlay_backend()
         self._remember_customization(to_save)
 
@@ -326,18 +345,20 @@ class Backend:
 
     def get_current_model(self, customOid=None, saveResult=False):
         oid = customOid if customOid is not None else self.conf.oid
-        Backend.logger.info('getting state for oid %s', oid)
-        self._ensure_overlay_backend(oid)
-        return self._overlay.get_model(oid=oid, save_result=saveResult)
+        Backend.logger.debug('getting state for oid %s', oid)
+        with _timed('get_current_model', Backend.logger):
+            self._ensure_overlay_backend(oid)
+            return self._overlay.get_model(oid=oid, save_result=saveResult)
 
     def get_current_customization(self, customOid=None):
-        Backend.logger.info('getting customization')
-        oid = customOid if customOid is not None else self.conf.oid
-        self._ensure_overlay_backend(oid)
-        data = self._overlay.get_customization(oid=oid)
-        if data is not None:
-            self._remember_customization(data)
-        return data
+        Backend.logger.debug('getting customization')
+        with _timed('get_current_customization', Backend.logger):
+            oid = customOid if customOid is not None else self.conf.oid
+            self._ensure_overlay_backend(oid)
+            data = self._overlay.get_customization(oid=oid)
+            if data is not None:
+                self._remember_customization(data)
+            return data
 
     def is_visible(self):
         self._ensure_overlay_backend()

--- a/app/backend.py
+++ b/app/backend.py
@@ -5,6 +5,8 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from app.env_vars_manager import EnvVarsManager
 from app.overlay_backends import (
@@ -59,6 +61,23 @@ class Backend:
             'Content-Type': 'application/json',
             'Accept': 'application/json, text/plain, */*'
         })
+        # Pool sized for ThreadPoolExecutor (max_workers=5) plus the foreground
+        # request thread, with headroom. Retry covers transient 5xx/connection
+        # hiccups from the overlay server without masking real failures — the
+        # short per-call timeouts (2-5 s) keep the worst case bounded.
+        _adapter = HTTPAdapter(
+            pool_connections=10,
+            pool_maxsize=20,
+            max_retries=Retry(
+                total=2,
+                backoff_factor=0.3,
+                status_forcelist=(502, 503, 504),
+                allowed_methods=frozenset(["GET", "PUT", "POST"]),
+                raise_on_status=False,
+            ),
+        )
+        self.session.mount("http://", _adapter)
+        self.session.mount("https://", _adapter)
         self.executor = ThreadPoolExecutor(max_workers=5)
         self._customization_cache = None
         self._customization_cache_ts = 0.0

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -100,7 +100,31 @@ class SPAStaticFiles(StaticFiles):
         rewritten = _render_index_html(
             str(index_path), index_path.stat().st_mtime, get_app_title(),
         )
-        return HTMLResponse(rewritten)
+        # index.html is the SPA shell — must always be revalidated so clients
+        # pick up new hashed asset URLs after a frontend rebuild.
+        return HTMLResponse(
+            rewritten,
+            headers={"Cache-Control": "no-cache, must-revalidate"},
+        )
+
+
+class CachedStaticFiles(StaticFiles):
+    """StaticFiles subclass that sets a shared Cache-Control on 200 responses.
+
+    Used for fingerprinted asset mounts (``/assets``) and content-addressable
+    resources (``/fonts``) where the URL changes whenever the file does, so
+    a long ``immutable`` TTL is safe.
+    """
+
+    def __init__(self, *args, cache_control: str, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._cache_control = cache_control
+
+    async def get_response(self, path, scope):
+        response = await super().get_response(path, scope)
+        if response.status_code == 200:
+            response.headers.setdefault("Cache-Control", self._cache_control)
+        return response
 
 
 @asynccontextmanager
@@ -156,7 +180,16 @@ def _register_overlay_routes(application: FastAPI) -> None:
 
 
 def _register_static_mounts(application: FastAPI) -> None:
-    application.mount("/fonts", StaticFiles(directory="font"), name="fonts")
+    # Fonts are content-addressable (filename is the version); a year of
+    # browser caching with ``immutable`` removes revalidation round-trips.
+    application.mount(
+        "/fonts",
+        CachedStaticFiles(
+            directory="font",
+            cache_control="public, max-age=31536000, immutable",
+        ),
+        name="fonts",
+    )
     if OVERLAY_STATIC_DIR.is_dir():
         application.mount(
             "/static",
@@ -232,9 +265,15 @@ def _register_spa(application: FastAPI) -> None:
         return
 
     if (FRONTEND_DIR / "assets").is_dir():
+        # Vite-built assets are fingerprinted (e.g. ``index.abc123.js``);
+        # rebuilds produce new filenames, so long-lived immutable caching
+        # is safe.
         application.mount(
             "/assets",
-            StaticFiles(directory=FRONTEND_DIR / "assets"),
+            CachedStaticFiles(
+                directory=FRONTEND_DIR / "assets",
+                cache_control="public, max-age=31536000, immutable",
+            ),
             name="spa-assets",
         )
     application.mount(

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -16,6 +16,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -259,6 +260,9 @@ def create_app() -> FastAPI:
     _register_spa(application)
     # Outermost-first: RequestContextMiddleware must wrap ExceptionLoggingMiddleware
     # so the contextvars are populated by the time we log unhandled exceptions.
+    # GZip is registered last so it ends up outermost and compresses the final
+    # response body after observability middlewares have annotated it.
     application.add_middleware(ExceptionLoggingMiddleware)
     application.add_middleware(RequestContextMiddleware)
+    application.add_middleware(GZipMiddleware, minimum_size=1024)
     return application


### PR DESCRIPTION
## Summary

Four small performance commits on top of `dev`, all Python-side. Addresses audit findings that remained after the NiceGUI → React/TS migration and the recent `perf: phase-3` round.

1. **`perf(measure)`** — `perf_counter` spans on `Backend.save_model`, `get_current_model`, `get_current_customization`, and `GameService.get_state`. Logs at DEBUG under the threshold and WARNING above (500 ms remote / 50 ms in-process). Demotes the noisy INFO logs on those paths so the new timing signal isn't drowned out during a match.

2. **`perf(http)`** — attach `fastapi.middleware.gzip.GZipMiddleware(minimum_size=1024)` to the FastAPI app, ordered outermost so it compresses the final response body after observability middlewares.

3. **`perf(static)`** — new `CachedStaticFiles` subclass stamps `public, max-age=31536000, immutable` on `/fonts` and `/assets` (font filenames are stable; Vite fingerprints SPA asset filenames — long-lived immutable caching is safe). The SPA shell `index.html` gets `no-cache, must-revalidate` so clients always pick up new hashed asset URLs after a frontend rebuild.

4. **`perf(backend)`** — `HTTPAdapter(pool_connections=10, pool_maxsize=20)` + `Retry(total=2, backoff_factor=0.3, status_forcelist=(502,503,504))` mounted on `Backend.session`. Pool sized for `ThreadPoolExecutor(max_workers=5)` plus the foreground request thread with headroom. `raise_on_status=False` preserves the final status seen by callers. No new dependencies — `HTTPAdapter` and `Retry` are already installed via `requests` / `urllib3`.

## What's intentionally not here

Two audit findings turned out to already be optimal in `dev` after re-inspection, so no commit was made:

- **Font preload** — the 10 scoreboard fonts in `App.css` all use `font-display: swap` and are only applied when the user picks one via `selectedFont`. Preloading any specific font would waste bandwidth on every page load.
- **`useSettings` memoization** — `useSettings.tsx` already uses `useState(readAll)` (lazy initializer) + `useMemo` + `useCallback`. The finding was incorrect.

Larger items are deferred to their own branches: `requests` → `httpx.AsyncClient` migration, session-init parallelization, JSON log formatter micro-opts.

## Test plan

- [x] `pytest` — 401 passed locally (Playwright UI tests excluded because the sandbox has no Playwright browsers).
- [x] End-to-end gzip check via `TestClient(create_app())` — `/openapi.json` (~34 KB) returns `content-encoding: gzip`; `/health` (small payload) correctly skips compression.
- [x] End-to-end cache-header check — `/fonts/<file>.ttf` returns `cache-control: public, max-age=31536000, immutable`.
- [x] Middleware stack verified: `[GZipMiddleware, RequestContextMiddleware, ExceptionLoggingMiddleware]` so gzip is outermost on responses.
- [x] Backend `HTTPAdapter` mount verified — both `http://` and `https://` report `pool_connections=10`, `pool_maxsize=20`, `retries=2`.
- [ ] Manual smoke against a live overlay (recommend `docker compose up` and `curl -sI -H 'Accept-Encoding: gzip' http://localhost:8080/openapi.json` to confirm the gzip header end-to-end).

> **Note on previous PR description:** the prior title/body on this PR (`refactor: replace flat string-dict state with typed dataclass model`) did not match the contents of this branch. The four commits here have always been the perf changes above. Updated to match.