### PR TITLE
fix(config): style :disabled state for the config bottom buttons

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -853,6 +853,19 @@ body {
   background: var(--hover-bg);
 }
 
+.config-bottom-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.config-bottom-btn:disabled:hover {
+  background: transparent;
+}
+
+.config-bottom-btn:disabled:active {
+  transform: none;
+}
+
 .config-bottom-btn .material-icons {
   font-size: 1.2rem;
 }


### PR DESCRIPTION
## Summary

Follow-up to #201. The Save button correctly received the `disabled` attribute when there were no unsaved changes (clicks were ignored), but `.config-bottom-btn` had no `:disabled` style, so visually the button looked identical whether it was active or not. This adds the same treatment that already exists on `.config-top-btn-save:disabled` (50% opacity, `cursor: not-allowed`) and clears the hover/active feedback so a disabled button doesn't react to taps.

## Test plan
- [x] `npx vitest run` — 213 tests passing
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: open config with no changes → Save button is greyed out and the cursor shows the not-allowed icon on hover
- [ ] Manual: edit a team name → Save button regains full opacity and pointer cursor; click → disables again after the model refreshes

https://claude.ai/code/session_01WcbX2SMGhxTditMapKQCZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcbX2SMGhxTditMapKQCZC)_