### PR TITLE
fix(config): disable Save when no changes instead of hiding it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,12 @@ once a first tagged release ships.
 
 ### Changed
 
-- Config panel save UX: the "Save" button is now hidden until a setting that
-  needs to be persisted to the overlay actually changes, making it visually
-  obvious which controls apply directly versus which require an explicit save.
-  Leaving the panel via the back arrow, a browser back/edge-swipe gesture, or
-  the in-app right-swipe now prompts the user before discarding pending edits
+- Config panel save UX: the "Save" button is now disabled (kept visible)
+  until a setting that needs to be persisted to the overlay actually changes,
+  making it visually obvious which controls apply directly versus which
+  require an explicit save without the bottom bar reflowing. Leaving the
+  panel via the back arrow, a browser back/edge-swipe gesture, or the in-app
+  right-swipe now prompts the user before discarding pending edits
   (`config.unsavedChangesConfirm` translated for EN/ES/PT/IT/FR/DE).
 
 ---

--- a/frontend/src/components/ConfigPanel.tsx
+++ b/frontend/src/components/ConfigPanel.tsx
@@ -286,13 +286,11 @@ export default function ConfigPanel({
       </div>
 
       <div className="config-bottom-bar">
-        {isDirty && (
-          <button className="config-bottom-btn config-bottom-btn-save"
-            onClick={handleSave} disabled={saving} title={t('config.saveCustomization')} data-testid="save-button">
-            <span className="material-icons">save</span>
-            <span>{saving ? '...' : t('config.save')}</span>
-          </button>
-        )}
+        <button className="config-bottom-btn config-bottom-btn-save"
+          onClick={handleSave} disabled={saving || !isDirty} title={t('config.saveCustomization')} data-testid="save-button">
+          <span className="material-icons">save</span>
+          <span>{saving ? '...' : t('config.save')}</span>
+        </button>
         <div className="spacer" />
         <button className="config-bottom-btn config-bottom-btn-refresh" onClick={handleRefresh}
           disabled={refreshing} title={t('config.reloadFromServer')} data-testid="refresh-button">

--- a/frontend/src/test/ConfigPanel.test.tsx
+++ b/frontend/src/test/ConfigPanel.test.tsx
@@ -47,19 +47,21 @@ describe('ConfigPanel', () => {
     });
   });
 
-  it('hides the save button when there are no unsaved changes', () => {
+  it('disables the save button when there are no unsaved changes', () => {
     renderWithI18n(<ConfigPanel {...defaultProps} />);
-    expect(screen.queryByTestId('save-button')).not.toBeInTheDocument();
+    const saveBtn = screen.getByTestId('save-button');
+    expect(saveBtn).toBeInTheDocument();
+    expect(saveBtn).toBeDisabled();
+    expect(saveBtn).toHaveTextContent('Save');
   });
 
-  it('shows the save button after a customization change', async () => {
+  it('enables the save button after a customization change', async () => {
     renderWithI18n(<ConfigPanel {...defaultProps} />);
     const selector = await screen.findByTestId('team-1-name-selector');
     fireEvent.change(selector, { target: { value: '' } });
     await waitFor(() => {
-      expect(screen.getByTestId('save-button')).toBeInTheDocument();
+      expect(screen.getByTestId('save-button')).not.toBeDisabled();
     });
-    expect(screen.getByTestId('save-button')).toHaveTextContent('Save');
   });
 
   it('confirms before leaving when there are unsaved changes', async () => {
@@ -68,7 +70,7 @@ describe('ConfigPanel', () => {
     const selector = await screen.findByTestId('team-1-name-selector');
     fireEvent.change(selector, { target: { value: '' } });
     await waitFor(() => {
-      expect(screen.getByTestId('save-button')).toBeInTheDocument();
+      expect(screen.getByTestId('save-button')).not.toBeDisabled();
     });
     fireEvent.click(screen.getByTestId('scoreboard-tab-button'));
     await waitFor(() => {
@@ -83,7 +85,7 @@ describe('ConfigPanel', () => {
     const selector = await screen.findByTestId('team-1-name-selector');
     fireEvent.change(selector, { target: { value: '' } });
     await waitFor(() => {
-      expect(screen.getByTestId('save-button')).toBeInTheDocument();
+      expect(screen.getByTestId('save-button')).not.toBeDisabled();
     });
     window.dispatchEvent(new PopStateEvent('popstate'));
     expect(window.confirm).toHaveBeenCalled();
@@ -104,7 +106,10 @@ describe('ConfigPanel', () => {
     renderWithI18n(<ConfigPanel {...defaultProps} />);
     const selector = await screen.findByTestId('team-1-name-selector');
     fireEvent.change(selector, { target: { value: '' } });
-    const saveBtn = await screen.findByTestId('save-button');
+    const saveBtn = screen.getByTestId('save-button');
+    await waitFor(() => {
+      expect(saveBtn).not.toBeDisabled();
+    });
     fireEvent.click(saveBtn);
     await waitFor(() => {
       expect(api.updateCustomization).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Follow-up to #200. Instead of removing the **Save** button from the bottom bar when the configuration model matches the loaded customization, keep it rendered and just toggle its `disabled` attribute. Users still get the visual cue that "no save is required right now," but the bar layout no longer reflows when the first edit happens (or when a save flushes the dirty flag), and the button has a stable affordance regardless of state.

The unsaved-changes confirmation flow on the back arrow / browser back / in-app right-swipe is unchanged.

## Test plan
- [x] `npx vitest run` — 213 tests passing (existing "hide" tests rewritten to assert `toBeDisabled` / `not.toBeDisabled`)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: open config with no changes → Save button is greyed out and clicks do nothing
- [ ] Manual: edit a team name → Save button enables; click it → button disables again after the model refreshes from the server

https://claude.ai/code/session_01WcbX2SMGhxTditMapKQCZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcbX2SMGhxTditMapKQCZC)_