### PR TITLE
fix(mosaic): scale grid to fit viewport without scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Changed
+
+- The `mosaic` overlay style (`/overlay/{id}?style=mosaic`) now scales to
+  fit the current viewport without scrolling. The grid picks the best
+  cols × rows split for the number of available styles, and each
+  preview iframe is cropped to its reported render bounds and centred
+  inside its cell, so all styles are visible at once and re-fit on
+  window resize. Previously the page used a fixed 580px-min column with
+  a 200px height cap, producing a vertically scrolling list once more
+  than a few styles were available.
+
 ---
 
 ## [5.0.3] - 2026-04-30

--- a/overlay_static/css/mosaic.css
+++ b/overlay_static/css/mosaic.css
@@ -1,25 +1,36 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
 
+html,
 body {
     margin: 0;
-    padding: 20px;
+    padding: 0;
+    height: 100%;
+    width: 100%;
+}
+
+body {
     background: transparent;
     font-family: 'Inter', sans-serif;
-    min-height: 100vh;
+    overflow: hidden;
     box-sizing: border-box;
 }
 
 .mosaic-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(580px, 1fr));
-    gap: 20px;
-    max-width: 1920px;
-    margin: 0 auto;
+    gap: 8px;
+    padding: 8px;
+    width: 100vw;
+    height: 100vh;
+    box-sizing: border-box;
+    /* grid-template-columns / -rows are set by JS to fit the viewport */
 }
 
 .mosaic-cell {
     position: relative;
     overflow: hidden;
+    /* Allow grid tracks to shrink below intrinsic content size */
+    min-width: 0;
+    min-height: 0;
 }
 
 .mosaic-label {
@@ -64,10 +75,8 @@ body {
 .mosaic-iframe-wrapper {
     position: relative;
     width: 100%;
-    /* Initial height — JS will resize once overlay bounds are reported */
-    height: 120px;
+    height: 100%;
     overflow: hidden;
-    transition: height 0.4s ease;
 }
 
 .mosaic-iframe-wrapper iframe {
@@ -77,6 +86,6 @@ body {
     width: 1920px;
     height: 1080px;
     border: none;
-    transform-origin: top left;
-    /* Scale down to fit the cell; JS will calculate exact scale */
+    transform-origin: 0 0;
+    /* JS sets the transform to crop + scale + centre into the cell. */
 }

--- a/overlay_static/css/mosaic.css
+++ b/overlay_static/css/mosaic.css
@@ -6,12 +6,14 @@ body {
     padding: 0;
     height: 100%;
     width: 100%;
+    /* overflow: hidden on html as well — some mobile browsers don't
+       propagate body overflow to the viewport. */
+    overflow: hidden;
 }
 
 body {
     background: transparent;
     font-family: 'Inter', sans-serif;
-    overflow: hidden;
     box-sizing: border-box;
 }
 
@@ -19,9 +21,17 @@ body {
     display: grid;
     gap: 8px;
     padding: 8px;
+    box-sizing: border-box;
+    /* Anchor to the visible viewport. position:fixed + inset:0 keeps the
+       grid pinned even if html/body sizing is wonky on mobile. dvh/dvw
+       track the dynamic viewport (URL bar collapse) so the grid resizes
+       with the visible area instead of overflowing under the chrome. */
+    position: fixed;
+    inset: 0;
     width: 100vw;
     height: 100vh;
-    box-sizing: border-box;
+    width: 100dvw;
+    height: 100dvh;
     /* grid-template-columns / -rows are set by JS to fit the viewport */
 }
 

--- a/overlay_templates/mosaic.html
+++ b/overlay_templates/mosaic.html
@@ -153,13 +153,19 @@
 
         // Outer rAF debounces a burst of resize events into one relayout.
         let resizeRaf = 0;
-        window.addEventListener("resize", () => {
+        function scheduleRelayout() {
             if (resizeRaf) cancelAnimationFrame(resizeRaf);
             resizeRaf = requestAnimationFrame(() => {
                 applyLayout();
                 scaleAllToCells();
             });
-        });
+        }
+        window.addEventListener("resize", scheduleRelayout);
+        // visualViewport fires on mobile URL-bar collapse; window.resize
+        // doesn't always fire for that on iOS Safari, so listen to both.
+        if (window.visualViewport) {
+            window.visualViewport.addEventListener("resize", scheduleRelayout);
+        }
 
         buildGrid(AVAILABLE_STYLES);
     </script>

--- a/overlay_templates/mosaic.html
+++ b/overlay_templates/mosaic.html
@@ -20,12 +20,54 @@
         // OVERLAY_SERVER_TOKEN).
         const AVAILABLE_STYLES = {{ available_styles | tojson }};
 
+        const OVERLAY_W = 1920;
+        const OVERLAY_H = 1080;
+        // Padding inside the 1920×1080 viewport that we add around the
+        // reported overlay bounds so the cropped slice has a small margin.
+        const BOUNDS_PAD = 15;
+
         // Track render bounds reported by each iframe (style → bounds)
         const iframeBounds = new Map();
+
+        // Choose (cols, rows) so all N cells fit the viewport while
+        // maximising the rendered overlay area. We optimise for the
+        // 16:9 native overlay aspect; per-cell cropping then refits each
+        // iframe once its true bounds arrive.
+        function chooseLayout(n, vw, vh) {
+            const aspect = OVERLAY_W / OVERLAY_H;
+            let best = { cols: 1, rows: n, score: -1 };
+            for (let cols = 1; cols <= n; cols++) {
+                const rows = Math.ceil(n / cols);
+                const cellW = vw / cols;
+                const cellH = vh / rows;
+                if (cellW <= 0 || cellH <= 0) continue;
+                // Largest 16:9 box that fits the cell — taller is better.
+                const renderedH = Math.min(cellH, cellW / aspect);
+                if (renderedH > best.score) {
+                    best = { cols, rows, score: renderedH };
+                }
+            }
+            return best;
+        }
+
+        function applyLayout() {
+            const grid = document.getElementById("mosaic-grid");
+            const styles = grid.dataset.styles
+                ? JSON.parse(grid.dataset.styles)
+                : AVAILABLE_STYLES;
+            const rect = grid.getBoundingClientRect();
+            // Fall back to viewport if the grid has not laid out yet.
+            const vw = rect.width || window.innerWidth;
+            const vh = rect.height || window.innerHeight;
+            const { cols, rows } = chooseLayout(styles.length, vw, vh);
+            grid.style.gridTemplateColumns = `repeat(${cols}, minmax(0, 1fr))`;
+            grid.style.gridTemplateRows = `repeat(${rows}, minmax(0, 1fr))`;
+        }
 
         function buildGrid(styles) {
             const grid = document.getElementById("mosaic-grid");
             grid.innerHTML = "";
+            grid.dataset.styles = JSON.stringify(styles);
 
             styles.forEach(style => {
                 const cell = document.createElement("div");
@@ -49,38 +91,45 @@
                 cell.appendChild(wrapper);
                 grid.appendChild(cell);
             });
+
+            applyLayout();
+            // After the grid lays out, fit each iframe into its cell.
+            requestAnimationFrame(scaleAllToCells);
         }
 
-        // Max cell height in px — tall overlays (e.g. vertical) are scaled down to stay within this
-        const MAX_CELL_HEIGHT = 200;
-
-        function cropToOverlay(iframe, bounds) {
+        function fitIframeToCell(iframe) {
             const wrapper = iframe.parentElement;
             if (!wrapper) return;
+            const cw = wrapper.clientWidth;
+            const ch = wrapper.clientHeight;
+            if (cw <= 0 || ch <= 0) return;
 
-            // Padding around the overlay area
-            const pad = 15;
-            const ox = Math.max(0, bounds.x - pad);
-            const oy = Math.max(0, bounds.y - pad);
-            const ow = Math.min(1920 - ox, bounds.width + pad * 2);
-            const oh = Math.min(1080 - oy, bounds.height + pad * 2);
-
+            const bounds = iframeBounds.get(iframe.dataset.style);
+            let ox = 0;
+            let oy = 0;
+            let ow = OVERLAY_W;
+            let oh = OVERLAY_H;
+            if (bounds && bounds.width > 0 && bounds.height > 0) {
+                ox = Math.max(0, bounds.x - BOUNDS_PAD);
+                oy = Math.max(0, bounds.y - BOUNDS_PAD);
+                ow = Math.min(OVERLAY_W - ox, bounds.width + BOUNDS_PAD * 2);
+                oh = Math.min(OVERLAY_H - oy, bounds.height + BOUNDS_PAD * 2);
+            }
             if (ow <= 0 || oh <= 0) return;
 
-            // Scale to fit width, but also cap by MAX_CELL_HEIGHT so tall overlays
-            // don't dominate the grid — use whichever scale is smaller.
-            const cellWidth = wrapper.clientWidth;
-            const scaleW = cellWidth / ow;
-            const scaleH = MAX_CELL_HEIGHT / oh;
-            const scale = Math.min(scaleW, scaleH);
+            const scale = Math.min(cw / ow, ch / oh);
+            // Centre the cropped slice inside the cell.
+            const tx = (cw - ow * scale) / 2;
+            const ty = (ch - oh * scale) / 2;
+            // Right-to-left: translate(-ox,-oy) → scale → translate(tx,ty).
+            iframe.style.transform =
+                `translate(${tx}px, ${ty}px) scale(${scale}) translate(${-ox}px, ${-oy}px)`;
+        }
 
-            // Set wrapper height to match the cropped aspect ratio
-            wrapper.style.height = Math.round(oh * scale) + "px";
-
-            // Transform: first translate the overlay to (0,0), then scale down.
-            // CSS transforms apply right-to-left, so translate runs first.
-            iframe.style.transformOrigin = "0 0";
-            iframe.style.transform = `scale(${scale}) translate(${-ox}px, ${-oy}px)`;
+        function scaleAllToCells() {
+            document
+                .querySelectorAll(".mosaic-iframe-wrapper iframe")
+                .forEach(fitIframeToCell);
         }
 
         // Listen for render-area reports from overlay iframes (sent by app.js reportRenderArea)
@@ -93,17 +142,19 @@
             for (const iframe of iframes) {
                 if (iframe.contentWindow === event.source) {
                     iframeBounds.set(iframe.dataset.style, bounds);
-                    cropToOverlay(iframe, bounds);
+                    fitIframeToCell(iframe);
                     break;
                 }
             }
         });
 
-        // Recalculate on resize
+        // Recalculate layout + scaling on viewport changes.
+        let resizeRaf = 0;
         window.addEventListener("resize", () => {
-            document.querySelectorAll(".mosaic-iframe-wrapper iframe").forEach(iframe => {
-                const bounds = iframeBounds.get(iframe.dataset.style);
-                if (bounds) cropToOverlay(iframe, bounds);
+            if (resizeRaf) cancelAnimationFrame(resizeRaf);
+            resizeRaf = requestAnimationFrame(() => {
+                applyLayout();
+                requestAnimationFrame(scaleAllToCells);
             });
         });
 

--- a/overlay_templates/mosaic.html
+++ b/overlay_templates/mosaic.html
@@ -93,8 +93,10 @@
             });
 
             applyLayout();
-            // After the grid lays out, fit each iframe into its cell.
-            requestAnimationFrame(scaleAllToCells);
+            // fitIframeToCell reads clientWidth/Height, which flushes layout
+            // synchronously — no rAF needed, and skipping it avoids a paint
+            // where cells are sized but iframes are still at their old scale.
+            scaleAllToCells();
         }
 
         function fitIframeToCell(iframe) {
@@ -154,7 +156,7 @@
             if (resizeRaf) cancelAnimationFrame(resizeRaf);
             resizeRaf = requestAnimationFrame(() => {
                 applyLayout();
-                requestAnimationFrame(scaleAllToCells);
+                scaleAllToCells();
             });
         });
 

--- a/overlay_templates/mosaic.html
+++ b/overlay_templates/mosaic.html
@@ -26,13 +26,12 @@
         // reported overlay bounds so the cropped slice has a small margin.
         const BOUNDS_PAD = 15;
 
-        // Track render bounds reported by each iframe (style → bounds)
+        // style → bounds reported by each iframe via postMessage
         const iframeBounds = new Map();
 
-        // Choose (cols, rows) so all N cells fit the viewport while
-        // maximising the rendered overlay area. We optimise for the
-        // 16:9 native overlay aspect; per-cell cropping then refits each
-        // iframe once its true bounds arrive.
+        // Pick (cols, rows) optimised for 16:9, the native overlay surface.
+        // Per-cell cropping then refits each iframe once its true bounds
+        // arrive, so the 16:9 bias only affects the grid split, not fidelity.
         function chooseLayout(n, vw, vh) {
             const aspect = OVERLAY_W / OVERLAY_H;
             let best = { cols: 1, rows: n, score: -1 };
@@ -51,15 +50,18 @@
         }
 
         function applyLayout() {
+            const n = AVAILABLE_STYLES.length;
+            if (n === 0) return;
             const grid = document.getElementById("mosaic-grid");
-            const styles = grid.dataset.styles
-                ? JSON.parse(grid.dataset.styles)
-                : AVAILABLE_STYLES;
-            const rect = grid.getBoundingClientRect();
-            // Fall back to viewport if the grid has not laid out yet.
-            const vw = rect.width || window.innerWidth;
-            const vh = rect.height || window.innerHeight;
-            const { cols, rows } = chooseLayout(styles.length, vw, vh);
+            // clientWidth/Height already exclude borders/scrollbars; subtract
+            // the grid's own padding to get the content box (where 1fr tracks
+            // are sized). Fall back to the viewport before first layout.
+            const cs = getComputedStyle(grid);
+            const padX = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight);
+            const padY = parseFloat(cs.paddingTop) + parseFloat(cs.paddingBottom);
+            const vw = (grid.clientWidth || window.innerWidth) - padX;
+            const vh = (grid.clientHeight || window.innerHeight) - padY;
+            const { cols, rows } = chooseLayout(n, vw, vh);
             grid.style.gridTemplateColumns = `repeat(${cols}, minmax(0, 1fr))`;
             grid.style.gridTemplateRows = `repeat(${rows}, minmax(0, 1fr))`;
         }
@@ -67,7 +69,6 @@
         function buildGrid(styles) {
             const grid = document.getElementById("mosaic-grid");
             grid.innerHTML = "";
-            grid.dataset.styles = JSON.stringify(styles);
 
             styles.forEach(style => {
                 const cell = document.createElement("div");
@@ -120,10 +121,10 @@
             if (ow <= 0 || oh <= 0) return;
 
             const scale = Math.min(cw / ow, ch / oh);
-            // Centre the cropped slice inside the cell.
             const tx = (cw - ow * scale) / 2;
             const ty = (ch - oh * scale) / 2;
-            // Right-to-left: translate(-ox,-oy) → scale → translate(tx,ty).
+            // CSS transforms apply right-to-left, so the translate(-ox,-oy)
+            // shifts the cropped region to the origin before scaling.
             iframe.style.transform =
                 `translate(${tx}px, ${ty}px) scale(${scale}) translate(${-ox}px, ${-oy}px)`;
         }
@@ -150,7 +151,7 @@
             }
         });
 
-        // Recalculate layout + scaling on viewport changes.
+        // Outer rAF debounces a burst of resize events into one relayout.
         let resizeRaf = 0;
         window.addEventListener("resize", () => {
             if (resizeRaf) cancelAnimationFrame(resizeRaf);


### PR DESCRIPTION
Pick cols x rows that maximise rendered overlay area for the number of
available styles, give the grid the full viewport, and centre each
cropped iframe inside its cell. Re-fit on resize. Replaces the prior
fixed 580px-min column / 200px-cap layout that scrolled vertically once
more than a few styles existed.