### PR TITLE
feat(report): MATCH_REPORT_PUBLIC_DELETE flag + OID redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Configure the application using the following environment variables:
 | `WEBHOOKS_TIMEOUT_S` | *(Optional)* Per-target POST timeout in seconds. | `5` |
 | `WEBHOOKS_JSON` | *(Optional)* JSON list of webhook targets, e.g. `[{"url":"…","secret":"…","events":["set_end"],"timeout_s":5}]`. Takes precedence over `WEBHOOKS_URL`. | |
 | `MATCH_REPORT_PUBLIC` | If `true`, `/match/{id}/report` is reachable without a token (matches the `/overlay/{output_key}` model). When unset, the route requires `OVERLAY_MANAGER_PASSWORD` via Bearer header or `?token=`. Returns 503 if neither is configured. | `false` |
+| `MATCH_REPORT_PUBLIC_DELETE` | If `true`, `DELETE /matches/{id}` no longer requires the admin token — the per-row Delete button on `/matches/index.html` becomes usable without sharing `OVERLAY_MANAGER_PASSWORD`. Independent from `MATCH_REPORT_PUBLIC`: granting public read does *not* grant public delete. | `false` |
 
 <br>
 
@@ -359,6 +360,7 @@ Import configuration from an external resource via `REMOTE_CONFIG_URL`. The appl
 | `/api/v1/game/undo` | `POST` — pop the last forward `add_point`/`add_set`/`add_timeout` from the audit log and reverse it. Returns 200 with `success=false` and `message="Nothing to undo."` when the log is empty. |
 | `/match/{match_id}/report` | `GET` — print-friendly HTML match report. Gated by `OVERLAY_MANAGER_PASSWORD` (Bearer header or `?token=`) unless `MATCH_REPORT_PUBLIC=true`. Returns 503 when neither is configured. |
 | `/matches/index.html?oid=X` | `GET` — browseable HTML list of every archived match for the OID (date, sets, duration, link to each report). Same auth gate as `/match/{id}/report`; the `?token=` query is propagated to the per-match report links. |
+| `/matches/{match_id}` | `DELETE` — remove a single archived snapshot. Gated by `OVERLAY_MANAGER_PASSWORD` unless `MATCH_REPORT_PUBLIC_DELETE=true`. |
 | `/overlay/{id}` | Overlay HTML for OBS browser sources (built-in engine). `?style=mosaic` renders a preview grid of every selectable style. |
 | `/ws/{id}` | WebSocket for OBS browser sources (overlay state broadcast) |
 | `/api/config/{id}` | Overlay config (output URL, available styles) |

--- a/app/match_report.py
+++ b/app/match_report.py
@@ -53,9 +53,14 @@ match_report_router = APIRouter()
 _TRUTHY_ENV = ("1", "true", "t", "yes", "on")
 
 
-def _public_mode_enabled() -> bool:
-    raw = EnvVarsManager.get_env_var("MATCH_REPORT_PUBLIC", "false")
+def _is_env_enabled(key: str) -> bool:
+    """``True`` when env var *key* parses as a truthy boolean string."""
+    raw = EnvVarsManager.get_env_var(key, "false")
     return str(raw).strip().lower() in _TRUTHY_ENV
+
+
+def _public_mode_enabled() -> bool:
+    return _is_env_enabled("MATCH_REPORT_PUBLIC")
 
 
 def _public_delete_enabled() -> bool:
@@ -64,8 +69,7 @@ def _public_delete_enabled() -> bool:
     Independent from :func:`_public_mode_enabled` on purpose: granting
     public read shouldn't silently authorise public destruction.
     """
-    raw = EnvVarsManager.get_env_var("MATCH_REPORT_PUBLIC_DELETE", "false")
-    return str(raw).strip().lower() in _TRUTHY_ENV
+    return _is_env_enabled("MATCH_REPORT_PUBLIC_DELETE")
 
 
 def _admin_password() -> Optional[str]:

--- a/app/match_report.py
+++ b/app/match_report.py
@@ -23,6 +23,12 @@ more sensitive than live overlay state. Access requires either:
 When ``OVERLAY_MANAGER_PASSWORD`` is unset and ``MATCH_REPORT_PUBLIC``
 is not enabled, the route returns 503 — operators must explicitly
 opt in to one mode or the other.
+
+Destructive actions (``DELETE /matches/{match_id}``) keep their own
+flag, ``MATCH_REPORT_PUBLIC_DELETE``: when ``true`` the delete route
+no longer requires the admin token. This is intentionally separate
+from ``MATCH_REPORT_PUBLIC`` so that public *read* doesn't silently
+unlock public *delete* — the operator has to opt in to each.
 """
 
 from __future__ import annotations
@@ -44,9 +50,22 @@ logger = logging.getLogger(__name__)
 match_report_router = APIRouter()
 
 
+_TRUTHY_ENV = ("1", "true", "t", "yes", "on")
+
+
 def _public_mode_enabled() -> bool:
     raw = EnvVarsManager.get_env_var("MATCH_REPORT_PUBLIC", "false")
-    return str(raw).strip().lower() in ("1", "true", "t", "yes", "on")
+    return str(raw).strip().lower() in _TRUTHY_ENV
+
+
+def _public_delete_enabled() -> bool:
+    """``True`` when the operator has opted into unauthenticated delete.
+
+    Independent from :func:`_public_mode_enabled` on purpose: granting
+    public read shouldn't silently authorise public destruction.
+    """
+    raw = EnvVarsManager.get_env_var("MATCH_REPORT_PUBLIC_DELETE", "false")
+    return str(raw).strip().lower() in _TRUTHY_ENV
 
 
 def _admin_password() -> Optional[str]:
@@ -258,7 +277,6 @@ _REPORT_TEMPLATE = """<!doctype html>
 <table>
   <tbody>
     <tr><td>Match ID</td><td>{match_id}</td></tr>
-    <tr><td>OID</td><td>{oid}</td></tr>
     <tr><td>Format</td><td>Best of {sets_limit} &middot; {points_limit} pts/set ({points_limit_last_set} in final)</td></tr>
     <tr><td>Started</td><td>{started_at_display}</td></tr>
     <tr><td>Ended</td><td>{ended_at_display}</td></tr>
@@ -438,7 +456,6 @@ async def match_report(
     rendered = _REPORT_TEMPLATE.format(
         match_label=match_label,
         match_id=html.escape(payload.get("match_id", match_id)),
-        oid=html.escape(payload.get("oid", "—")),
         team1_name=html.escape(team1_name),
         team2_name=html.escape(team2_name),
         team1_sets=team1_sets,
@@ -777,12 +794,16 @@ async def delete_archived_match(
 ):
     """Delete a single archived match by id.
 
-    Always requires a valid admin token, even when
-    ``MATCH_REPORT_PUBLIC=true`` — public mode grants read-only access
-    only. Returns 204 on success, 404 when the match does not exist,
-    and 401/403/503 for the various authentication failure modes.
+    Requires a valid admin token unless ``MATCH_REPORT_PUBLIC_DELETE``
+    is set — that flag is independent from ``MATCH_REPORT_PUBLIC``
+    (public read does *not* imply public delete) and lets operators
+    expose the per-row Delete button on the matches index without
+    sharing the admin password. Returns 204 on success, 404 when the
+    match does not exist, and 401/403/503 for the various
+    authentication failure modes when the flag is off.
     """
-    _check_admin_access(authorization, token)
+    if not _public_delete_enabled():
+        _check_admin_access(authorization, token)
     if not match_archive.delete_match(match_id):
         raise HTTPException(status_code=404, detail="Match not found.")
     return Response(status_code=204)

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -3834,7 +3834,7 @@
     },
     "/matches/{match_id}": {
       "delete": {
-        "description": "Delete a single archived match by id.\n\nAlways requires a valid admin token, even when\n``MATCH_REPORT_PUBLIC=true`` \u2014 public mode grants read-only access\nonly. Returns 204 on success, 404 when the match does not exist,\nand 401/403/503 for the various authentication failure modes.",
+        "description": "Delete a single archived match by id.\n\nRequires a valid admin token unless ``MATCH_REPORT_PUBLIC_DELETE``\nis set \u2014 that flag is independent from ``MATCH_REPORT_PUBLIC``\n(public read does *not* imply public delete) and lets operators\nexpose the per-row Delete button on the matches index without\nsharing the admin password. Returns 204 on success, 404 when the\nmatch does not exist, and 401/403/503 for the various\nauthentication failure modes when the flag is off.",
         "operationId": "delete_archived_match_matches__match_id__delete",
         "parameters": [
           {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -829,10 +829,13 @@ export interface paths {
          * Delete an archived match snapshot
          * @description Delete a single archived match by id.
          *
-         *     Always requires a valid admin token, even when
-         *     ``MATCH_REPORT_PUBLIC=true`` — public mode grants read-only access
-         *     only. Returns 204 on success, 404 when the match does not exist,
-         *     and 401/403/503 for the various authentication failure modes.
+         *     Requires a valid admin token unless ``MATCH_REPORT_PUBLIC_DELETE``
+         *     is set — that flag is independent from ``MATCH_REPORT_PUBLIC``
+         *     (public read does *not* imply public delete) and lets operators
+         *     expose the per-row Delete button on the matches index without
+         *     sharing the admin password. Returns 204 on success, 404 when the
+         *     match does not exist, and 401/403/503 for the various
+         *     authentication failure modes when the flag is off.
          */
         delete: operations["delete_archived_match_matches__match_id__delete"];
         options?: never;

--- a/tests/test_match_report.py
+++ b/tests/test_match_report.py
@@ -118,6 +118,18 @@ class TestMatchReport:
         assert "#0047AB" in response.text
         assert "#FFD700" in response.text
 
+    def test_oid_is_not_exposed_in_report_html(self, client, archived_match):
+        # The single-match report URL uses an opaque hash-prefixed
+        # match_id, not the OID — so the OID is not derivable from
+        # the link. The page must not leak it back, otherwise anyone
+        # who receives a report URL learns which control session
+        # produced it. Both the literal OID string and the "OID"
+        # label row must be gone.
+        response = client.get(f"/match/{archived_match}/report")
+        assert response.status_code == 200
+        assert "rep-1" not in response.text
+        assert ">OID<" not in response.text
+
     def test_team_name_html_escaped(self, client):
         action_log.append("rep-xss", "add_point",
                           {"team": 1, "undo": False}, {})
@@ -394,3 +406,57 @@ class TestDeleteArchivedMatch:
         # reach the handler — accept either.
         response = gated_client.delete("/matches/not-a-match-id?token=s3cret")
         assert response.status_code in (404, 422)
+
+    # ── MATCH_REPORT_PUBLIC_DELETE opt-in ──────────────────────────────
+
+    def _public_delete_client(self, monkeypatch):
+        monkeypatch.setenv("MATCH_REPORT_PUBLIC_DELETE", "true")
+        # Read access still gated — we're isolating the delete flag.
+        monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
+        monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "s3cret")
+        app = FastAPI()
+        app.include_router(match_report_router)
+        return TestClient(app)
+
+    def test_delete_public_mode_succeeds_without_token(self, monkeypatch):
+        c = self._public_delete_client(monkeypatch)
+        match_id = self._archive()
+        response = c.delete(f"/matches/{match_id}")
+        assert response.status_code == 204
+        assert match_archive.load_match(match_id) is None
+
+    def test_delete_public_mode_works_without_admin_password(self, monkeypatch):
+        # The whole point of the flag is to avoid the "I have to set
+        # OVERLAY_MANAGER_PASSWORD just to enable Delete" trap. Without
+        # the password set, the delete must still go through.
+        monkeypatch.setenv("MATCH_REPORT_PUBLIC_DELETE", "true")
+        monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
+        monkeypatch.delenv("OVERLAY_MANAGER_PASSWORD", raising=False)
+        app = FastAPI()
+        app.include_router(match_report_router)
+        c = TestClient(app)
+        match_id = self._archive()
+        response = c.delete(f"/matches/{match_id}")
+        assert response.status_code == 204
+        assert match_archive.load_match(match_id) is None
+
+    def test_delete_public_mode_still_404s_for_unknown(self, monkeypatch):
+        c = self._public_delete_client(monkeypatch)
+        bogus = "match_" + "0" * 20 + "_20260101T000000_000000Z"
+        response = c.delete(f"/matches/{bogus}")
+        assert response.status_code == 404
+
+    def test_public_read_alone_does_not_unlock_delete(self, monkeypatch):
+        # MATCH_REPORT_PUBLIC=true (read) without
+        # MATCH_REPORT_PUBLIC_DELETE must NOT enable destructive calls
+        # — this independence is the safety property of the two flags.
+        monkeypatch.setenv("MATCH_REPORT_PUBLIC", "true")
+        monkeypatch.delenv("MATCH_REPORT_PUBLIC_DELETE", raising=False)
+        monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "s3cret")
+        app = FastAPI()
+        app.include_router(match_report_router)
+        c = TestClient(app)
+        match_id = self._archive()
+        response = c.delete(f"/matches/{match_id}")
+        assert response.status_code == 401
+        assert match_archive.load_match(match_id) is not None


### PR DESCRIPTION
## Summary

Two independent changes to the match-report surface:

1. **`MATCH_REPORT_PUBLIC_DELETE`** (default `false`): when set, the `DELETE /matches/{match_id}` route no longer requires the admin token. Operators who already share the matches-index URL can now wire up the per-row Delete button without handing out `OVERLAY_MANAGER_PASSWORD`. Kept distinct from `MATCH_REPORT_PUBLIC` so granting public read does **not** silently grant public delete.
2. **OID redaction on `/match/{match_id}/report`**: drops the `OID` row from the Match-facts table. The `match_id` in the URL is an opaque hash of the OID, so the OID was the only OID-leaking surface on the page; removing it stops the report from re-exposing it to anyone who receives a report URL.

The `/matches/index.html` page is intentionally **left unchanged** — its query string already contains the OID, so removing it from the page header would be cosmetic security at best.

## How

- New `_public_delete_enabled()` helper in `app/match_report.py`, mirroring `_public_mode_enabled()`. Shared truthy-string tuple `_TRUTHY_ENV` so the two readers don't drift.
- `delete_archived_match` short-circuits the `_check_admin_access` call when the new flag is on; everything else (404 fall-through, validation) is identical.
- `_REPORT_TEMPLATE` loses the `<tr><td>OID</td>…</tr>` row; the `oid=` kwarg is removed from `format()`.
- README env-var table gets the new flag; endpoints table gains a row for `DELETE /matches/{id}`.

## Test plan

- [x] `pytest` — 618 / 618 (5 new tests in `TestDeleteArchivedMatch` and `TestMatchReport`)
- [ ] Manual: with `MATCH_REPORT_PUBLIC=true` and `MATCH_REPORT_PUBLIC_DELETE` unset, the per-row Delete still 401s
- [ ] Manual: with `MATCH_REPORT_PUBLIC_DELETE=true`, click Delete from a fresh browser tab → row disappears, no token required
- [ ] Manual: open a match report and confirm the Match-facts table no longer shows OID

https://claude.ai/code/session_018diFmfmUL9Brq1NxgAZJ1i

---
_Generated by [Claude Code](https://claude.ai/code/session_018diFmfmUL9Brq1NxgAZJ1i)_