### PR TITLE
feat(rules): indoor deciding-set midpoint alert (frontend-driven)

### DIFF
--- a/app/api/match_rules.py
+++ b/app/api/match_rules.py
@@ -14,15 +14,16 @@ Indoor:
   * 25 points per set (must win by 2)
   * 15 points in the deciding set
   * Best of 5
+  * Side switch in the deciding set when the leading team first
+    reaches the midpoint of its target (8 of 15). Computed entirely
+    on the client as a transient alert — the backend just exposes
+    the limits in ``config`` so the UI can derive the trigger.
 
 Beach:
   * 21 points per set (must win by 2)
   * 15 points in the deciding set
   * Best of 3
-  * Side switch every 7 points (every 5 in the tiebreak), plus a
-    one-off switch in the deciding set when either team reaches the
-    midpoint of its target (FIVB indoor 5th-set rule, applied here so
-    operators get a dedicated alert at e.g. 8 of 15).
+  * Side switch every 7 points (every 5 in the tiebreak)
 """
 
 from __future__ import annotations
@@ -104,17 +105,6 @@ def side_switch_interval(
     return 5 if target <= 15 else 7
 
 
-def _last_set_midpoint(points_limit_last_set: int) -> int:
-    """Half of the deciding-set target, rounded up (15 → 8).
-
-    Returns 0 for non-positive targets so callers can use it as a
-    "midpoint rule disabled" sentinel without an extra branch.
-    """
-    if points_limit_last_set <= 0:
-        return 0
-    return (points_limit_last_set + 1) // 2
-
-
 def compute_side_switch(
     *, mode: str, current_set: int, sets_limit: int,
     team1_score: int, team2_score: int,
@@ -123,16 +113,9 @@ def compute_side_switch(
     """Return the beach side-switch indicator for the current set.
 
     Returns ``None`` for non-beach modes — callers attach the field
-    only when present, so the indoor payload stays unchanged.
-
-    The pending flag fires for two reasons, OR-ed together:
-
-    * Combined-cadence boundary: the current combined score is a
-      non-zero multiple of ``interval``.
-    * Deciding-set midpoint: in the last set, when the leading team
-      first reaches ``ceil(points_limit_last_set / 2)`` (8 for 15).
-      The flag stays on until the trailing team also reaches that
-      score — at which point both have crossed and the alert clears.
+    only when present, so the indoor payload stays unchanged. (Indoor
+    has a separate, transient deciding-set midpoint alert that the
+    frontend computes from consecutive state diffs.)
     """
     if mode != "beach":
         return None
@@ -140,9 +123,7 @@ def compute_side_switch(
         current_set=current_set, sets_limit=sets_limit,
         points_limit=points_limit, points_limit_last_set=points_limit_last_set,
     )
-    t1 = max(0, int(team1_score))
-    t2 = max(0, int(team2_score))
-    points_in_set = t1 + t2
+    points_in_set = max(0, int(team1_score)) + max(0, int(team2_score))
     # ``next_switch_at`` is the smallest multiple of *interval* that is
     # strictly greater than the current total — so when the total is
     # exactly on the boundary, we advance to the next one. This matches
@@ -152,21 +133,6 @@ def compute_side_switch(
         next_switch_at = interval
     else:
         next_switch_at = ((points_in_set // interval) + 1) * interval
-    cadence_pending = points_in_set > 0 and points_in_set % interval == 0
-
-    # Deciding-set midpoint rule (FIVB indoor 5th-set semantic). Fires
-    # from the moment the leading team crosses the midpoint until the
-    # trailing team also reaches it — that way the alert persists as a
-    # reminder if the leader scores past it before the opponent catches
-    # up (e.g. 8-0 → 9-0 keeps firing). Once both have crossed there's
-    # no second switch this set, so the alert clears.
-    is_last_set = current_set >= sets_limit
-    midpoint = _last_set_midpoint(points_limit_last_set) if is_last_set else 0
-    midpoint_pending = (
-        is_last_set and midpoint > 0
-        and max(t1, t2) >= midpoint and min(t1, t2) < midpoint
-    )
-
     return {
         "interval": interval,
         "points_in_set": points_in_set,
@@ -174,7 +140,9 @@ def compute_side_switch(
         "points_until_switch": next_switch_at - points_in_set,
         # ``is_switch_pending`` flags the moment the most recent point
         # crossed a boundary — the operator should swap sides now.
-        "is_switch_pending": cadence_pending or midpoint_pending,
+        "is_switch_pending": (
+            points_in_set > 0 and points_in_set % interval == 0
+        ),
     }
 
 

--- a/frontend/src/components/CenterPanel.tsx
+++ b/frontend/src/components/CenterPanel.tsx
@@ -6,6 +6,7 @@ import SideSwitchIndicator from './SideSwitchIndicator';
 import MatchAlertIndicator from './MatchAlertIndicator';
 import type { GameState } from '../api/client';
 import type { ConfigModel } from './TeamCard';
+import { useIndoorMidpointAlert } from '../hooks/useIndoorMidpointAlert';
 import { asString } from '../utils/coerce';
 
 export interface PreviewData {
@@ -53,6 +54,10 @@ export default function CenterPanel({
   onLongPressSet,
   onSetChange,
 }: CenterPanelProps) {
+  // Hooks must run before any early return — the hook itself handles
+  // a null/undefined state by returning ``false``.
+  const indoorMidpointPending = useIndoorMidpointAlert(state, currentSet, setsLimit);
+
   if (!state) return null;
 
   const t1Sets = state.team_1.sets;
@@ -145,7 +150,10 @@ export default function CenterPanel({
       <div className="match-alerts-row" data-testid="match-alerts-row">
         <MatchAlertIndicator state={state} />
         {!state.match_finished && (
-          <SideSwitchIndicator info={state.beach_side_switch} />
+          <SideSwitchIndicator
+            info={state.beach_side_switch}
+            forcePending={indoorMidpointPending}
+          />
         )}
       </div>
 

--- a/frontend/src/components/SideSwitchIndicator.tsx
+++ b/frontend/src/components/SideSwitchIndicator.tsx
@@ -4,17 +4,32 @@ import type { GameState } from '../api/client';
 export interface SideSwitchIndicatorProps {
   /**
    * The ``beach_side_switch`` field of the current ``GameState``.
-   * ``null``/``undefined`` (e.g. indoor matches) renders nothing.
+   * ``null``/``undefined`` (e.g. indoor matches) renders only the
+   * transient ``forcePending`` pill, if any.
    */
   info: GameState['beach_side_switch'] | null | undefined;
+  /**
+   * Force-render the pulsing "Switch sides now" pill regardless of
+   * ``info``. Used by the indoor-mode transient alert at the
+   * deciding-set midpoint — there's no countdown to show, just the
+   * immediate trigger, so the indicator collapses to the pending
+   * variant without the "in N points" branch.
+   */
+  forcePending?: boolean;
 }
 
-export default function SideSwitchIndicator({ info }: SideSwitchIndicatorProps) {
+export default function SideSwitchIndicator({
+  info,
+  forcePending = false,
+}: SideSwitchIndicatorProps) {
   const { t } = useI18n();
-  if (!info) return null;
+  if (!info && !forcePending) return null;
 
-  const pending = info.is_switch_pending;
-  const label = pending
+  const pending = forcePending || (info?.is_switch_pending ?? false);
+  // The countdown branch only makes sense when the backend supplied
+  // ``info`` (beach mode); the indoor transient alert has no notion
+  // of "points until next switch", so it always renders pending.
+  const label = pending || !info
     ? t('rules.sideSwitchPending')
     : t('rules.sideSwitchInN', { n: info.points_until_switch });
 

--- a/frontend/src/hooks/useIndoorMidpointAlert.ts
+++ b/frontend/src/hooks/useIndoorMidpointAlert.ts
@@ -1,0 +1,80 @@
+import { useEffect, useRef, useState } from 'react';
+import type { GameState } from '../api/client';
+
+/**
+ * Indoor mode side-switch alert for the deciding-set midpoint
+ * (FIVB rule: switch when the leading team first reaches 8 of 15).
+ *
+ * The trigger is *transient* — it fires the moment the leader crosses
+ * the midpoint and clears the next time the score changes — so we
+ * compute it from the diff between consecutive game states rather than
+ * from the current snapshot alone. Each tab tracks its own ``prev``
+ * state, which means a page refresh exactly at the trigger score
+ * silently misses the alert; that's acceptable since the operator
+ * would have already switched in that scenario.
+ *
+ * Returns ``false`` outside indoor mode, outside the deciding set, or
+ * when the match has already finished.
+ */
+export function useIndoorMidpointAlert(
+  state: GameState | null | undefined,
+  currentSet: number,
+  setsLimit: number,
+): boolean {
+  const prevScoreRef = useRef<{ t1: number; t2: number; set: number } | null>(null);
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    const mode = state?.config?.mode as string | undefined;
+    const lastSetTarget = state?.config?.points_limit_last_set as number | undefined;
+    const isLastSet = setsLimit > 0 && currentSet === setsLimit;
+    const eligible =
+      !!state
+      && !state.match_finished
+      && mode === 'indoor'
+      && isLastSet
+      && typeof lastSetTarget === 'number'
+      && lastSetTarget > 0;
+
+    if (!eligible) {
+      // Reset so a later eligible window (entering the deciding set)
+      // starts fresh — otherwise a stale ``prev`` from set 4 would
+      // skew the diff in set 5.
+      setPending(false);
+      prevScoreRef.current = null;
+      return;
+    }
+
+    const t1 = (state.team_1.scores[`set_${currentSet}`] as number | undefined) ?? 0;
+    const t2 = (state.team_2.scores[`set_${currentSet}`] as number | undefined) ?? 0;
+    const midpoint = Math.ceil(lastSetTarget / 2);
+    const prev = prevScoreRef.current;
+
+    // First eligible state (or a set transition): anchor ``prev``
+    // without firing. Refreshing the page exactly at 8-X would
+    // otherwise look like a fresh trigger even though no point was
+    // actually scored in this session.
+    if (!prev || prev.set !== currentSet) {
+      prevScoreRef.current = { t1, t2, set: currentSet };
+      setPending(false);
+      return;
+    }
+
+    const scoreChanged = prev.t1 !== t1 || prev.t2 !== t2;
+    if (!scoreChanged) {
+      // Unrelated state churn (visibility toggle, etc.) — leave the
+      // current ``pending`` value untouched so the alert keeps showing
+      // until the next actual point is scored.
+      return;
+    }
+
+    // Trigger: leader just crossed the midpoint. On every other score
+    // change the alert clears, so it is genuinely transient.
+    const currMax = Math.max(t1, t2);
+    const prevMax = Math.max(prev.t1, prev.t2);
+    setPending(currMax === midpoint && prevMax < midpoint);
+    prevScoreRef.current = { t1, t2, set: currentSet };
+  }, [state, currentSet, setsLimit]);
+
+  return pending;
+}

--- a/frontend/src/test/SideSwitchIndicator.test.tsx
+++ b/frontend/src/test/SideSwitchIndicator.test.tsx
@@ -42,4 +42,18 @@ describe('SideSwitchIndicator', () => {
     expect(el.className).toMatch(/pending/);
     expect(el.getAttribute('aria-live')).toBe('polite');
   });
+
+  it('renders the pending pill when forcePending is true even with no info', () => {
+    // Indoor mode supplies the trigger via ``forcePending`` rather than
+    // ``info`` — there's no countdown, just the immediate alert.
+    renderWithI18n(<SideSwitchIndicator info={null} forcePending={true} />);
+    const el = screen.getByTestId('side-switch-indicator');
+    expect(el.className).toMatch(/pending/);
+    expect(el.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('omits the indicator when both info and forcePending are absent', () => {
+    renderWithI18n(<SideSwitchIndicator info={null} forcePending={false} />);
+    expect(screen.queryByTestId('side-switch-indicator')).toBeNull();
+  });
 });

--- a/frontend/src/test/useIndoorMidpointAlert.test.tsx
+++ b/frontend/src/test/useIndoorMidpointAlert.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useIndoorMidpointAlert } from '../hooks/useIndoorMidpointAlert';
+import type { GameState } from '../api/client';
+
+function makeState(overrides: Partial<GameState> & {
+  t1?: number;
+  t2?: number;
+  set?: number;
+  mode?: 'indoor' | 'beach';
+  pointsLimitLastSet?: number;
+  matchFinished?: boolean;
+}): GameState {
+  const {
+    t1 = 0, t2 = 0, set = 5,
+    mode = 'indoor', pointsLimitLastSet = 15,
+    matchFinished = false,
+  } = overrides;
+  return {
+    team_1: { sets: 0, timeouts: 0, serving: true, scores: { [`set_${set}`]: t1 } },
+    team_2: { sets: 0, timeouts: 0, serving: false, scores: { [`set_${set}`]: t2 } },
+    visible: true,
+    simple_mode: false,
+    match_finished: matchFinished,
+    current_set: set,
+    serve: '1',
+    config: {
+      mode,
+      sets_limit: 5,
+      points_limit: 25,
+      points_limit_last_set: pointsLimitLastSet,
+    },
+    can_undo: false,
+  } as unknown as GameState;
+}
+
+describe('useIndoorMidpointAlert', () => {
+  it('returns false on the first observed state (no prior to diff against)', () => {
+    const { result } = renderHook(() =>
+      useIndoorMidpointAlert(makeState({ t1: 8, t2: 0, set: 5 }), 5, 5),
+    );
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false outside the deciding set', () => {
+    const initial = makeState({ t1: 7, t2: 0, set: 4 });
+    const { result, rerender } = renderHook(
+      ({ s }: { s: GameState }) => useIndoorMidpointAlert(s, 4, 5),
+      { initialProps: { s: initial } },
+    );
+    rerender({ s: makeState({ t1: 8, t2: 0, set: 4 }) });
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false in beach mode (frontend rule is indoor-only)', () => {
+    const initial = makeState({ t1: 7, t2: 0, set: 5, mode: 'beach' });
+    const { result, rerender } = renderHook(
+      ({ s }: { s: GameState }) => useIndoorMidpointAlert(s, 5, 5),
+      { initialProps: { s: initial } },
+    );
+    rerender({ s: makeState({ t1: 8, t2: 0, set: 5, mode: 'beach' }) });
+    expect(result.current).toBe(false);
+  });
+
+  it('fires when leader transitions across the midpoint', () => {
+    const initial = makeState({ t1: 7, t2: 0, set: 5 });
+    const { result, rerender } = renderHook(
+      ({ s }: { s: GameState }) => useIndoorMidpointAlert(s, 5, 5),
+      { initialProps: { s: initial } },
+    );
+    expect(result.current).toBe(false); // first observation anchors prev
+    rerender({ s: makeState({ t1: 8, t2: 0, set: 5 }) });
+    expect(result.current).toBe(true);
+  });
+
+  it('clears on the next score change (8-0 → 8-1)', () => {
+    const initial = makeState({ t1: 7, t2: 0, set: 5 });
+    const { result, rerender } = renderHook(
+      ({ s }: { s: GameState }) => useIndoorMidpointAlert(s, 5, 5),
+      { initialProps: { s: initial } },
+    );
+    rerender({ s: makeState({ t1: 8, t2: 0, set: 5 }) });
+    expect(result.current).toBe(true);
+    rerender({ s: makeState({ t1: 8, t2: 1, set: 5 }) });
+    expect(result.current).toBe(false);
+  });
+
+  it('clears when leader scores past the midpoint (8-0 → 9-0)', () => {
+    const initial = makeState({ t1: 7, t2: 0, set: 5 });
+    const { result, rerender } = renderHook(
+      ({ s }: { s: GameState }) => useIndoorMidpointAlert(s, 5, 5),
+      { initialProps: { s: initial } },
+    );
+    rerender({ s: makeState({ t1: 8, t2: 0, set: 5 }) });
+    expect(result.current).toBe(true);
+    rerender({ s: makeState({ t1: 9, t2: 0, set: 5 }) });
+    expect(result.current).toBe(false);
+  });
+
+  it('does not fire when entering the deciding set already past the midpoint', () => {
+    // Operator opens the app mid-set 5 at 8-3 (page refresh, late join…).
+    // Without a prior in-session ``prev`` we don't synthesise the trigger.
+    const { result } = renderHook(() =>
+      useIndoorMidpointAlert(makeState({ t1: 8, t2: 3, set: 5 }), 5, 5),
+    );
+    expect(result.current).toBe(false);
+  });
+
+  it('rounds the midpoint up for odd targets (13 → 7)', () => {
+    const initial = makeState({ t1: 6, t2: 0, set: 5, pointsLimitLastSet: 13 });
+    const { result, rerender } = renderHook(
+      ({ s }: { s: GameState }) => useIndoorMidpointAlert(s, 5, 5),
+      { initialProps: { s: initial } },
+    );
+    rerender({ s: makeState({ t1: 7, t2: 0, set: 5, pointsLimitLastSet: 13 }) });
+    expect(result.current).toBe(true);
+  });
+
+  it('survives unrelated state churn between point changes', () => {
+    // Visibility toggle and the like push a new state object without
+    // changing the score — the alert must keep showing until the next
+    // actual point.
+    const initial = makeState({ t1: 7, t2: 0, set: 5 });
+    const { result, rerender } = renderHook(
+      ({ s }: { s: GameState }) => useIndoorMidpointAlert(s, 5, 5),
+      { initialProps: { s: initial } },
+    );
+    rerender({ s: makeState({ t1: 8, t2: 0, set: 5 }) });
+    expect(result.current).toBe(true);
+    // Same scores, different state object identity (e.g. visibility flag).
+    rerender({ s: { ...makeState({ t1: 8, t2: 0, set: 5 }), visible: false } });
+    expect(result.current).toBe(true);
+  });
+
+  it('clears once the match has finished', () => {
+    const initial = makeState({ t1: 7, t2: 0, set: 5 });
+    const { result, rerender } = renderHook(
+      ({ s }: { s: GameState }) => useIndoorMidpointAlert(s, 5, 5),
+      { initialProps: { s: initial } },
+    );
+    rerender({ s: makeState({ t1: 8, t2: 0, set: 5 }) });
+    expect(result.current).toBe(true);
+    rerender({ s: makeState({ t1: 15, t2: 7, set: 5, matchFinished: true }) });
+    expect(result.current).toBe(false);
+  });
+
+  it('does not refire after a non-trigger change at the same score', () => {
+    // After 8-0 → 8-1 the alert clears. Re-emitting 8-1 (e.g. a
+    // ``get_state`` poll) must not turn it back on.
+    const initial = makeState({ t1: 7, t2: 0, set: 5 });
+    const { result, rerender } = renderHook(
+      ({ s }: { s: GameState }) => useIndoorMidpointAlert(s, 5, 5),
+      { initialProps: { s: initial } },
+    );
+    rerender({ s: makeState({ t1: 8, t2: 0, set: 5 }) });
+    rerender({ s: makeState({ t1: 8, t2: 1, set: 5 }) });
+    rerender({ s: makeState({ t1: 8, t2: 1, set: 5 }) });
+    expect(result.current).toBe(false);
+  });
+
+  it('handles the null-state case without throwing', () => {
+    const { result } = renderHook(() =>
+      useIndoorMidpointAlert(null, 5, 5),
+    );
+    expect(result.current).toBe(false);
+  });
+});
+
+// ``act`` is exported for parity with other hook tests; explicit usage
+// isn't needed here because ``rerender`` already wraps state updates.
+void act;

--- a/tests/test_match_rules.py
+++ b/tests/test_match_rules.py
@@ -151,98 +151,20 @@ class TestComputeSideSwitch:
         )
         assert result["points_in_set"] == 0
 
-    def test_midpoint_pending_when_leader_first_reaches_eight(self):
-        # Deciding set (15), leader at 8, opponent below: indoor
-        # 5th-set rule fires — switch pending even though combined=10
-        # also happens to be a cadence boundary (consistent overlap).
-        result = compute_side_switch(
-            **_ss_kwargs(
-                current_set=3, sets_limit=3,
-                team1_score=8, team2_score=2,
-            ),
-        )
-        assert result["is_switch_pending"] is True
-
-    def test_midpoint_pending_off_boundary_still_fires(self):
-        # 8-3 (combined=11, NOT a cadence boundary). The midpoint rule
-        # alone keeps the alert on while only one team has crossed 8.
+    def test_no_midpoint_rule_in_beach_deciding_set(self):
+        # Deciding set, leader at 8 of 15, opponent below the midpoint.
+        # Beach has no midpoint rule (it's the indoor 5th-set semantic
+        # and lives in the frontend), so combined=10 fires *only* via
+        # the 5-cadence — and 8-3 (combined=11) wouldn't fire at all.
         result = compute_side_switch(
             **_ss_kwargs(
                 current_set=3, sets_limit=3,
                 team1_score=8, team2_score=3,
             ),
         )
+        assert result["interval"] == 5
         assert result["points_in_set"] == 11
-        # Cadence next is 15 (15 % 5 == 0); 11 is not pending by cadence.
-        assert result["is_switch_pending"] is True
-
-    def test_midpoint_persists_when_leader_scores_past(self):
-        # 9-2: leader has scored past the midpoint before the trailing
-        # team caught up. The alert must persist as a reminder — the
-        # operator may not have switched yet — until both teams cross.
-        result = compute_side_switch(
-            **_ss_kwargs(
-                current_set=3, sets_limit=3,
-                team1_score=9, team2_score=2,
-            ),
-        )
-        assert result["is_switch_pending"] is True
-
-    def test_midpoint_persists_until_trailing_catches_up(self):
-        # 14-7: leader is one point from set/match win, trailing still
-        # below the midpoint — the alert is a stale reminder that the
-        # switch was missed. Stays on until trailing reaches 8.
-        result = compute_side_switch(
-            **_ss_kwargs(
-                current_set=3, sets_limit=3,
-                team1_score=14, team2_score=7,
-            ),
-        )
-        assert result["is_switch_pending"] is True
-
-    def test_midpoint_clears_once_both_reach_it(self):
-        # 8-8: leader is no longer alone at the midpoint, alert clears.
-        # (Combined=16 also misses the 5-cadence.)
-        result = compute_side_switch(
-            **_ss_kwargs(
-                current_set=3, sets_limit=3,
-                team1_score=8, team2_score=8,
-            ),
-        )
         assert result["is_switch_pending"] is False
-
-    def test_midpoint_only_fires_in_last_set(self):
-        # 8-2 in set 1 (regular 21-point set) → no midpoint rule.
-        # Combined=10 isn't a 7-cadence boundary either, so nothing fires.
-        result = compute_side_switch(
-            **_ss_kwargs(team1_score=8, team2_score=2),
-        )
-        assert result["is_switch_pending"] is False
-
-    def test_midpoint_rounds_up_for_odd_targets(self):
-        # 13-point deciding set → midpoint = ceil(13/2) = 7.
-        result = compute_side_switch(
-            **_ss_kwargs(
-                current_set=3, sets_limit=3,
-                points_limit_last_set=13,
-                team1_score=7, team2_score=2,
-            ),
-        )
-        assert result["is_switch_pending"] is True
-
-    def test_midpoint_for_even_target(self):
-        # 16-point deciding set → midpoint = 8.
-        result = compute_side_switch(
-            **_ss_kwargs(
-                current_set=3, sets_limit=3,
-                points_limit_last_set=16,
-                team1_score=8, team2_score=4,
-            ),
-        )
-        # 16 > 15 → cadence is 7, combined=12 is not a 7 boundary.
-        # The midpoint rule supplies the pending flag on its own.
-        assert result["interval"] == 7
-        assert result["is_switch_pending"] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Move the deciding-set midpoint side-switch alert from the beach backend (where I'd misplaced it in #231) to the indoor frontend, which is where it actually belongs per FIVB rules:

- **Indoor**: switch sides **once** in the deciding set, the moment the leading team reaches the midpoint of its target (8 of 15). Transient — visible at the trigger score, gone at the next point.
- **Beach**: keeps its all-match combined cadence. The cadence generalisation (5 if target ≤15, 7 otherwise) from #231 stays.

## Why frontend, not backend?

`compute_side_switch` is stateless — it only sees the current snapshot. The "appears at the trigger and disappears at the next point" semantic needs a *previous* state to diff against. Two options were on the table:

- Backend with session state (anchor field tracked across requests). Multi-tab consistent but adds session plumbing and persistence concerns.
- Frontend with `useRef` over consecutive `GameState` snapshots. Simpler, naturally transient, multi-tab consistent for live operators.

We picked the frontend approach. Trade-off: a page refresh exactly at the trigger score silently misses the alert. Acceptable — the operator would have already switched in that scenario.

## How

- `useIndoorMidpointAlert(state, currentSet, setsLimit)` — diffs `prev` vs `current`, fires when `prev_max < midpoint && current_max === midpoint && setsLimit === currentSet && mode === 'indoor'`, clears on every other score change. Anchors `prev` (without firing) on the first eligible state.
- `SideSwitchIndicator` gains `forcePending?: boolean`. When set with no `info`, renders the pulsing pill collapsed to the pending variant — there's no countdown to show for indoor.
- `CenterPanel` invokes the hook and threads the result.
- Backend: `compute_side_switch` reverts to cadence-only; the `_last_set_midpoint` helper and the beach midpoint tests go away.

## Test plan

- [x] `pytest` — 613 / 613 (the 6 beach-midpoint tests added in #231 are gone; 1 new test verifies beach no longer fires at 8-3 in the deciding set)
- [x] `npm run typecheck` clean
- [x] `npm test` — 272 / 272 (11 new hook tests + 2 new indicator tests for `forcePending`)
- [x] `python scripts/generate_openapi.py` — no schema drift (the indoor alert is purely frontend; `BeachSideSwitch` shape is unchanged)
- [ ] Manual: indoor 25/15/5 match — alert fires only when leader first reaches 8 in the deciding set, vanishes at the next point, doesn't fire in earlier sets or beach mode

https://claude.ai/code/session_018diFmfmUL9Brq1NxgAZJ1i

---
_Generated by [Claude Code](https://claude.ai/code/session_018diFmfmUL9Brq1NxgAZJ1i)_