### PR TITLE
fix(pwa): exclude /manage from SW navigate fallback

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -68,6 +68,7 @@ export default defineConfig(async () => ({
           /^\/api/, /^\/fonts/, /^\/pwa/, /^\/health/,
           /^\/overlay/, /^\/ws\//, /^\/static/,
           /^\/create\//, /^\/delete\//, /^\/list\//,
+          /^\/manage(\/|\?|$)/,
         ],
         runtimeCaching: [
           {


### PR DESCRIPTION
Closing — superseded by a fresh PR targeting `dev` directly to avoid spurious CodeQL noise from the `main`-vs-`dev` diff.