### PR TITLE
fix(config): make :disabled bottom buttons clearly greyed out

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -854,8 +854,11 @@ body {
 }
 
 .config-bottom-btn:disabled {
-  opacity: 0.5;
+  opacity: 0.45;
   cursor: not-allowed;
+  border-color: var(--text-muted);
+  color: var(--text-muted);
+  filter: grayscale(1);
 }
 
 .config-bottom-btn:disabled:hover {


### PR DESCRIPTION
## Summary

Follow-up to #202. The previous `:disabled` rule only set `opacity: 0.5`, so the Save button still read as a half-strength blue button rather than an obviously inactive control. This commit overrides the per-variant border and text colours with `--text-muted`, applies `filter: grayscale(1)`, and lowers the opacity slightly so the button reads as plain grey when there are no unsaved changes.

## Test plan
- [x] `npx vitest run` — 213 tests passing
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: open config with no changes → Save button is plain grey (no blue tint), refresh button is plain grey while refreshing
- [ ] Manual: edit a team name → Save button regains its blue colour and becomes clickable

https://claude.ai/code/session_01WcbX2SMGhxTditMapKQCZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcbX2SMGhxTditMapKQCZC)_