### PR TITLE
feat(layout): inline score history for landscape phones with preview

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -239,6 +239,17 @@ body {
   gap: 0.5rem;
 }
 
+/* Landscape compact: score button + history-col sit side-by-side, with the
+   history pinned to the side closest to the centre (right of team 1, left
+   of team 2). Used when CenterPanel needs to free up space for alert pills.
+   The team-panel-col still stacks this row above the timeout/serve row. */
+.team-score-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 /* Score history column (logo + per-set scores) — portrait only */
 .team-history-col {
   display: flex;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -365,6 +365,13 @@ export default function App() {
           buttonSize={buttonSize}
           previewData={previewData}
           showPreview={settings.showPreview}
+          // Landscape compact: phones in landscape with the preview enabled
+          // don't have room in CenterPanel for both score tables AND the new
+          // alert pills. Move the per-team score history into the team panels
+          // (matching portrait's layout) and free CenterPanel for the alerts.
+          inlineScoreHistory={
+            !isPortrait && !hasRoomForPersistentControls && settings.showPreview
+          }
           showControls={showControls}
           setShowControls={setShowControls}
           canUndo={state?.can_undo ?? false}

--- a/frontend/src/components/CenterPanel.tsx
+++ b/frontend/src/components/CenterPanel.tsx
@@ -23,6 +23,14 @@ export interface CenterPanelProps {
   currentSet: number;
   setsLimit: number;
   isPortrait: boolean;
+  /**
+   * When true (landscape compact), the per-team score tables are
+   * rendered inside each TeamPanel instead of here, so the alert pills
+   * have room to breathe in the centre. Independent of ``isPortrait``
+   * because portrait already routes the tables to TeamPanel via a
+   * different code path.
+   */
+  inlineScoreHistory?: boolean;
   previewData: PreviewData | null | undefined;
   fontStyle?: ScoreButtonFontStyle;
   onAddSet: (teamId: 1 | 2) => void;
@@ -36,6 +44,7 @@ export default function CenterPanel({
   currentSet,
   setsLimit,
   isPortrait,
+  inlineScoreHistory = false,
   previewData,
   fontStyle,
   onAddSet,
@@ -65,7 +74,7 @@ export default function CenterPanel({
           data-testid="team-1-sets"
         />
 
-        {!isPortrait && (
+        {!isPortrait && !inlineScoreHistory && (
           <div className="logos-scores-section">
             <div className="team-score-column">
               {logo1 && (

--- a/frontend/src/components/ScoreboardView.tsx
+++ b/frontend/src/components/ScoreboardView.tsx
@@ -24,6 +24,14 @@ export interface ScoreboardViewProps {
   buttonSize?: number;
   previewData: PreviewData | null | undefined;
   showPreview: boolean;
+  /**
+   * When true, the per-team score history is rendered next to each
+   * team's score button (on the side closest to centre) instead of in
+   * CenterPanel. Used for landscape phones with the preview enabled,
+   * where CenterPanel doesn't have room for both the tables and the
+   * alert pills.
+   */
+  inlineScoreHistory: boolean;
   showControls: boolean;
   setShowControls: Dispatch<SetStateAction<boolean>>;
   canUndo: boolean;
@@ -65,6 +73,7 @@ export default function ScoreboardView({
   buttonSize,
   previewData,
   showPreview,
+  inlineScoreHistory,
   showControls,
   setShowControls,
   canUndo,
@@ -111,6 +120,7 @@ export default function ScoreboardView({
           timeoutColor={TEAM_A_LIGHT}
           buttonSize={buttonSize}
           isPortrait={isPortrait}
+          inlineScoreHistory={inlineScoreHistory}
           iconLogo={iconLogoA}
           iconOpacity={iconOpacity}
           fontStyle={fontStyle}
@@ -131,6 +141,7 @@ export default function ScoreboardView({
           currentSet={currentSet}
           setsLimit={setsLimit}
           isPortrait={isPortrait}
+          inlineScoreHistory={inlineScoreHistory}
           previewData={showPreview ? previewData : null}
           fontStyle={fontStyle}
           onAddSet={onAddSet}
@@ -148,6 +159,7 @@ export default function ScoreboardView({
           timeoutColor={TEAM_B_LIGHT}
           buttonSize={buttonSize}
           isPortrait={isPortrait}
+          inlineScoreHistory={inlineScoreHistory}
           iconLogo={iconLogoB}
           iconOpacity={iconOpacity}
           fontStyle={fontStyle}

--- a/frontend/src/components/TeamPanel.tsx
+++ b/frontend/src/components/TeamPanel.tsx
@@ -19,6 +19,13 @@ export interface TeamPanelProps {
   timeoutColor: string;
   buttonSize?: number;
   isPortrait: boolean;
+  /**
+   * In landscape, when true, render the per-team score history next to
+   * the score button instead of relying on CenterPanel to host it. The
+   * history sits on the side closest to the centre — right of the
+   * button for team 1, left for team 2.
+   */
+  inlineScoreHistory?: boolean;
   iconLogo?: string | null;
   iconOpacity?: number;
   fontStyle?: ScoreButtonFontStyle;
@@ -56,6 +63,7 @@ export default function TeamPanel({
   timeoutColor,
   buttonSize,
   isPortrait,
+  inlineScoreHistory = false,
   iconLogo,
   iconOpacity = 50,
   fontStyle,
@@ -134,41 +142,62 @@ export default function TeamPanel({
 
   const teamLogo = asString(customization?.[`Team ${teamId} Logo`]);
 
+  const historyBlock = state ? (
+    <div className="team-history-col">
+      {teamLogo && (
+        <img
+          src={teamLogo}
+          alt={`Team ${teamId}`}
+          className="team-logo"
+          data-testid={`team-${teamId}-logo`}
+        />
+      )}
+      <ScoreTable
+        state={state}
+        setsLimit={setsLimit}
+        currentSet={currentSet}
+        teamId={teamId}
+      />
+    </div>
+  ) : null;
+
+  const scoreButton = (
+    <ScoreButton
+      text={scoreText}
+      color={buttonColor}
+      textColor={buttonTextColor}
+      size={buttonSize}
+      fontStyle={fontStyle}
+      style={iconStyle}
+      onClick={handleAddPoint}
+      onDoubleTap={handleDoubleTap}
+      onLongPress={handleLongPress}
+      aria-label={scoreAriaLabel}
+      aria-describedby={scoreDescId}
+      data-testid={`team-${teamId}-score`}
+    />
+  );
+
+  // In landscape compact mode, the history rides next to the button on
+  // the side closest to the centre — right of team 1, left of team 2.
+  const renderInlineLandscapeHistory = !isPortrait && inlineScoreHistory && historyBlock;
+
   return (
     <div className={`team-panel ${isPortrait ? 'team-panel-portrait' : 'team-panel-landscape'}`}>
       <div className={isPortrait ? 'team-panel-row' : 'team-panel-col'}>
-        {isPortrait && state && (
-          <div className="team-history-col">
-            {teamLogo && (
-              <img
-                src={teamLogo}
-                alt={`Team ${teamId}`}
-                className="team-logo"
-                data-testid={`team-${teamId}-logo`}
-              />
-            )}
-            <ScoreTable
-              state={state}
-              setsLimit={setsLimit}
-              currentSet={currentSet}
-              teamId={teamId}
-            />
+        {isPortrait && historyBlock}
+        {renderInlineLandscapeHistory ? (
+          <div
+            className={`team-score-row team-score-row-team-${teamId}`}
+            data-testid={`team-${teamId}-score-row`}
+          >
+            {teamId === 2 && historyBlock}
+            {scoreButton}
+            {teamId === 1 && historyBlock}
           </div>
+        ) : (
+          scoreButton
         )}
-        <ScoreButton
-          text={scoreText}
-          color={buttonColor}
-          textColor={buttonTextColor}
-          size={buttonSize}
-          fontStyle={fontStyle}
-          style={iconStyle}
-          onClick={handleAddPoint}
-          onDoubleTap={handleDoubleTap}
-          onLongPress={handleLongPress}
-          aria-label={scoreAriaLabel}
-          aria-describedby={scoreDescId}
-          data-testid={`team-${teamId}-score`}
-        />
         <span id={scoreDescId} className="visually-hidden">
           Tap to add point, double-tap to undo, long-press to set value.
         </span>

--- a/frontend/src/components/TeamPanel.tsx
+++ b/frontend/src/components/TeamPanel.tsx
@@ -180,15 +180,17 @@ export default function TeamPanel({
 
   // In landscape compact mode, the history rides next to the button on
   // the side closest to the centre — right of team 1, left of team 2.
-  const renderInlineLandscapeHistory = !isPortrait && inlineScoreHistory && historyBlock;
+  // ``state`` may be null on first load; fall back to the bare button.
+  const showInlineLandscapeHistory =
+    !isPortrait && inlineScoreHistory && historyBlock !== null;
 
   return (
     <div className={`team-panel ${isPortrait ? 'team-panel-portrait' : 'team-panel-landscape'}`}>
       <div className={isPortrait ? 'team-panel-row' : 'team-panel-col'}>
         {isPortrait && historyBlock}
-        {renderInlineLandscapeHistory ? (
+        {showInlineLandscapeHistory ? (
           <div
-            className={`team-score-row team-score-row-team-${teamId}`}
+            className="team-score-row"
             data-testid={`team-${teamId}-score-row`}
           >
             {teamId === 2 && historyBlock}

--- a/frontend/src/test/CenterPanel.test.tsx
+++ b/frontend/src/test/CenterPanel.test.tsx
@@ -120,4 +120,19 @@ describe('CenterPanel', () => {
     expect(screen.queryByTestId('team-1-logo')).not.toBeInTheDocument();
     expect(screen.queryByTestId('team-2-logo')).not.toBeInTheDocument();
   });
+
+  it('hides the in-centre score tables when inlineScoreHistory is true (landscape compact)', () => {
+    const cust = { ...mockCustomization, 'Team 1 Logo': 'logo1.png', 'Team 2 Logo': 'logo2.png' };
+    const { container } = renderWithI18n(
+      <CenterPanel
+        {...defaultProps}
+        customization={cust}
+        isPortrait={false}
+        inlineScoreHistory={true}
+      />,
+    );
+    // The logos-scores-section is the wrapper for the per-team tables;
+    // it should disappear when the tables are hosted by TeamPanel instead.
+    expect(container.querySelector('.logos-scores-section')).toBeNull();
+  });
 });

--- a/frontend/src/test/TeamPanel.test.tsx
+++ b/frontend/src/test/TeamPanel.test.tsx
@@ -232,5 +232,20 @@ describe('TeamPanel', () => {
       // History-col is still rendered (portrait has always shown it).
       expect(container.querySelector('.team-history-col')).not.toBeNull();
     });
+
+    it('falls back to the bare score button when state is null in compact mode', () => {
+      const { container } = render(
+        <TeamPanel
+          {...defaultProps}
+          isPortrait={false}
+          inlineScoreHistory={true}
+          state={null}
+        />,
+      );
+      // No history-col to render → no inline wrapper, just the button.
+      expect(container.querySelector('.team-score-row')).toBeNull();
+      expect(container.querySelector('.team-history-col')).toBeNull();
+      expect(screen.getByTestId('team-1-score')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/test/TeamPanel.test.tsx
+++ b/frontend/src/test/TeamPanel.test.tsx
@@ -167,4 +167,70 @@ describe('TeamPanel', () => {
     render(<TeamPanel {...defaultProps} teamState={{ ...baseTeamState, scores: { set_2: 3 } }} />);
     expect(screen.getByTestId('team-1-score')).toHaveTextContent('03');
   });
+
+  describe('inlineScoreHistory (landscape compact)', () => {
+    it('renders no score row in landscape when inlineScoreHistory is false', () => {
+      const { container } = render(
+        <TeamPanel {...defaultProps} isPortrait={false} inlineScoreHistory={false} />,
+      );
+      expect(container.querySelector('.team-score-row')).toBeNull();
+    });
+
+    it('renders the inline score row in landscape when inlineScoreHistory is true', () => {
+      render(
+        <TeamPanel {...defaultProps} isPortrait={false} inlineScoreHistory={true} />,
+      );
+      expect(screen.getByTestId('team-1-score-row')).toBeInTheDocument();
+    });
+
+    it('places history-col after the score button for team 1 (right of button)', () => {
+      const { container } = render(
+        <TeamPanel
+          {...defaultProps}
+          teamId={1}
+          isPortrait={false}
+          inlineScoreHistory={true}
+        />,
+      );
+      const row = screen.getByTestId('team-1-score-row');
+      const button = container.querySelector('[data-testid="team-1-score"]');
+      const history = row.querySelector('.team-history-col');
+      expect(button).not.toBeNull();
+      expect(history).not.toBeNull();
+      // DOM order: button first, history-col second → history sits to the right.
+      const children = Array.from(row.children);
+      expect(children.indexOf(button as Element))
+        .toBeLessThan(children.indexOf(history as Element));
+    });
+
+    it('places history-col before the score button for team 2 (left of button)', () => {
+      const { container } = render(
+        <TeamPanel
+          {...defaultProps}
+          teamId={2}
+          isPortrait={false}
+          inlineScoreHistory={true}
+        />,
+      );
+      const row = screen.getByTestId('team-2-score-row');
+      const button = container.querySelector('[data-testid="team-2-score"]');
+      const history = row.querySelector('.team-history-col');
+      expect(button).not.toBeNull();
+      expect(history).not.toBeNull();
+      // DOM order: history-col first, button second → history sits to the left.
+      const children = Array.from(row.children);
+      expect(children.indexOf(history as Element))
+        .toBeLessThan(children.indexOf(button as Element));
+    });
+
+    it('inlineScoreHistory has no effect in portrait', () => {
+      const { container } = render(
+        <TeamPanel {...defaultProps} isPortrait={true} inlineScoreHistory={true} />,
+      );
+      // Portrait keeps its existing layout — no team-score-row wrapper.
+      expect(container.querySelector('.team-score-row')).toBeNull();
+      // History-col is still rendered (portrait has always shown it).
+      expect(container.querySelector('.team-history-col')).not.toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Phones in landscape with the preview enabled don't have room in `CenterPanel` for both the per-team score tables and the new alert pills (`MatchAlertIndicator`, `SideSwitchIndicator`). When that combination triggers — `!isPortrait && !hasRoomForPersistentControls && showPreview` — move the score history out of `CenterPanel` and into each `TeamPanel`, mirroring portrait's existing layout. The pinned position is the side closest to the centre: history-col to the right of team 1's score button, to the left of team 2's, so the operator's eye stays drawn to the middle of the scoreboard.

The flag (`inlineScoreHistory`) is computed once in `App`, threaded through `ScoreboardView`, and consumed by both:

- `TeamPanel` — wraps `ScoreButton` + `ScoreTable` in a new `team-score-row` flex row, swapping DOM order based on `teamId` to put the history on the centre side.
- `CenterPanel` — skips its `logos-scores-section` (the in-centre tables would just duplicate what's now in the team panels).

Portrait behaviour is unchanged. Landscape with room (tablet/desktop, or no preview) is also unchanged.

## Self-review notes

- Dropped a dead `team-score-row-team-${teamId}` modifier class — DOM order is what positions the history, no per-team CSS hook was actually needed.
- Renamed the gating predicate to `showInlineLandscapeHistory` (was `renderInlineLandscapeHistory`, which read like a JSX node).
- Added a null-state fallback test: when `state` is null in compact mode, render just the bare score button rather than an empty `team-score-row` wrapper.

## Test plan

- [x] `npx vitest run` — 259 passed (6 new in `TeamPanel.test.tsx` + 1 new in `CenterPanel.test.tsx`).
- [x] `npm run typecheck` — clean.
- [x] `npm run build` — clean.
- [ ] Manual: phone in landscape with preview on — verify the history-col rides next to each score button on the centre-facing side, and CenterPanel only shows the alert pills + sets row + preview.
- [ ] Manual: tablet in landscape — verify the history stays in CenterPanel (no regression on `hasRoomForPersistentControls=true` devices).
- [ ] Manual: portrait on phone — verify nothing visible changed.
- [ ] Manual: phone in landscape with preview *off* — verify CenterPanel keeps the score tables (compact mode shouldn't trigger).

https://claude.ai/code/session_01FCxQ4d65nUndLT2iCxmFoN

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCxQ4d65nUndLT2iCxmFoN)_