### PR TITLE
feat(api): accept `control` as a backward-compatible alias for `oid` query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Added
+
+- `?control=<id>` is now accepted as a backward-compatible alias for `?oid=<id>`
+  on every API endpoint that takes the OID via query string (REST routes, the
+  `/ws` WebSocket, and the request-logging middleware) and on the React
+  control UI's initial-OID lookup. Either parameter resolves to the same
+  overlay; passing both prefers `oid`.
+
 ---
 
 ## [5.0.0] - 2026-04-24

--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -72,20 +72,29 @@ def check_oid_access(authorization: str, oid: str):
 
 async def get_session(
     request: Request,
-    oid: str = Query(..., description="Overlay ID")
+    oid: str | None = Query(None, description="Overlay ID"),
+    control: str | None = Query(None, description="Alias of `oid` for backward compatibility"),
 ) -> GameSession:
     """Retrieve a previously initialised ``GameSession``.
 
-    Returns HTTP 404 if no session exists for the given OID — callers
-    should call ``POST /api/v1/session/init`` first.
+    Accepts either ``?oid=`` or ``?control=`` (alias). Returns HTTP 404 if
+    no session exists for the given OID — callers should call
+    ``POST /api/v1/session/init`` first.
     """
-    authorization = request.headers.get("authorization", "")
-    check_oid_access(authorization, oid)
+    resolved = oid or control
+    if not resolved:
+        raise HTTPException(
+            status_code=422,
+            detail="Missing required query parameter: 'oid' (or alias 'control').",
+        )
 
-    session = SessionManager.get(oid)
+    authorization = request.headers.get("authorization", "")
+    check_oid_access(authorization, resolved)
+
+    session = SessionManager.get(resolved)
     if session is None:
         raise HTTPException(
             status_code=404,
-            detail=f"No active session for OID '{oid}'. Call POST /api/v1/session/init first.",
+            detail=f"No active session for OID '{resolved}'. Call POST /api/v1/session/init first.",
         )
     return session

--- a/app/api/middleware/logging.py
+++ b/app/api/middleware/logging.py
@@ -66,5 +66,5 @@ def _extract_oid(scope) -> str | None:
     # latin-1 is total over bytes (never raises) and matches Starlette's
     # own handling of raw ASGI byte strings.
     params = parse_qs(qs.decode("latin-1"), keep_blank_values=False)
-    values = params.get("oid")
+    values = params.get("oid") or params.get("control")
     return values[0] if values else None

--- a/app/api/routes/websocket.py
+++ b/app/api/routes/websocket.py
@@ -18,8 +18,8 @@ router = APIRouter()
 @router.websocket("/ws")
 async def websocket_endpoint(
     ws: WebSocket,
-    oid: str | None = Query(None),
-    control: str | None = Query(None),
+    oid: str | None = Query(None, description="Overlay ID"),
+    control: str | None = Query(None, description="Alias of `oid` for backward compatibility"),
 ):
     resolved = oid or control
     if not resolved:

--- a/app/api/routes/websocket.py
+++ b/app/api/routes/websocket.py
@@ -16,22 +16,31 @@ router = APIRouter()
 
 
 @router.websocket("/ws")
-async def websocket_endpoint(ws: WebSocket, oid: str = Query(...)):
+async def websocket_endpoint(
+    ws: WebSocket,
+    oid: str | None = Query(None),
+    control: str | None = Query(None),
+):
+    resolved = oid or control
+    if not resolved:
+        await ws.close(code=4400, reason="Missing 'oid' (or alias 'control') query parameter.")
+        return
+
     token = ws.query_params.get("token")
     auth_header = f"Bearer {token}" if token else ws.headers.get("authorization", "")
 
     try:
-        check_oid_access(auth_header, oid)
+        check_oid_access(auth_header, resolved)
     except HTTPException as e:
         await ws.close(code=4003, reason=e.detail)
         return
 
-    session = SessionManager.get(oid)
+    session = SessionManager.get(resolved)
     if session is None:
         await ws.close(code=4004, reason="No active session for this OID.")
         return
 
-    await WSHub.connect(ws, oid)
+    await WSHub.connect(ws, resolved)
     try:
         state_data = GameService.get_state(session).model_dump()
         await ws.send_json({"type": "state_update", "data": state_data})
@@ -44,6 +53,6 @@ async def websocket_endpoint(ws: WebSocket, oid: str = Query(...)):
     except WebSocketDisconnect:
         pass
     except Exception:
-        logger.exception("WebSocket error for OID %s", redact_oid(oid))
+        logger.exception("WebSocket error for OID %s", redact_oid(resolved))
     finally:
-        WSHub.disconnect(ws, oid)
+        WSHub.disconnect(ws, resolved)

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -1409,11 +1409,36 @@
             "description": "Overlay ID",
             "in": "query",
             "name": "oid",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Overlay ID",
-              "title": "Oid",
-              "type": "string"
+              "title": "Oid"
+            }
+          },
+          {
+            "description": "Alias of `oid` for backward compatibility",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Alias of `oid` for backward compatibility",
+              "title": "Control"
             }
           },
           {
@@ -1460,11 +1485,36 @@
             "description": "Overlay ID",
             "in": "query",
             "name": "oid",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Overlay ID",
-              "title": "Oid",
-              "type": "string"
+              "title": "Oid"
+            }
+          },
+          {
+            "description": "Alias of `oid` for backward compatibility",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Alias of `oid` for backward compatibility",
+              "title": "Control"
             }
           },
           {
@@ -1509,11 +1559,36 @@
             "description": "Overlay ID",
             "in": "query",
             "name": "oid",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Overlay ID",
-              "title": "Oid",
-              "type": "string"
+              "title": "Oid"
+            }
+          },
+          {
+            "description": "Alias of `oid` for backward compatibility",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Alias of `oid` for backward compatibility",
+              "title": "Control"
             }
           },
           {
@@ -1574,11 +1649,36 @@
             "description": "Overlay ID",
             "in": "query",
             "name": "oid",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Overlay ID",
-              "title": "Oid",
-              "type": "string"
+              "title": "Oid"
+            }
+          },
+          {
+            "description": "Alias of `oid` for backward compatibility",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Alias of `oid` for backward compatibility",
+              "title": "Control"
             }
           },
           {
@@ -1637,11 +1737,36 @@
             "description": "Overlay ID",
             "in": "query",
             "name": "oid",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Overlay ID",
-              "title": "Oid",
-              "type": "string"
+              "title": "Oid"
+            }
+          },
+          {
+            "description": "Alias of `oid` for backward compatibility",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Alias of `oid` for backward compatibility",
+              "title": "Control"
             }
           },
           {
@@ -1700,11 +1825,36 @@
             "description": "Overlay ID",
             "in": "query",
             "name": "oid",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Overlay ID",
-              "title": "Oid",
-              "type": "string"
+              "title": "Oid"
+            }
+          },
+          {
+            "description": "Alias of `oid` for backward compatibility",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Alias of `oid` for backward compatibility",
+              "title": "Control"
             }
           },
           {
@@ -1763,11 +1913,36 @@
             "description": "Overlay ID",
             "in": "query",
             "name": "oid",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Overlay ID",
-              "title": "Oid",
-              "type": "string"
+              "title": "Oid"
+            }
+          },
+          {
+            "description": "Alias of `oid` for backward compatibility",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Alias of `oid` for backward compatibility",
+              "title": "Control"
             }
           },
           {
@@ -1826,11 +2001,36 @@
             "description": "Overlay ID",
             "in": "query",
             "name": "oid",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Overlay ID",
-              "title": "Oid",
-              "type": "string"
+              "title": "Oid"
+            }
+          },
+          {
+            "description": "Alias of `oid` for backward compatibility",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Alias of `oid` for backward compatibility",
+              "title": "Control"
             }
           },
           {
@@ -1889,11 +2089,36 @@
             "description": "Overlay ID",
             "in": "query",
             "name": "oid",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Overlay ID",
-              "title": "Oid",
-              "type": "string"
+              "title": "Oid"
+            }
+          },
+          {
+            "description": "Alias of `oid` for backward compatibility",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Alias of `oid` for backward compatibility",
+              "title": "Control"
             }
           },
           {
@@ -1952,11 +2177,36 @@
             "description": "Overlay ID",
             "in": "query",
             "name": "oid",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Overlay ID",
-              "title": "Oid",
-              "type": "string"
+              "title": "Oid"
+            }
+          },
+          {
+            "description": "Alias of `oid` for backward compatibility",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Alias of `oid` for backward compatibility",
+              "title": "Control"
             }
           },
           {
@@ -2005,11 +2255,36 @@
             "description": "Overlay ID",
             "in": "query",
             "name": "oid",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Overlay ID",
-              "title": "Oid",
-              "type": "string"
+              "title": "Oid"
+            }
+          },
+          {
+            "description": "Alias of `oid` for backward compatibility",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Alias of `oid` for backward compatibility",
+              "title": "Control"
             }
           },
           {
@@ -2068,11 +2343,36 @@
             "description": "Overlay ID",
             "in": "query",
             "name": "oid",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Overlay ID",
-              "title": "Oid",
-              "type": "string"
+              "title": "Oid"
+            }
+          },
+          {
+            "description": "Alias of `oid` for backward compatibility",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Alias of `oid` for backward compatibility",
+              "title": "Control"
             }
           },
           {
@@ -2132,11 +2432,36 @@
             "description": "Overlay ID",
             "in": "query",
             "name": "oid",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Overlay ID",
-              "title": "Oid",
-              "type": "string"
+              "title": "Oid"
+            }
+          },
+          {
+            "description": "Alias of `oid` for backward compatibility",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Alias of `oid` for backward compatibility",
+              "title": "Control"
             }
           },
           {
@@ -2283,11 +2608,36 @@
             "description": "Overlay ID",
             "in": "query",
             "name": "oid",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Overlay ID",
-              "title": "Oid",
-              "type": "string"
+              "title": "Oid"
+            }
+          },
+          {
+            "description": "Alias of `oid` for backward compatibility",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Alias of `oid` for backward compatibility",
+              "title": "Control"
             }
           },
           {
@@ -2337,11 +2687,36 @@
             "description": "Overlay ID",
             "in": "query",
             "name": "oid",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "Overlay ID",
-              "title": "Oid",
-              "type": "string"
+              "title": "Oid"
+            }
+          },
+          {
+            "description": "Alias of `oid` for backward compatibility",
+            "in": "query",
+            "name": "control",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Alias of `oid` for backward compatibility",
+              "title": "Control"
             }
           },
           {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,7 +37,7 @@ interface FontScale {
 
 function getInitialOid(): string {
   const params = new URLSearchParams(window.location.search);
-  const urlOid = params.get('oid');
+  const urlOid = params.get('oid') || params.get('control');
   if (urlOid) return urlOid;
   try {
     return localStorage.getItem('volley_oid') || '';

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1371,9 +1371,11 @@ export interface operations {
     };
     get_config_api_v1_config_get: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Overlay ID */
-                oid: string;
+                oid?: string | null;
+                /** @description Alias of `oid` for backward compatibility */
+                control?: string | null;
             };
             header?: {
                 authorization?: string;
@@ -1405,9 +1407,11 @@ export interface operations {
     };
     get_customization_api_v1_customization_get: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Overlay ID */
-                oid: string;
+                oid?: string | null;
+                /** @description Alias of `oid` for backward compatibility */
+                control?: string | null;
             };
             header?: {
                 authorization?: string;
@@ -1439,9 +1443,11 @@ export interface operations {
     };
     update_customization_api_v1_customization_put: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Overlay ID */
-                oid: string;
+                oid?: string | null;
+                /** @description Alias of `oid` for backward compatibility */
+                control?: string | null;
             };
             header?: {
                 authorization?: string;
@@ -1479,9 +1485,11 @@ export interface operations {
     };
     set_simple_mode_api_v1_display_simple_mode_post: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Overlay ID */
-                oid: string;
+                oid?: string | null;
+                /** @description Alias of `oid` for backward compatibility */
+                control?: string | null;
             };
             header?: {
                 authorization?: string;
@@ -1517,9 +1525,11 @@ export interface operations {
     };
     set_visibility_api_v1_display_visibility_post: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Overlay ID */
-                oid: string;
+                oid?: string | null;
+                /** @description Alias of `oid` for backward compatibility */
+                control?: string | null;
             };
             header?: {
                 authorization?: string;
@@ -1555,9 +1565,11 @@ export interface operations {
     };
     add_point_api_v1_game_add_point_post: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Overlay ID */
-                oid: string;
+                oid?: string | null;
+                /** @description Alias of `oid` for backward compatibility */
+                control?: string | null;
             };
             header?: {
                 authorization?: string;
@@ -1593,9 +1605,11 @@ export interface operations {
     };
     add_set_api_v1_game_add_set_post: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Overlay ID */
-                oid: string;
+                oid?: string | null;
+                /** @description Alias of `oid` for backward compatibility */
+                control?: string | null;
             };
             header?: {
                 authorization?: string;
@@ -1631,9 +1645,11 @@ export interface operations {
     };
     add_timeout_api_v1_game_add_timeout_post: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Overlay ID */
-                oid: string;
+                oid?: string | null;
+                /** @description Alias of `oid` for backward compatibility */
+                control?: string | null;
             };
             header?: {
                 authorization?: string;
@@ -1669,9 +1685,11 @@ export interface operations {
     };
     change_serve_api_v1_game_change_serve_post: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Overlay ID */
-                oid: string;
+                oid?: string | null;
+                /** @description Alias of `oid` for backward compatibility */
+                control?: string | null;
             };
             header?: {
                 authorization?: string;
@@ -1707,9 +1725,11 @@ export interface operations {
     };
     reset_game_api_v1_game_reset_post: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Overlay ID */
-                oid: string;
+                oid?: string | null;
+                /** @description Alias of `oid` for backward compatibility */
+                control?: string | null;
             };
             header?: {
                 authorization?: string;
@@ -1741,9 +1761,11 @@ export interface operations {
     };
     set_score_api_v1_game_set_score_post: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Overlay ID */
-                oid: string;
+                oid?: string | null;
+                /** @description Alias of `oid` for backward compatibility */
+                control?: string | null;
             };
             header?: {
                 authorization?: string;
@@ -1779,9 +1801,11 @@ export interface operations {
     };
     set_sets_api_v1_game_set_sets_post: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Overlay ID */
-                oid: string;
+                oid?: string | null;
+                /** @description Alias of `oid` for backward compatibility */
+                control?: string | null;
             };
             header?: {
                 authorization?: string;
@@ -1817,9 +1841,11 @@ export interface operations {
     };
     get_links_api_v1_links_get: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Overlay ID */
-                oid: string;
+                oid?: string | null;
+                /** @description Alias of `oid` for backward compatibility */
+                control?: string | null;
             };
             header?: {
                 authorization?: string;
@@ -1917,9 +1943,11 @@ export interface operations {
     };
     get_state_api_v1_state_get: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Overlay ID */
-                oid: string;
+                oid?: string | null;
+                /** @description Alias of `oid` for backward compatibility */
+                control?: string | null;
             };
             header?: {
                 authorization?: string;
@@ -1951,9 +1979,11 @@ export interface operations {
     };
     get_styles_api_v1_styles_get: {
         parameters: {
-            query: {
+            query?: {
                 /** @description Overlay ID */
-                oid: string;
+                oid?: string | null;
+                /** @description Alias of `oid` for backward compatibility */
+                control?: string | null;
             };
             header?: {
                 authorization?: string;

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -146,4 +146,19 @@ describe('App', () => {
       expect(localStorage.setItem).toHaveBeenCalledWith('volley_oid', 'persist-oid');
     });
   });
+
+  it('seeds initial OID from ?control= query alias', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        protocol: 'https:',
+        host: 'localhost',
+        search: '?control=alias-oid',
+        href: 'https://localhost/?control=alias-oid',
+      },
+      writable: true,
+    });
+    renderWithI18n(<App />);
+    const input = screen.getByPlaceholderText('my-overlay') as HTMLInputElement;
+    expect(input.value).toBe('alias-oid');
+  });
 });

--- a/frontend/src/utils/errorReporter.ts
+++ b/frontend/src/utils/errorReporter.ts
@@ -42,7 +42,7 @@ function dedupe(signature: string): boolean {
 
 function readOidFromUrl(): string | undefined {
   const params = new URLSearchParams(window.location.search);
-  return params.get('oid') ?? params.get('control') ?? undefined;
+  return params.get('oid') || params.get('control') || undefined;
 }
 
 function safeStringify(value: unknown): string {

--- a/frontend/src/utils/errorReporter.ts
+++ b/frontend/src/utils/errorReporter.ts
@@ -41,7 +41,8 @@ function dedupe(signature: string): boolean {
 }
 
 function readOidFromUrl(): string | undefined {
-  return new URLSearchParams(window.location.search).get('oid') ?? undefined;
+  const params = new URLSearchParams(window.location.search);
+  return params.get('oid') ?? params.get('control') ?? undefined;
 }
 
 function safeStringify(value: unknown): string {

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -109,6 +109,20 @@ class TestGameRoutes:
         assert r.status_code == 200
         assert r.json()["state"]["team_1"]["sets"] == 1
 
+    def test_add_point_accepts_control_alias(self, client, fake_backend_cls):
+        client.post("/api/v1/session/init", json={"oid": "abc"})
+        r = client.post(
+            "/api/v1/game/add-point?control=abc",
+            json={"team": 1},
+        )
+        assert r.status_code == 200
+        assert r.json()["state"]["team_1"]["scores"]["set_1"] == 1
+
+    def test_missing_oid_and_control_returns_422(self, client, fake_backend_cls):
+        client.post("/api/v1/session/init", json={"oid": "abc"})
+        r = client.post("/api/v1/game/add-point", json={"team": 1})
+        assert r.status_code == 422
+
 
 # ---------------------------------------------------------------------------
 # WebSocket /ws
@@ -133,6 +147,13 @@ class TestWebSocketRoute:
             ws.receive_json()  # initial state_update
             ws.send_text("ping")
             assert ws.receive_text() == "pong"
+
+    def test_ws_accepts_control_alias(self, client, fake_backend_cls):
+        client.post("/api/v1/session/init", json={"oid": "abc"})
+        with client.websocket_connect("/api/v1/ws?control=abc") as ws:
+            msg = ws.receive_json()
+            assert msg["type"] == "state_update"
+            assert msg["data"]["current_set"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_logging_context.py
+++ b/tests/test_logging_context.py
@@ -52,6 +52,11 @@ class TestRequestContextMiddleware:
         response = client.get("/probe", params={"oid": "test_oid_valid"})
         assert response.json()["oid"] == "test_oid_valid"
 
+    def test_extracts_oid_from_control_alias(self):
+        client = TestClient(_build_app())
+        response = client.get("/probe", params={"control": "test_oid_valid"})
+        assert response.json()["oid"] == "test_oid_valid"
+
     def test_absent_oid_defaults_to_dash(self):
         client = TestClient(_build_app())
         response = client.get("/probe")


### PR DESCRIPTION
`?control=<id>` now resolves identically to `?oid=<id>` on REST routes,
the `/ws` WebSocket, the request-logging middleware, and the React
control UI's initial-OID lookup. Passing both prefers `oid`.

https://claude.ai/code/session_01AcYpTt4kpWFbxrDi2GnfN2