### PR TITLE
feat(frontend): keyboard a11y, useActionHistory hook, coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,14 @@ jobs:
       working-directory: frontend
       run: npm run typecheck
 
-    - name: Run Vitest
+    - name: Run Vitest with coverage gate
       working-directory: frontend
-      run: npm test
+      run: npm run test:coverage
+
+    - name: Upload frontend coverage artifact
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: frontend-coverage
+        path: frontend/coverage/lcov.info
+        if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Added
+
+- Keyboard activation on the score and timeout buttons in the React
+  control UI: Enter and Space now trigger the same single-tap / rapid
+  double-tap / long-press gestures previously only reachable by mouse
+  or touch, closing a WCAG 2.1.1 (Keyboard) gap. Implemented in the
+  shared `useDoubleTap` hook and covered by new keyboard test cases.
+- Frontend coverage gate in CI. `vitest run --coverage` is now enforced
+  on every PR via `npm run test:coverage`; thresholds are pinned tightly
+  below current coverage to act as a regression floor and the lcov
+  report is uploaded as a CI artifact alongside the existing backend
+  coverage artifact.
+
 ### Changed
 
 - Centralised frontend timing and capacity tunables into a new
@@ -18,6 +31,13 @@ once a first tagged release ships.
   call sites now import from one place so future tuning is discoverable.
 - Bumped the client-side undo history cap from 200 to 300 so a 5-set
   match with extended deuces is fully covered without truncation.
+- Refactored the client-side undo state out of `App.tsx` into a
+  dedicated `useActionHistory` hook (`frontend/src/hooks/useActionHistory.ts`).
+  The hook owns the bounded stack, exposes a small testable API
+  (`push`, `undoLast`, `popMatching`, `clear`) and uses a ref-mirrored
+  state so rapid undo dispatches see the latest history even between
+  React batches. Behaviour is unchanged; the hook now has dedicated
+  unit tests covering the truncation path and the rapid-undo case.
 - Internationalization is now correctly described in `README.md` as the
   React control UI being available in six locales (English, Spanish,
   Portuguese, Italian, French, German), and the bullet has been moved

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.4.1",
+        "@vitest/coverage-v8": "^4.1.2",
         "jsdom": "^29.0.1",
         "openapi-typescript": "^7.13.0",
         "typescript": "^5.9.3",
@@ -1668,6 +1669,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
@@ -3116,6 +3127,37 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.2",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.2",
+        "vitest": "4.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
@@ -3369,6 +3411,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -4514,6 +4575,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -4597,6 +4668,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
@@ -5077,6 +5155,58 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
@@ -5308,6 +5438,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "gen:types": "openapi-typescript ./schema/openapi.json -o ./src/api/schema.d.ts",
     "typecheck": "tsc --noEmit"
   },
@@ -25,6 +26,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.4.1",
+    "@vitest/coverage-v8": "^4.1.2",
     "jsdom": "^29.0.1",
     "openapi-typescript": "^7.13.0",
     "typescript": "^5.9.3",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -168,7 +168,10 @@ export default function App() {
         actions.setSimpleMode(true);
       }
     },
-    [actions, matchFinished, undoHistory, settings.autoSimple, simpleMode]
+    // Depend on the stable individual functions rather than the wrapper
+    // object so callbacks don't re-build on every history push (which
+    // would propagate fresh prop identities into memoised ScoreButtons).
+    [actions, matchFinished, undoHistory.push, settings.autoSimple, simpleMode]
   );
 
   const handleAddSet = useCallback(
@@ -177,7 +180,7 @@ export default function App() {
       actions.addSet(team, false);
       undoHistory.push({ type: 'set', team });
     },
-    [actions, matchFinished, undoHistory]
+    [actions, matchFinished, undoHistory.push]
   );
 
   const handleAddTimeout = useCallback(
@@ -189,7 +192,7 @@ export default function App() {
         actions.setSimpleMode(false);
       }
     },
-    [actions, matchFinished, undoHistory, settings.autoSimple, settings.autoSimpleOnTimeout, simpleMode]
+    [actions, matchFinished, undoHistory.push, settings.autoSimple, settings.autoSimpleOnTimeout, simpleMode]
   );
 
   const handleChangeServe = useCallback(
@@ -211,7 +214,7 @@ export default function App() {
     if (popped.type === 'point') actions.addPoint(popped.team, true);
     else if (popped.type === 'set') actions.addSet(popped.team, true);
     else actions.addTimeout(popped.team, true);
-  }, [actions, undoHistory]);
+  }, [actions, undoHistory.undoLast]);
 
   const handleToggleFullscreen = useCallback(() => {
     if (document.fullscreenElement) {
@@ -233,7 +236,7 @@ export default function App() {
       actions.reset();
       undoHistory.clear();
     }
-  }, [actions, t, undoHistory]);
+  }, [actions, t, undoHistory.clear]);
 
   const handleLogout = useCallback(() => {
     try { localStorage.removeItem('volley_oid'); } catch (e) { console.warn('Failed to remove OID:', e); }
@@ -241,7 +244,7 @@ export default function App() {
     setOidInput('');
     undoHistory.clear();
     setActiveTab('scoreboard');
-  }, [undoHistory]);
+  }, [undoHistory.clear]);
 
   const handleSetChange = useCallback(
     (set: number) => {
@@ -256,7 +259,7 @@ export default function App() {
       actions.addPoint(team, true);
       undoHistory.popMatching('point', team);
     },
-    [actions, undoHistory]
+    [actions, undoHistory.popMatching]
   );
 
   const handleDoubleTapTimeout = useCallback(
@@ -264,7 +267,7 @@ export default function App() {
       actions.addTimeout(team, true);
       undoHistory.popMatching('timeout', team);
     },
-    [actions, undoHistory]
+    [actions, undoHistory.popMatching]
   );
 
   const handleLongPressScore = useCallback(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,11 +19,10 @@ import {
   TEAM_B_COLOR,
   FONT_SCALES,
 } from './theme';
-import { ACTION_HISTORY_LIMIT, HUD_AUTO_HIDE_MS } from './constants';
+import { HUD_AUTO_HIDE_MS } from './constants';
+import { useActionHistory } from './hooks/useActionHistory';
 
 type Team = 1 | 2;
-
-type ActionEntry = { type: 'point' | 'set' | 'timeout'; team: Team };
 
 interface DialogState {
   open: boolean;
@@ -58,7 +57,7 @@ export default function App() {
 
   const [oid, setOid] = useState<string>(getInitialOid);
   const [oidInput, setOidInput] = useState<string>(oid);
-  const [actionHistory, setActionHistory] = useState<ActionEntry[]>([]);
+  const undoHistory = useActionHistory();
   const [activeTab, setActiveTab] = useState<'scoreboard' | 'config'>('scoreboard');
   const swipeHandlers = useSwipeNavigation({
     onSwipeLeft: activeTab === 'scoreboard' ? () => setActiveTab('config') : undefined,
@@ -160,44 +159,37 @@ export default function App() {
     }
   }, [oid, initialize]);
 
-  const pushAction = useCallback((entry: ActionEntry) => {
-    setActionHistory((h) => {
-      const next = h.length >= ACTION_HISTORY_LIMIT ? h.slice(-ACTION_HISTORY_LIMIT + 1) : h;
-      return [...next, entry];
-    });
-  }, []);
-
   const handleAddPoint = useCallback(
     (team: Team) => {
       if (matchFinished) return;
       actions.addPoint(team, false);
-      pushAction({ type: 'point', team });
+      undoHistory.push({ type: 'point', team });
       if (settings.autoSimple && !simpleMode) {
         actions.setSimpleMode(true);
       }
     },
-    [actions, matchFinished, pushAction, settings.autoSimple, simpleMode]
+    [actions, matchFinished, undoHistory, settings.autoSimple, simpleMode]
   );
 
   const handleAddSet = useCallback(
     (team: Team) => {
       if (matchFinished) return;
       actions.addSet(team, false);
-      pushAction({ type: 'set', team });
+      undoHistory.push({ type: 'set', team });
     },
-    [actions, matchFinished, pushAction]
+    [actions, matchFinished, undoHistory]
   );
 
   const handleAddTimeout = useCallback(
     (team: Team) => {
       if (matchFinished) return;
       actions.addTimeout(team, false);
-      pushAction({ type: 'timeout', team });
+      undoHistory.push({ type: 'timeout', team });
       if (settings.autoSimple && settings.autoSimpleOnTimeout && simpleMode) {
         actions.setSimpleMode(false);
       }
     },
-    [actions, matchFinished, pushAction, settings.autoSimple, settings.autoSimpleOnTimeout, simpleMode]
+    [actions, matchFinished, undoHistory, settings.autoSimple, settings.autoSimpleOnTimeout, simpleMode]
   );
 
   const handleChangeServe = useCallback(
@@ -214,29 +206,12 @@ export default function App() {
   }, [actions, simpleMode]);
 
   const handleUndoLast = useCallback(() => {
-    // Side effects belong outside the state updater (React contract +
-    // StrictMode dev double-invokes updaters). Read history synchronously
-    // here and dispatch the API call before mutating state.
-    if (actionHistory.length === 0) return;
-    const last = actionHistory[actionHistory.length - 1];
-    if (last.type === 'point') actions.addPoint(last.team, true);
-    else if (last.type === 'set') actions.addSet(last.team, true);
-    else actions.addTimeout(last.team, true);
-    setActionHistory((h) => h.slice(0, -1));
-  }, [actions, actionHistory]);
-
-  // Pops the most recent matching entry off the history. Used by double-tap
-  // gestures, which are themselves an undo of the corresponding action.
-  const popMatchingAction = useCallback((type: ActionEntry['type'], team: Team) => {
-    setActionHistory((h) => {
-      for (let i = h.length - 1; i >= 0; i--) {
-        if (h[i].type === type && h[i].team === team) {
-          return [...h.slice(0, i), ...h.slice(i + 1)];
-        }
-      }
-      return h;
-    });
-  }, []);
+    const popped = undoHistory.undoLast();
+    if (!popped) return;
+    if (popped.type === 'point') actions.addPoint(popped.team, true);
+    else if (popped.type === 'set') actions.addSet(popped.team, true);
+    else actions.addTimeout(popped.team, true);
+  }, [actions, undoHistory]);
 
   const handleToggleFullscreen = useCallback(() => {
     if (document.fullscreenElement) {
@@ -256,17 +231,17 @@ export default function App() {
   const handleReset = useCallback(() => {
     if (window.confirm(t('config.resetConfirm'))) {
       actions.reset();
-      setActionHistory([]);
+      undoHistory.clear();
     }
-  }, [actions, t]);
+  }, [actions, t, undoHistory]);
 
   const handleLogout = useCallback(() => {
     try { localStorage.removeItem('volley_oid'); } catch (e) { console.warn('Failed to remove OID:', e); }
     setOid('');
     setOidInput('');
-    setActionHistory([]);
+    undoHistory.clear();
     setActiveTab('scoreboard');
-  }, []);
+  }, [undoHistory]);
 
   const handleSetChange = useCallback(
     (set: number) => {
@@ -279,17 +254,17 @@ export default function App() {
   const handleDoubleTapScore = useCallback(
     (team: Team) => {
       actions.addPoint(team, true);
-      popMatchingAction('point', team);
+      undoHistory.popMatching('point', team);
     },
-    [actions, popMatchingAction]
+    [actions, undoHistory]
   );
 
   const handleDoubleTapTimeout = useCallback(
     (team: Team) => {
       actions.addTimeout(team, true);
-      popMatchingAction('timeout', team);
+      undoHistory.popMatching('timeout', team);
     },
-    [actions, popMatchingAction]
+    [actions, undoHistory]
   );
 
   const handleLongPressScore = useCallback(
@@ -396,7 +371,7 @@ export default function App() {
           showPreview={settings.showPreview}
           showControls={showControls}
           setShowControls={setShowControls}
-          canUndo={actionHistory.length > 0}
+          canUndo={undoHistory.canUndo}
           simpleMode={simpleMode}
           isFullscreen={isFullscreen}
           darkMode={settings.darkMode}

--- a/frontend/src/hooks/useActionHistory.ts
+++ b/frontend/src/hooks/useActionHistory.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ACTION_HISTORY_LIMIT } from '../constants';
+
+export type Team = 1 | 2;
+
+export type ActionEntry = {
+  type: 'point' | 'set' | 'timeout';
+  team: Team;
+};
+
+export interface UseActionHistory {
+  history: readonly ActionEntry[];
+  canUndo: boolean;
+  /** Append a forward action to the stack, evicting the oldest entry if the
+   *  cap is reached. */
+  push: (entry: ActionEntry) => void;
+  /** Pop the most recent entry. Returns the popped entry so the caller can
+   *  dispatch the matching API undo, or `null` if the stack is empty.
+   *  Side effects must run *after* this returns — never inside a state
+   *  updater (React contract; StrictMode double-invokes updaters in dev). */
+  undoLast: () => ActionEntry | null;
+  /** Remove the most recent entry whose `type` and `team` match (used by
+   *  the double-tap gestures, which are themselves an undo and so consume
+   *  one entry). No-op when no match is found. */
+  popMatching: (type: ActionEntry['type'], team: Team) => void;
+  /** Drop everything (e.g. on session reset / logout). */
+  clear: () => void;
+}
+
+/**
+ * Bounded client-side history of the user's forward actions, used to drive
+ * the undo button and reconcile double-tap gestures.
+ *
+ * State is mirrored into a ref so action functions can read the latest
+ * value synchronously even between React batches — important when a user
+ * fires the undo button repeatedly faster than React can re-render.
+ */
+export function useActionHistory(): UseActionHistory {
+  const [history, setHistory] = useState<readonly ActionEntry[]>([]);
+  const historyRef = useRef<readonly ActionEntry[]>(history);
+
+  useEffect(() => {
+    historyRef.current = history;
+  }, [history]);
+
+  const push = useCallback((entry: ActionEntry) => {
+    const next = historyRef.current.length >= ACTION_HISTORY_LIMIT
+      ? historyRef.current.slice(-(ACTION_HISTORY_LIMIT - 1))
+      : historyRef.current;
+    historyRef.current = [...next, entry];
+    setHistory(historyRef.current);
+  }, []);
+
+  const undoLast = useCallback((): ActionEntry | null => {
+    const h = historyRef.current;
+    if (h.length === 0) return null;
+    const popped = h[h.length - 1];
+    historyRef.current = h.slice(0, -1);
+    setHistory(historyRef.current);
+    return popped;
+  }, []);
+
+  const popMatching = useCallback((type: ActionEntry['type'], team: Team) => {
+    const h = historyRef.current;
+    for (let i = h.length - 1; i >= 0; i--) {
+      if (h[i].type === type && h[i].team === team) {
+        historyRef.current = [...h.slice(0, i), ...h.slice(i + 1)];
+        setHistory(historyRef.current);
+        return;
+      }
+    }
+  }, []);
+
+  const clear = useCallback(() => {
+    historyRef.current = [];
+    setHistory([]);
+  }, []);
+
+  return {
+    history,
+    canUndo: history.length > 0,
+    push,
+    undoLast,
+    popMatching,
+    clear,
+  };
+}

--- a/frontend/src/hooks/useActionHistory.ts
+++ b/frontend/src/hooks/useActionHistory.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ACTION_HISTORY_LIMIT } from '../constants';
 
 export type Team = 1 | 2;
@@ -76,12 +76,19 @@ export function useActionHistory(): UseActionHistory {
     setHistory([]);
   }, []);
 
-  return {
-    history,
-    canUndo: history.length > 0,
-    push,
-    undoLast,
-    popMatching,
-    clear,
-  };
+  // Memoise the returned object so consumers that depend on the whole
+  // hook value (rather than individual functions) only see a new
+  // identity when `history` actually changes — the action callbacks
+  // themselves are already stable via useCallback([]).
+  return useMemo(
+    () => ({
+      history,
+      canUndo: history.length > 0,
+      push,
+      undoLast,
+      popMatching,
+      clear,
+    }),
+    [history, push, undoLast, popMatching, clear],
+  );
 }

--- a/frontend/src/hooks/useDoubleTap.ts
+++ b/frontend/src/hooks/useDoubleTap.ts
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useRef, MouseEvent, TouchEvent } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  KeyboardEvent,
+  MouseEvent,
+  TouchEvent,
+} from 'react';
 import { DOUBLE_TAP_MS, LONG_PRESS_MS } from '../constants';
 
 export interface UseDoubleTapOptions {
@@ -21,19 +28,23 @@ export interface PressHandlers {
   onTouchEnd: (e: TouchEvent<HTMLElement>) => void;
   onTouchMove: (e: TouchEvent<HTMLElement>) => void;
   onTouchCancel: (e: TouchEvent<HTMLElement>) => void;
+  onKeyDown: (e: KeyboardEvent<HTMLElement>) => void;
+  onKeyUp: (e: KeyboardEvent<HTMLElement>) => void;
 }
 
 /**
- * Press-gesture detector with single-tap, double-tap and (optional) long-press.
+ * Press-gesture detector with single-tap, double-tap and (optional)
+ * long-press. Activated by mouse, touch, or keyboard (Enter / Space).
  *
  * Gesture priority: long-press > double-tap > single-tap.
  *
- * Double-tap is detected at press-start (touchstart / mousedown) because that
- * event fires immediately and reliably on mobile, whereas touchend timing
- * varies with how long the user keeps their finger down.
+ * Double-tap is detected at press-start (touchstart / mousedown / keydown)
+ * because that event fires immediately and reliably, whereas the
+ * corresponding "release" timing varies with how long the user holds the
+ * input.
  *
- * If `onDoubleTap` is not provided, `onClick` fires immediately on press-end
- * (no single-tap delay).
+ * If `onDoubleTap` is not provided, `onClick` fires immediately on
+ * press-end (no single-tap delay).
  */
 export function useDoubleTap({
   onClick,
@@ -48,6 +59,7 @@ export function useDoubleTap({
   const singleTapTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const doubleTapPending = useRef(false);
   const touchActive = useRef(false);
+  const keyActive = useRef(false);
 
   useEffect(() => {
     return () => {
@@ -62,10 +74,8 @@ export function useDoubleTap({
     };
   }, []);
 
-  const startPress = useCallback((e: PressEvent) => {
-    if (e?.type === 'mousedown' && touchActive.current) return;
-    if (e?.type === 'touchstart') touchActive.current = true;
-
+  // Core press-start logic, shared by mouse / touch / keyboard.
+  const beginPress = useCallback(() => {
     isLongPress.current = false;
 
     const now = Date.now();
@@ -95,13 +105,8 @@ export function useDoubleTap({
     }
   }, [onDoubleTap, onLongPress, doubleTapMs, longPressMs]);
 
-  const endPress = useCallback((e: PressEvent) => {
-    if (e?.type === 'touchend') {
-      e.preventDefault();
-      setTimeout(() => { touchActive.current = false; }, 50);
-    }
-    if (e?.type === 'mouseup' && touchActive.current) return;
-
+  // Core press-end logic, shared by mouse / touch / keyboard.
+  const finishPress = useCallback(() => {
     if (pressTimer.current) {
       clearTimeout(pressTimer.current);
       pressTimer.current = null;
@@ -122,6 +127,21 @@ export function useDoubleTap({
     }
   }, [onClick, onDoubleTap, doubleTapMs]);
 
+  const startPress = useCallback((e: PressEvent) => {
+    if (e?.type === 'mousedown' && touchActive.current) return;
+    if (e?.type === 'touchstart') touchActive.current = true;
+    beginPress();
+  }, [beginPress]);
+
+  const endPress = useCallback((e: PressEvent) => {
+    if (e?.type === 'touchend') {
+      e.preventDefault();
+      setTimeout(() => { touchActive.current = false; }, 50);
+    }
+    if (e?.type === 'mouseup' && touchActive.current) return;
+    finishPress();
+  }, [finishPress]);
+
   const cancelPress = useCallback((e: PressEvent) => {
     if (e?.type === 'touchmove') touchActive.current = false;
     if (pressTimer.current) {
@@ -131,6 +151,26 @@ export function useDoubleTap({
     doubleTapPending.current = false;
   }, []);
 
+  const onKeyDown = useCallback((e: KeyboardEvent<HTMLElement>) => {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    // Hold-down browsers fire keydown repeatedly; only the first edge counts
+    // so the long-press timer isn't reset every frame.
+    if (e.repeat) return;
+    // Suppress the browser default that would scroll the page on Space and
+    // synthesise a click on Enter (we manage activation ourselves).
+    e.preventDefault();
+    keyActive.current = true;
+    beginPress();
+  }, [beginPress]);
+
+  const onKeyUp = useCallback((e: KeyboardEvent<HTMLElement>) => {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    if (!keyActive.current) return;
+    keyActive.current = false;
+    e.preventDefault();
+    finishPress();
+  }, [finishPress]);
+
   return {
     onMouseDown: startPress,
     onMouseUp: endPress,
@@ -139,5 +179,7 @@ export function useDoubleTap({
     onTouchEnd: endPress,
     onTouchMove: cancelPress,
     onTouchCancel: cancelPress,
+    onKeyDown,
+    onKeyUp,
   };
 }

--- a/frontend/src/hooks/useDoubleTap.ts
+++ b/frontend/src/hooks/useDoubleTap.ts
@@ -76,6 +76,13 @@ export function useDoubleTap({
 
   // Core press-start logic, shared by mouse / touch / keyboard.
   const beginPress = useCallback(() => {
+    // Defensive: a concurrent input path (e.g. finger held + keyboard
+    // press) could otherwise overwrite an in-flight long-press timer
+    // and leak it, firing onLongPress later out of context.
+    if (pressTimer.current) {
+      clearTimeout(pressTimer.current);
+      pressTimer.current = null;
+    }
     isLongPress.current = false;
 
     const now = Date.now();

--- a/frontend/src/test/ScoreButton.test.tsx
+++ b/frontend/src/test/ScoreButton.test.tsx
@@ -89,4 +89,65 @@ describe('ScoreButton', () => {
     );
     expect(screen.getByTestId('btn').style.fontFamily).toContain('Digital Dismay');
   });
+
+  it('keyboard: Enter key activates onClick (single tap)', () => {
+    const onClick = vi.fn();
+    const onDoubleTap = vi.fn();
+    render(<ScoreButton text="00" color="#000" onClick={onClick} onDoubleTap={onDoubleTap} data-testid="btn" />);
+    const btn = screen.getByTestId('btn');
+    fireEvent.keyDown(btn, { key: 'Enter' });
+    fireEvent.keyUp(btn, { key: 'Enter' });
+    act(() => { vi.advanceTimersByTime(400); });
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(onDoubleTap).not.toHaveBeenCalled();
+  });
+
+  it('keyboard: Space key activates onClick (single tap)', () => {
+    const onClick = vi.fn();
+    render(<ScoreButton text="00" color="#000" onClick={onClick} data-testid="btn" />);
+    const btn = screen.getByTestId('btn');
+    fireEvent.keyDown(btn, { key: ' ' });
+    fireEvent.keyUp(btn, { key: ' ' });
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('keyboard: rapid double-Enter triggers onDoubleTap', () => {
+    const onClick = vi.fn();
+    const onDoubleTap = vi.fn();
+    render(<ScoreButton text="00" color="#000" onClick={onClick} onDoubleTap={onDoubleTap} data-testid="btn" />);
+    const btn = screen.getByTestId('btn');
+    fireEvent.keyDown(btn, { key: 'Enter' });
+    fireEvent.keyUp(btn, { key: 'Enter' });
+    act(() => { vi.advanceTimersByTime(100); });
+    fireEvent.keyDown(btn, { key: 'Enter' });
+    fireEvent.keyUp(btn, { key: 'Enter' });
+    expect(onDoubleTap).toHaveBeenCalledOnce();
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('keyboard: Tab key (and other non-activation keys) is ignored', () => {
+    const onClick = vi.fn();
+    render(<ScoreButton text="00" color="#000" onClick={onClick} data-testid="btn" />);
+    const btn = screen.getByTestId('btn');
+    fireEvent.keyDown(btn, { key: 'Tab' });
+    fireEvent.keyUp(btn, { key: 'Tab' });
+    fireEvent.keyDown(btn, { key: 'a' });
+    fireEvent.keyUp(btn, { key: 'a' });
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('keyboard: held Enter (repeat=true) does not stack the long-press timer', () => {
+    const onClick = vi.fn();
+    const onLongPress = vi.fn();
+    render(<ScoreButton text="00" color="#000" onClick={onClick} onLongPress={onLongPress} data-testid="btn" />);
+    const btn = screen.getByTestId('btn');
+    fireEvent.keyDown(btn, { key: 'Enter' });
+    // Browser repeats keydown while held; these shouldn't reset the timer.
+    fireEvent.keyDown(btn, { key: 'Enter', repeat: true });
+    fireEvent.keyDown(btn, { key: 'Enter', repeat: true });
+    act(() => { vi.advanceTimersByTime(1100); });
+    fireEvent.keyUp(btn, { key: 'Enter' });
+    expect(onLongPress).toHaveBeenCalledOnce();
+    expect(onClick).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/test/TeamPanel.test.tsx
+++ b/frontend/src/test/TeamPanel.test.tsx
@@ -117,6 +117,36 @@ describe('TeamPanel', () => {
     expect(onAddTimeout).not.toHaveBeenCalled();
   });
 
+  it('keyboard: Enter on timeout button activates onAddTimeout', () => {
+    const onAddTimeout = vi.fn();
+    render(<TeamPanel {...defaultProps} onAddTimeout={onAddTimeout} />);
+    const btn = screen.getByTestId('team-1-timeout');
+    fireEvent.keyDown(btn, { key: 'Enter' });
+    fireEvent.keyUp(btn, { key: 'Enter' });
+    act(() => { vi.advanceTimersByTime(400); });
+    expect(onAddTimeout).toHaveBeenCalledWith(1);
+  });
+
+  it('keyboard: rapid double-Enter on timeout button triggers onDoubleTapTimeout', () => {
+    const onAddTimeout = vi.fn();
+    const onDoubleTapTimeout = vi.fn();
+    render(
+      <TeamPanel
+        {...defaultProps}
+        onAddTimeout={onAddTimeout}
+        onDoubleTapTimeout={onDoubleTapTimeout}
+      />
+    );
+    const btn = screen.getByTestId('team-1-timeout');
+    fireEvent.keyDown(btn, { key: 'Enter' });
+    fireEvent.keyUp(btn, { key: 'Enter' });
+    act(() => { vi.advanceTimersByTime(100); });
+    fireEvent.keyDown(btn, { key: 'Enter' });
+    fireEvent.keyUp(btn, { key: 'Enter' });
+    expect(onDoubleTapTimeout).toHaveBeenCalledWith(1);
+    expect(onAddTimeout).not.toHaveBeenCalled();
+  });
+
   it('calls onChangeServe when serve icon clicked', () => {
     render(<TeamPanel {...defaultProps} />);
     fireEvent.click(screen.getByTestId('team-1-serve'));

--- a/frontend/src/test/useActionHistory.test.ts
+++ b/frontend/src/test/useActionHistory.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useActionHistory } from '../hooks/useActionHistory';
+import { ACTION_HISTORY_LIMIT } from '../constants';
+
+describe('useActionHistory', () => {
+  it('starts empty and not-undoable', () => {
+    const { result } = renderHook(() => useActionHistory());
+    expect(result.current.history).toEqual([]);
+    expect(result.current.canUndo).toBe(false);
+  });
+
+  it('push appends entries and flips canUndo', () => {
+    const { result } = renderHook(() => useActionHistory());
+    act(() => result.current.push({ type: 'point', team: 1 }));
+    expect(result.current.history).toEqual([{ type: 'point', team: 1 }]);
+    expect(result.current.canUndo).toBe(true);
+    act(() => result.current.push({ type: 'set', team: 2 }));
+    expect(result.current.history).toEqual([
+      { type: 'point', team: 1 },
+      { type: 'set', team: 2 },
+    ]);
+  });
+
+  it('undoLast pops the most recent entry and returns it', () => {
+    const { result } = renderHook(() => useActionHistory());
+    act(() => result.current.push({ type: 'point', team: 1 }));
+    act(() => result.current.push({ type: 'timeout', team: 2 }));
+
+    let popped: ReturnType<typeof result.current.undoLast> = null;
+    act(() => { popped = result.current.undoLast(); });
+    expect(popped).toEqual({ type: 'timeout', team: 2 });
+    expect(result.current.history).toEqual([{ type: 'point', team: 1 }]);
+  });
+
+  it('undoLast returns null when empty', () => {
+    const { result } = renderHook(() => useActionHistory());
+    let popped: ReturnType<typeof result.current.undoLast> = { type: 'point', team: 1 };
+    act(() => { popped = result.current.undoLast(); });
+    expect(popped).toBeNull();
+    expect(result.current.history).toEqual([]);
+  });
+
+  it('rapid sequential undoLast calls return distinct popped entries', () => {
+    // Verifies the ref-mirroring contract: a second call before React
+    // re-renders must still see the latest state and pop the second entry.
+    const { result } = renderHook(() => useActionHistory());
+    act(() => {
+      result.current.push({ type: 'point', team: 1 });
+      result.current.push({ type: 'set', team: 2 });
+    });
+    let firstPop: ReturnType<typeof result.current.undoLast> = null;
+    let secondPop: ReturnType<typeof result.current.undoLast> = null;
+    act(() => {
+      firstPop = result.current.undoLast();
+      secondPop = result.current.undoLast();
+    });
+    expect(firstPop).toEqual({ type: 'set', team: 2 });
+    expect(secondPop).toEqual({ type: 'point', team: 1 });
+    expect(result.current.history).toEqual([]);
+  });
+
+  it('popMatching removes the most recent entry matching type+team', () => {
+    const { result } = renderHook(() => useActionHistory());
+    act(() => {
+      result.current.push({ type: 'point', team: 1 });
+      result.current.push({ type: 'point', team: 2 });
+      result.current.push({ type: 'point', team: 1 });
+    });
+    act(() => result.current.popMatching('point', 1));
+    // Only the *most recent* matching entry is removed.
+    expect(result.current.history).toEqual([
+      { type: 'point', team: 1 },
+      { type: 'point', team: 2 },
+    ]);
+  });
+
+  it('popMatching is a no-op when no entry matches', () => {
+    const { result } = renderHook(() => useActionHistory());
+    act(() => result.current.push({ type: 'point', team: 1 }));
+    act(() => result.current.popMatching('timeout', 2));
+    expect(result.current.history).toEqual([{ type: 'point', team: 1 }]);
+  });
+
+  it('clear empties the stack', () => {
+    const { result } = renderHook(() => useActionHistory());
+    act(() => {
+      result.current.push({ type: 'point', team: 1 });
+      result.current.push({ type: 'set', team: 2 });
+    });
+    act(() => result.current.clear());
+    expect(result.current.history).toEqual([]);
+    expect(result.current.canUndo).toBe(false);
+  });
+
+  it('truncates at ACTION_HISTORY_LIMIT, evicting the oldest entry on overflow', () => {
+    const { result } = renderHook(() => useActionHistory());
+    act(() => {
+      for (let i = 0; i < ACTION_HISTORY_LIMIT; i++) {
+        result.current.push({ type: 'point', team: 1 });
+      }
+    });
+    expect(result.current.history.length).toBe(ACTION_HISTORY_LIMIT);
+
+    // Push one more — count stays at the cap, oldest entry is evicted.
+    act(() => result.current.push({ type: 'set', team: 2 }));
+    expect(result.current.history.length).toBe(ACTION_HISTORY_LIMIT);
+    // The newly-pushed entry sits at the top.
+    expect(result.current.history[result.current.history.length - 1])
+      .toEqual({ type: 'set', team: 2 });
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -105,5 +105,28 @@ export default defineConfig(async () => ({
     environment: 'jsdom',
     globals: true,
     setupFiles: './src/test/setup.ts',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov'],
+      include: ['src/**/*.{ts,tsx}'],
+      // Exclude generated types, the test harness itself, and entry shims
+      // that are exercised by integration paths but not by unit tests.
+      exclude: [
+        'src/api/schema.d.ts',
+        'src/test/**',
+        'src/main.tsx',
+        'src/PreviewApp.tsx',
+      ],
+      // Thresholds act as a regression floor — pinned tightly below
+      // current coverage at the time of introduction so a drop fails CI
+      // and a recovery pass can ratchet them upward. Bump these whenever
+      // you raise coverage; do not lower them to make CI green.
+      thresholds: {
+        lines: 72,
+        statements: 70,
+        functions: 57,
+        branches: 60,
+      },
+    },
   },
 }));


### PR DESCRIPTION
## Summary

Quality-block tranche from the v5.0.2 follow-up backlog. Three independent quality wins landed in one PR.

> **Stacked on [#209](https://github.com/JacoboSanchez/volley-overlay-control/pull/209)** — base is \`claude/quick-wins-doc-drift\` so the new hook can import \`ACTION_HISTORY_LIMIT\` from the \`constants.ts\` introduced there. Once #209 merges I'll rebase this onto \`main\` and update the PR base.

### F6 — Keyboard activation (a11y)

The score and timeout buttons used to be reachable by mouse and touch only. \`useDoubleTap\` now also returns \`onKeyDown\` / \`onKeyUp\` handlers that map **Enter** and **Space** through the same gesture pipeline:

- one press → \`onClick\` (single tap)
- two presses inside the double-tap window → \`onDoubleTap\` (undo)
- held press → \`onLongPress\` (open numeric dialog)

Closes the WCAG 2.1.1 (Keyboard) gap I'd flagged in the backlog. Five new \`ScoreButton\` cases + two new \`TeamPanel\` cases cover the keyboard paths.

### R5 — \`useActionHistory\` hook

The bounded client-side undo history (state + push + undoLast + popMatching + clear) used to live inline in \`App.tsx\`. Extracted into \`frontend/src/hooks/useActionHistory.ts\` with these properties:

- Same external behaviour — \`App.tsx\` swap is purely structural.
- The hook owns a ref mirror of the state so successive \`undoLast\` calls before React re-renders still see the latest stack. This was the trickiest correctness aspect of the original inline implementation; it now has explicit test coverage.
- 9 new dedicated unit tests — most importantly the cap-truncation path (which had no coverage before) and the rapid-undo path.

### E9 — Frontend coverage gate

Vitest now runs with the v8 coverage provider on every PR via \`npm run test:coverage\`. Thresholds are pinned tightly **below current totals** so they act as a **regression floor**, not a wishlist:

| metric | current | gate | slack |
|---|---|---|---|
| lines | 73.24% | 72 | 1.2pp |
| statements | 70.9% | 70 | 0.9pp |
| functions | 58.61% | 57 | 1.6pp |
| branches | 60.67% | 60 | 0.7pp |

A comment in \`vite.config.js\` instructs future contributors to **bump the thresholds upward** when they raise coverage and to never lower them. CI uploads \`frontend/coverage/lcov.info\` as an artifact alongside the existing backend coverage XML.

## Test plan

- [x] \`cd frontend && npx tsc --noEmit\` — clean
- [x] \`cd frontend && npm run test:coverage\` — 232 tests pass, all four thresholds met
- [x] 16 new tests broken down: 9 \`useActionHistory\` + 5 keyboard \`ScoreButton\` + 2 keyboard \`TeamPanel\` timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)