### PR TITLE
fix(scoreboard): keep control bar pinned on tablets and desktops

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,7 +51,7 @@ export default function App() {
   const { t } = useI18n();
   const appConfig = useAppConfig();
   const { settings, setSetting } = useSettings();
-  const { isPortrait, buttonSize } = useOrientation();
+  const { isPortrait, buttonSize, hasRoomForPersistentControls } = useOrientation();
 
   const [oid, setOid] = useState<string>(getInitialOid);
   const [oidInput, setOidInput] = useState<string>(oid);
@@ -96,6 +96,12 @@ export default function App() {
   const previewData = usePreview(oid, settings.showPreview, !!state);
 
   useEffect(() => {
+    // On tablets/desktops the control bar fits without covering scoreboard
+    // elements, so keep it pinned and skip the inactivity timer.
+    if (hasRoomForPersistentControls) {
+      if (!showControls) setShowControls(true);
+      return;
+    }
     if (showControls && activeTab === 'scoreboard' && state) {
       resetHideTimer();
       window.addEventListener('pointerdown', resetHideTimer, { passive: true });
@@ -104,7 +110,7 @@ export default function App() {
       if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
       window.removeEventListener('pointerdown', resetHideTimer);
     };
-  }, [showControls, activeTab, state, resetHideTimer]);
+  }, [showControls, activeTab, state, resetHideTimer, hasRoomForPersistentControls]);
 
   const setsLimit = (state?.config?.sets_limit as number | undefined) ?? 5;
   const matchFinished = state?.match_finished ?? false;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -95,13 +95,20 @@ export default function App() {
   // initSession has created the session.
   const previewData = usePreview(oid, settings.showPreview, !!state);
 
+  // Reveal the bar when the viewport gains room for it (e.g. phone→tablet
+  // resize). Kept in its own effect so the manual hide toggle still works
+  // on tablets — the auto-hide effect below would otherwise re-show it on
+  // every showControls change.
+  useEffect(() => {
+    if (hasRoomForPersistentControls) {
+      setShowControls(true);
+    }
+  }, [hasRoomForPersistentControls]);
+
   useEffect(() => {
     // On tablets/desktops the control bar fits without covering scoreboard
-    // elements, so keep it pinned and skip the inactivity timer.
-    if (hasRoomForPersistentControls) {
-      if (!showControls) setShowControls(true);
-      return;
-    }
+    // elements, so skip the inactivity timer entirely.
+    if (hasRoomForPersistentControls) return;
     if (showControls && activeTab === 'scoreboard' && state) {
       resetHideTimer();
       window.addEventListener('pointerdown', resetHideTimer, { passive: true });

--- a/frontend/src/hooks/useOrientation.ts
+++ b/frontend/src/hooks/useOrientation.ts
@@ -3,7 +3,14 @@ import { useState, useEffect } from 'react';
 export interface OrientationLayout {
   isPortrait: boolean;
   buttonSize: number;
+  // True on tablets/desktops where the overlay control bar fits at the
+  // bottom without covering scoreboard controls — used to skip auto-hide.
+  hasRoomForPersistentControls: boolean;
 }
+
+// Material Design's tablet breakpoint: anything whose smaller side is at
+// least 600 CSS px (e.g. iPad, desktop) has room to keep the bar pinned.
+const PERSISTENT_CONTROLS_MIN_DIMENSION = 600;
 
 function computeLayout(): OrientationLayout {
   const w = window.innerWidth;
@@ -12,6 +19,8 @@ function computeLayout(): OrientationLayout {
   return {
     isPortrait: portrait,
     buttonSize: portrait ? Math.min(h / 4, 360) : Math.min(w / 3.5, 360),
+    hasRoomForPersistentControls:
+      Math.min(w, h) >= PERSISTENT_CONTROLS_MIN_DIMENSION,
   };
 }
 


### PR DESCRIPTION
## Summary

- The bottom control bar on the scoreboard auto-hides after 5 s of inactivity. That makes sense on phones, where the bar overlays scoreboard panels and steals vertical space, but it feels flaky on tablets/desktops where there is plenty of room to keep it visible.
- `useOrientation` now exposes `hasRoomForPersistentControls`, true when the smaller viewport dimension is at least 600 CSS px (Material Design tablet breakpoint).
- `App.tsx` short-circuits the auto-hide effect when that flag is set: no inactivity timer, no `pointerdown` listener, and the bar is forced back visible if it was hidden before resizing.

## Notes

- The breakpoint covers all current iPad / Galaxy Tab sizes and keeps every iPhone (incl. 14 Pro Max at 430 px) on the phone path. iPad split-screen narrow columns also stay on the phone path, since `min(w, h)` collapses to the column width.
- Phone↔tablet transitions handle correctly: the effect re-runs on the dimension change, restores the bar when entering tablet mode, and re-arms timer + listener when going back to phone.
- The unrelated `settings.autoHide` / `autoHideSeconds` (stream overlay auto-hide) are untouched.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 213 / 213 passing
- [x] `npm run build` — clean
- [ ] Manual: verify on a phone-sized viewport that the bar still auto-hides after 5 s of inactivity and reappears via the wakeup tab
- [ ] Manual: verify on a tablet/desktop viewport that the bar stays visible regardless of inactivity
- [ ] Manual: resize across the 600 px boundary and confirm the bar is restored when entering tablet mode

https://claude.ai/code/session_01TXQe1q3mnATVHV5caxf6cb

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXQe1q3mnATVHV5caxf6cb)_