### PR TITLE
feat(ui): apply selected button font to set buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,11 @@ once a first tagged release ships.
   `SCOREBOARD_LANGUAGE` env var dropped. The Spanish placeholder defaults (`Local` /
   `Visitante`) are replaced with empty strings; users set team names via `APP_TEAMS`
   or the runtime Teams config panel (`#177`).
+- Set buttons respect the button font: the center-panel set counters now
+  render in the same `fontFamily` selected for the score buttons (via
+  `FontSelector` / `settings.selectedFont`), instead of the browser default.
+  `CenterPanel` gained an optional `fontStyle` prop that `ScoreboardView`
+  forwards through; the `.set-button` CSS `font-size` is unchanged.
 
 ### Fixed
 

--- a/frontend/src/components/CenterPanel.tsx
+++ b/frontend/src/components/CenterPanel.tsx
@@ -56,6 +56,7 @@ export default function CenterPanel({
           color="#424242"
           textColor="#fff"
           className="set-button"
+          size={48}
           fontStyle={fontStyle}
           onClick={() => onAddSet(1)}
           onLongPress={() => onLongPressSet(1)}
@@ -94,6 +95,7 @@ export default function CenterPanel({
           color="#424242"
           textColor="#fff"
           className="set-button"
+          size={48}
           fontStyle={fontStyle}
           onClick={() => onAddSet(2)}
           onLongPress={() => onLongPressSet(2)}

--- a/frontend/src/components/CenterPanel.tsx
+++ b/frontend/src/components/CenterPanel.tsx
@@ -1,4 +1,5 @@
 import ScoreButton from './ScoreButton';
+import type { ScoreButtonFontStyle } from './ScoreButton';
 import ScoreTable from './ScoreTable';
 import OverlayPreview from './OverlayPreview';
 import type { GameState } from '../api/client';
@@ -21,6 +22,7 @@ export interface CenterPanelProps {
   setsLimit: number;
   isPortrait: boolean;
   previewData: PreviewData | null | undefined;
+  fontStyle?: ScoreButtonFontStyle;
   onAddSet: (teamId: 1 | 2) => void;
   onLongPressSet: (teamId: 1 | 2) => void;
   onSetChange: (set: number) => void;
@@ -33,6 +35,7 @@ export default function CenterPanel({
   setsLimit,
   isPortrait,
   previewData,
+  fontStyle,
   onAddSet,
   onLongPressSet,
   onSetChange,
@@ -53,6 +56,7 @@ export default function CenterPanel({
           color="#424242"
           textColor="#fff"
           className="set-button"
+          fontStyle={fontStyle}
           onClick={() => onAddSet(1)}
           onLongPress={() => onLongPressSet(1)}
           data-testid="team-1-sets"
@@ -90,6 +94,7 @@ export default function CenterPanel({
           color="#424242"
           textColor="#fff"
           className="set-button"
+          fontStyle={fontStyle}
           onClick={() => onAddSet(2)}
           onLongPress={() => onLongPressSet(2)}
           data-testid="team-2-sets"

--- a/frontend/src/components/ScoreboardView.tsx
+++ b/frontend/src/components/ScoreboardView.tsx
@@ -130,6 +130,7 @@ export default function ScoreboardView({
           setsLimit={setsLimit}
           isPortrait={isPortrait}
           previewData={showPreview ? previewData : null}
+          fontStyle={fontStyle}
           onAddSet={onAddSet}
           onLongPressSet={onLongPressSet}
           onSetChange={onSetChange}


### PR DESCRIPTION
## Summary

- The center-panel set counters (`.set-button` in `CenterPanel.tsx`) previously fell back to the browser default font, while the score buttons honoured `settings.selectedFont` via `ScoreButton`'s `fontStyle` prop.
- Thread `fontStyle` through `CenterPanel` so both set buttons pick up the same `fontFamily` as the score buttons. `ScoreboardView` already receives `fontStyle` and now forwards it.
- The `.set-button` CSS `font-size: 1.5rem !important` keeps their rendered size unchanged — only `fontFamily` flows through from the selector.

## Changes

- `frontend/src/components/CenterPanel.tsx`: import `ScoreButtonFontStyle` type, add optional `fontStyle` prop, forward it to both set `ScoreButton` instances.
- `frontend/src/components/ScoreboardView.tsx`: pass the already-received `fontStyle` through to `CenterPanel`.
- `CHANGELOG.md`: entry under `[Unreleased] → Changed`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 180/180 pass (including 13 `CenterPanel` tests)
- [ ] Manual: open the control UI, change the font via the Buttons config section, confirm the two set counters in the center panel re-render in the same font as the team score buttons
- [ ] Manual: verify `.set-button` size (48×48, 1.5rem) is unchanged

https://claude.ai/code/session_01Sx1JQpqjbBBDKQ9iwWrqfQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx1JQpqjbBBDKQ9iwWrqfQ)_