### PR TITLE
feat(alerts): team-pointing triangle icons for set/match point

### DIFF
--- a/frontend/src/components/CenterPanel.tsx
+++ b/frontend/src/components/CenterPanel.tsx
@@ -148,7 +148,7 @@ export default function CenterPanel({
       </div>
 
       <div className="match-alerts-row" data-testid="match-alerts-row">
-        <MatchAlertIndicator state={state} />
+        <MatchAlertIndicator state={state} isPortrait={isPortrait} />
         {!state.match_finished && (
           <SideSwitchIndicator
             info={state.beach_side_switch}

--- a/frontend/src/components/MatchAlertIndicator.tsx
+++ b/frontend/src/components/MatchAlertIndicator.tsx
@@ -9,6 +9,13 @@ export interface MatchAlertIndicatorProps {
    * matches the empty/loading state from the rest of the app.
    */
   state: GameState | null | undefined;
+  /**
+   * Layout orientation, used to pick the direction of the team-pointing
+   * triangle: left/right in landscape (where team panels sit on either
+   * side of the centre column), up/down in portrait (where they stack).
+   * Defaults to landscape — the icon still encodes the team correctly.
+   */
+  isPortrait?: boolean;
 }
 
 type AlertKind = 'finished' | 'match-point' | 'set-point';
@@ -34,7 +41,10 @@ function pickAlert(state: GameState): AlertSpec | null {
   return null;
 }
 
-export default function MatchAlertIndicator({ state }: MatchAlertIndicatorProps) {
+export default function MatchAlertIndicator({
+  state,
+  isPortrait = false,
+}: MatchAlertIndicatorProps) {
   const { t } = useI18n();
   if (!state) return null;
   const alert = pickAlert(state);
@@ -46,15 +56,20 @@ export default function MatchAlertIndicator({ state }: MatchAlertIndicatorProps)
     : 'alerts.setPoint';
   const label = t(labelKey);
 
+  // For team-bearing alerts (set / match point) the icon is a filled
+  // triangle pointing toward the team that can win — mirroring the
+  // panel's physical position: left/up for team 1, right/down for
+  // team 2. Match-finished has no team, so it keeps the trophy.
   const icon =
     alert.kind === 'finished' ? 'emoji_events'
-    : alert.kind === 'match-point' ? 'sports_score'
-    : 'flag';
+    : alert.team === 1 ? (isPortrait ? 'arrow_drop_up' : 'arrow_left')
+    : alert.team === 2 ? (isPortrait ? 'arrow_drop_down' : 'arrow_right')
+    : 'emoji_events';
 
-  // The icon's position is the only cue for which team is on point —
-  // left for team 1, right for team 2 — mirroring the team panels'
-  // physical position on the layout. Match-finished has no team and
-  // keeps the icon on the left like every other "lead" pill.
+  // The icon also sits on the side closest to the team — left for
+  // team 1, right for team 2 — so the triangle's tip and its
+  // position both reinforce the team identity. Match-finished pins
+  // to the left like every other "lead" pill.
   const iconLeft = alert.team !== 2;
   const iconEl = <span className="material-icons">{icon}</span>;
 

--- a/frontend/src/components/MatchAlertIndicator.tsx
+++ b/frontend/src/components/MatchAlertIndicator.tsx
@@ -25,6 +25,14 @@ interface AlertSpec {
   team?: 1 | 2;
 }
 
+// Per-team triangle that points toward the team's panel: left/up for
+// team 1 (top-left of the layout), right/down for team 2 — picking
+// the orientation that matches the current viewport.
+const TEAM_TRIANGLE = {
+  1: { portrait: 'arrow_drop_up', landscape: 'arrow_left' },
+  2: { portrait: 'arrow_drop_down', landscape: 'arrow_right' },
+} as const;
+
 function pickAlert(state: GameState): AlertSpec | null {
   // Match end is the loudest event — render it on its own and skip
   // everything else so the operator's eye lands here first.
@@ -57,13 +65,10 @@ export default function MatchAlertIndicator({
   const label = t(labelKey);
 
   // For team-bearing alerts (set / match point) the icon is a filled
-  // triangle pointing toward the team that can win — mirroring the
-  // panel's physical position: left/up for team 1, right/down for
-  // team 2. Match-finished has no team, so it keeps the trophy.
-  const icon =
-    alert.kind === 'finished' ? 'emoji_events'
-    : alert.team === 1 ? (isPortrait ? 'arrow_drop_up' : 'arrow_left')
-    : alert.team === 2 ? (isPortrait ? 'arrow_drop_down' : 'arrow_right')
+  // triangle pointing toward the team that can win. Match-finished
+  // has no team, so it keeps the trophy.
+  const icon = alert.team
+    ? TEAM_TRIANGLE[alert.team][isPortrait ? 'portrait' : 'landscape']
     : 'emoji_events';
 
   // The icon also sits on the side closest to the team — left for

--- a/frontend/src/test/MatchAlertIndicator.test.tsx
+++ b/frontend/src/test/MatchAlertIndicator.test.tsx
@@ -132,4 +132,69 @@ describe('MatchAlertIndicator', () => {
     // The visible text drops the team, but assistive tech still gets it.
     expect(el.getAttribute('aria-label')).toMatch(/2/);
   });
+
+  // ── Team-pointing triangle icon ────────────────────────────────────
+
+  it('uses a left-pointing triangle for team 1 in landscape', () => {
+    renderWithI18n(
+      <MatchAlertIndicator
+        state={withInfo({}, { team_1_set_point: true })}
+        isPortrait={false}
+      />,
+    );
+    const icon = screen.getByTestId('match-alert-indicator')
+      .querySelector('.material-icons');
+    expect(icon?.textContent).toBe('arrow_left');
+  });
+
+  it('uses a right-pointing triangle for team 2 in landscape', () => {
+    renderWithI18n(
+      <MatchAlertIndicator
+        state={withInfo({}, { team_2_match_point: true })}
+        isPortrait={false}
+      />,
+    );
+    const icon = screen.getByTestId('match-alert-indicator')
+      .querySelector('.material-icons');
+    expect(icon?.textContent).toBe('arrow_right');
+  });
+
+  it('uses an up-pointing triangle for team 1 in portrait', () => {
+    renderWithI18n(
+      <MatchAlertIndicator
+        state={withInfo({}, { team_1_set_point: true })}
+        isPortrait={true}
+      />,
+    );
+    const icon = screen.getByTestId('match-alert-indicator')
+      .querySelector('.material-icons');
+    expect(icon?.textContent).toBe('arrow_drop_up');
+  });
+
+  it('uses a down-pointing triangle for team 2 in portrait', () => {
+    renderWithI18n(
+      <MatchAlertIndicator
+        state={withInfo({}, { team_2_match_point: true })}
+        isPortrait={true}
+      />,
+    );
+    const icon = screen.getByTestId('match-alert-indicator')
+      .querySelector('.material-icons');
+    expect(icon?.textContent).toBe('arrow_drop_down');
+  });
+
+  it('keeps the trophy icon for match-finished regardless of orientation', () => {
+    for (const isPortrait of [true, false]) {
+      const { unmount } = renderWithI18n(
+        <MatchAlertIndicator
+          state={withInfo({ match_finished: true })}
+          isPortrait={isPortrait}
+        />,
+      );
+      const icon = screen.getByTestId('match-alert-indicator')
+        .querySelector('.material-icons');
+      expect(icon?.textContent).toBe('emoji_events');
+      unmount();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Replace the generic icons on the set-point and match-point pills (`flag` and `sports_score`) with a filled triangle that points toward the team that can win — using the team panels' physical position on the layout as the cue.

| Team | Landscape | Portrait |
|------|-----------|----------|
| 1 | `arrow_left` ◀ | `arrow_drop_up` ▲ |
| 2 | `arrow_right` ▶ | `arrow_drop_down` ▼ |

The triangle's tip and the icon's position (left of label for team 1, right for team 2) now both encode the team identity. Match-finished keeps the trophy (`emoji_events`) — no team to point to.

Set-point vs match-point is now distinguished by the label text alone (`"Set point"` / `"Match point"` etc.). The icon was redundant with the text anyway, and freeing it up to convey team direction is more useful.

## How

- `MatchAlertIndicator` accepts a new `isPortrait?: boolean` prop, threaded through `CenterPanel` which already knows the orientation.
- Icon selection becomes a small lookup keyed off `(alert.team, isPortrait)`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 277 / 277 (5 new tests covering each direction + the trophy invariance across orientations)
- [ ] Manual: rotate the device between portrait and landscape during set/match point — verify the triangle flips between left/right and up/down on the same team
- [ ] Manual: confirm trophy still shows on match-finished in both orientations

https://claude.ai/code/session_018diFmfmUL9Brq1NxgAZJ1i

---
_Generated by [Claude Code](https://claude.ai/code/session_018diFmfmUL9Brq1NxgAZJ1i)_