### PR TITLE
fix(overlay): sanitize logo_url before assigning to <img>.src

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5700,16 +5700,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -5971,27 +5961,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -6057,13 +6026,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,5 +31,8 @@
     "vite": "^6.4.2",
     "vite-plugin-pwa": "^1.2.0",
     "vitest": "^4.1.2"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
   }
 }

--- a/overlay_static/js/app.js
+++ b/overlay_static/js/app.js
@@ -2,6 +2,21 @@ let previousState = null;
 let socket = null;
 let heartbeatInterval = null;
 
+// Restrict <img src> values coming from remote state to http(s) so a
+// malicious logo_url (javascript:, data:, vbscript:, …) cannot turn into XSS.
+function sanitizeImageUrl(url) {
+    if (typeof url !== 'string' || url === '') return '';
+    try {
+        const parsed = new URL(url, window.location.origin);
+        if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+            return parsed.href;
+        }
+    } catch (_e) {
+        // Malformed URL — fall through and reject.
+    }
+    return '';
+}
+
 // Send a "ping" to the server every 30 s so long-lived connections don't
 // silently drop without triggering the onclose reconnect logic.
 function startHeartbeat() {
@@ -225,15 +240,17 @@ function renderFullState(state) {
     document.getElementById("away-name").textContent = state.team_away.name;
     equalizeNamePanels();
 
-    if (state.team_home.logo_url) {
-        document.getElementById("home-logo").src = state.team_home.logo_url;
+    const homeLogoUrl = sanitizeImageUrl(state.team_home.logo_url);
+    if (homeLogoUrl) {
+        document.getElementById("home-logo").src = homeLogoUrl;
         document.getElementById("home-logo").style.display = 'block';
     } else {
         document.getElementById("home-logo").style.display = 'none';
     }
 
-    if (state.team_away.logo_url) {
-        document.getElementById("away-logo").src = state.team_away.logo_url;
+    const awayLogoUrl = sanitizeImageUrl(state.team_away.logo_url);
+    if (awayLogoUrl) {
+        document.getElementById("away-logo").src = awayLogoUrl;
         document.getElementById("away-logo").style.display = 'block';
     } else {
         document.getElementById("away-logo").style.display = 'none';
@@ -335,16 +352,18 @@ function updateStateDiff(oldState, newState) {
 
     // Logos
     if (oldState.team_home.logo_url !== newState.team_home.logo_url) {
-        if (newState.team_home.logo_url) {
-            document.getElementById("home-logo").src = newState.team_home.logo_url;
+        const safeUrl = sanitizeImageUrl(newState.team_home.logo_url);
+        if (safeUrl) {
+            document.getElementById("home-logo").src = safeUrl;
             document.getElementById("home-logo").style.display = 'block';
         } else {
             document.getElementById("home-logo").style.display = 'none';
         }
     }
     if (oldState.team_away.logo_url !== newState.team_away.logo_url) {
-        if (newState.team_away.logo_url) {
-            document.getElementById("away-logo").src = newState.team_away.logo_url;
+        const safeUrl = sanitizeImageUrl(newState.team_away.logo_url);
+        if (safeUrl) {
+            document.getElementById("away-logo").src = safeUrl;
             document.getElementById("away-logo").style.display = 'block';
         } else {
             document.getElementById("away-logo").style.display = 'none';


### PR DESCRIPTION
Remote state values (team_home.logo_url, team_away.logo_url) flow straight
from the websocket into `.src`. CodeQL flagged the four assignments in
renderFullState/updateStateDiff as client-side XSS because a crafted URL
(javascript:, data:, vbscript: …) turns a remote-controlled field into
script execution.

Add a sanitizeImageUrl() allow-list that resolves the value via URL() and
only accepts http:/https:; every malformed or non-http scheme falls
through to the empty-string branch that already hides the logo.

https://claude.ai/code/session_01KbE4pVJ9FXu1wPXnCipj5g