### PR TITLE
docs(changelog): cut v5.0.0 release entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+---
+
+## [5.0.0] - 2026-04-24
+
 ### Added
 
 - In-process overlay engine: `LocalOverlayBackend` serves Jinja2 overlay


### PR DESCRIPTION
Promote the Unreleased section to [5.0.0] - 2026-04-24, marking the
release that completes the NiceGUI removal, in-process overlay engine,
full TypeScript frontend migration, and auth/observability hardening.

https://claude.ai/code/session_017eqcBF3NGYHM3cFZFkiv7x