### PR TITLE
feat(report): trim pregame records and hide unplayed sets

### DIFF
--- a/app/match_report.py
+++ b/app/match_report.py
@@ -591,12 +591,13 @@ def _trim_pregame(audit: list[dict]) -> list[dict]:
     """Drop pre-first-scoring records (``reset``, stray timeouts, …).
 
     Keeps everything from the first scoring action onward. When the
-    audit has no scoring action the original list is returned so the
-    caller can decide how to handle the degenerate case (currently the
-    timeline renders "no audit records" in that branch).
+    audit has no scoring action at all we return ``[]`` — the timeline
+    renderer already understands the empty case and shows "no audit
+    records", and falling through to the unfiltered list would let the
+    pregame noise leak back into the report.
     """
     idx = _first_scoring_index(audit)
-    return audit[idx:] if idx is not None else audit
+    return audit[idx:] if idx is not None else []
 
 
 def _played_set_count(final_state: dict, fallback: int) -> int:
@@ -606,9 +607,13 @@ def _played_set_count(final_state: dict, fallback: int) -> int:
     set up to ``sets_limit``, even sets that were never played (best
     of 3 ending 2-0 still has ``set_3``: 0/0). Render only the sets
     that actually saw points so empty trailing columns don't dilute
-    the report. Falls back to *fallback* when no set has scores —
-    keeps the "fresh archive" edge case showing a single set frame
-    instead of collapsing the whole report.
+    the report. When no set has scores yet (fresh archive) we collapse
+    to a single set frame rather than painting all ``sets_limit``
+    columns full of ``—``s.
+
+    *fallback* is honoured only as an upper bound — corrupt snapshots
+    reporting set N > sets_limit shouldn't paint a column the rules
+    don't allow.
     """
     teams = (final_state.get("team_1") or {}, final_state.get("team_2") or {})
     highest = 0
@@ -628,7 +633,7 @@ def _played_set_count(final_state: dict, fallback: int) -> int:
             if v > 0:
                 highest = max(highest, n)
     if highest == 0:
-        return max(1, fallback)
+        return 1
     return min(highest, fallback) if fallback > 0 else highest
 
 

--- a/app/match_report.py
+++ b/app/match_report.py
@@ -569,6 +569,69 @@ def _is_score_action(record: dict) -> bool:
     return record.get("action") in ("add_point", "set_score")
 
 
+def _first_scoring_index(audit: list[dict]) -> Optional[int]:
+    """Index of the first non-undo ``add_point`` / ``set_score`` record.
+
+    The audit log starts with whatever the operator did first — often a
+    ``reset`` to clear the previous match's state — but a "match" only
+    really begins once someone scores. Until the UI exposes a dedicated
+    "match start" marker, every report-side time anchor (relative
+    timestamps, duration, set durations, stats) snaps to this index.
+    Returns ``None`` when the audit has no scoring action at all.
+    """
+    for index, record in enumerate(audit):
+        if (record.get("params") or {}).get("undo"):
+            continue
+        if _is_score_action(record):
+            return index
+    return None
+
+
+def _trim_pregame(audit: list[dict]) -> list[dict]:
+    """Drop pre-first-scoring records (``reset``, stray timeouts, …).
+
+    Keeps everything from the first scoring action onward. When the
+    audit has no scoring action the original list is returned so the
+    caller can decide how to handle the degenerate case (currently the
+    timeline renders "no audit records" in that branch).
+    """
+    idx = _first_scoring_index(audit)
+    return audit[idx:] if idx is not None else audit
+
+
+def _played_set_count(final_state: dict, fallback: int) -> int:
+    """Highest set N with non-zero scoring data, clamped to *fallback*.
+
+    The match-history archive bundles ``team_X.scores.set_N`` for every
+    set up to ``sets_limit``, even sets that were never played (best
+    of 3 ending 2-0 still has ``set_3``: 0/0). Render only the sets
+    that actually saw points so empty trailing columns don't dilute
+    the report. Falls back to *fallback* when no set has scores —
+    keeps the "fresh archive" edge case showing a single set frame
+    instead of collapsing the whole report.
+    """
+    teams = (final_state.get("team_1") or {}, final_state.get("team_2") or {})
+    highest = 0
+    for team in teams:
+        scores = team.get("scores") or {}
+        for key, value in scores.items():
+            if not isinstance(key, str) or not key.startswith("set_"):
+                continue
+            try:
+                n = int(key.removeprefix("set_"))
+            except ValueError:
+                continue
+            try:
+                v = int(value) if value is not None else 0
+            except (TypeError, ValueError):
+                continue
+            if v > 0:
+                highest = max(highest, n)
+    if highest == 0:
+        return max(1, fallback)
+    return min(highest, fallback) if fallback > 0 else highest
+
+
 def _collapse_undos(audit: list[dict]) -> list[dict]:
     """Mark forward audit records whose effect was reverted by a later ``undo``.
 
@@ -1009,7 +1072,12 @@ async def match_report(
     customization = payload.get("customization", {}) or {}
     final = payload.get("final_state", {}) or {}
     config = payload.get("config", {}) or {}
-    audit = payload.get("audit_log", []) or []
+    raw_audit = payload.get("audit_log", []) or []
+    # The "match" only exists from the first scored point onward — see
+    # ``_first_scoring_index`` for the rationale. Every audit consumer
+    # below operates on the trimmed slice so pre-game noise (resets,
+    # stray clicks) doesn't skew durations, charts, or relative times.
+    audit = _trim_pregame(raw_audit)
 
     team1_name = _team_name(customization, 1)
     team2_name = _team_name(customization, 2)
@@ -1019,6 +1087,10 @@ async def match_report(
     team1_sets = team1.get("sets") or 0
     team2_sets = team2.get("sets") or 0
     sets_limit = config.get("sets_limit") or 5
+    # Trailing sets that never saw points (e.g. set 3 of a 2-0 best-of-3)
+    # don't earn a column / chart / duration cell; they'd just read as
+    # ``—``s and dilute the rest of the report.
+    played_sets = _played_set_count(final, sets_limit)
 
     t1_color = _team_color(customization, 1, primary=True)
     t1_fg = _team_color(customization, 1, primary=False)
@@ -1027,19 +1099,39 @@ async def match_report(
 
     set_headers = "".join(
         f'<th>{html.escape(_t(locale, "setLabel", n=i))}</th>'
-        for i in range(1, sets_limit + 1)
+        for i in range(1, played_sets + 1)
     )
 
     def _team_set_cells(team_dict: dict) -> str:
         cells = []
         scores = team_dict.get("scores", {}) or {}
-        for i in range(1, sets_limit + 1):
+        for i in range(1, played_sets + 1):
             v = scores.get(f"set_{i}", "")
             cells.append(f"<td>{html.escape(str(v) if v != '' else '—')}</td>")
         return "".join(cells)
 
     stats = _compute_stats(audit)
     set_durations = stats.get("set_durations", {}) or {}
+
+    # The reported "Started" and "Duration" snap to the first scoring
+    # action, not the snapshot's wallclock — keeps the header subtitle
+    # honest about how long the *match* lasted, not how long the
+    # operator's tab was open.
+    first_scoring_ts: Optional[float] = None
+    for record in audit:
+        ts = record.get("ts")
+        if isinstance(ts, (int, float)):
+            first_scoring_ts = float(ts)
+            break
+    ended_at = payload.get("ended_at")
+    if first_scoring_ts is not None and isinstance(ended_at, (int, float)):
+        effective_duration = max(0.0, float(ended_at) - first_scoring_ts)
+    else:
+        effective_duration = payload.get("duration_s")
+    effective_started_at = (
+        first_scoring_ts if first_scoring_ts is not None
+        else payload.get("started_at")
+    )
 
     timeouts_t1 = team1.get("timeouts")
     timeouts_t2 = team2.get("timeouts")
@@ -1080,32 +1172,34 @@ async def match_report(
         team2_fg=t2_fg,
         team1_winner_badge=team1_winner,
         team2_winner_badge=team2_winner,
-        set_count=sets_limit,
+        set_count=played_sets,
         set_headers=set_headers,
         team1_set_cells=_team_set_cells(team1),
         team2_set_cells=_team_set_cells(team2),
-        set_duration_cells=_render_set_durations_row(set_durations, sets_limit),
+        set_duration_cells=_render_set_durations_row(set_durations, played_sets),
         timeouts_summary=timeouts_summary,
         # ``config`` values are operator-controlled — escape the
         # interpolated string defensively even though the formatter
-        # only sees ints in the happy path.
+        # only sees ints in the happy path. ``Best of {sets_limit}`` is
+        # the *match rule* and stays at sets_limit even when fewer
+        # sets actually got played.
         format_desc=html.escape(_t(
             locale, "formatDesc",
             sets=sets_limit,
             points=config.get("points_limit") or "—",
             last=config.get("points_limit_last_set") or "—",
         )),
-        started_at_display=_fmt_ts(payload.get("started_at")),
+        started_at_display=_fmt_ts(effective_started_at),
         ended_at_display=_fmt_ts(payload.get("ended_at")),
-        duration_display=_fmt_seconds(payload.get("duration_s")),
+        duration_display=_fmt_seconds(effective_duration),
         audit_count=len(audit),
         highlights_html=_render_highlights(stats, locale),
         charts_html=_render_charts(
-            audit, sets_limit, locale,
+            audit, played_sets, locale,
             t1_name=team1_name, t2_name=team2_name,
             t1_color=t1_color, t2_color=t2_color,
         ),
-        timeline_html=_render_timeline(audit, locale, sets_limit),
+        timeline_html=_render_timeline(audit, locale, played_sets),
         # i18n labels
         duration_label=html.escape(_t(locale, "duration")),
         versus=html.escape(_t(locale, "versus")),

--- a/tests/test_match_report.py
+++ b/tests/test_match_report.py
@@ -533,6 +533,26 @@ class TestMatchReportEmptySets:
         for label in ("Set 1", "Set 2", "Set 3"):
             assert label in response.text
 
+    def test_empty_match_collapses_to_single_set_frame(self, client):
+        # ``_played_set_count`` returns 1 (not ``sets_limit``) when the
+        # archive has no scoring data — otherwise a fresh-archive
+        # snapshot would paint 3 or 5 empty columns.
+        match_id = match_archive.archive_match(
+            oid="empty-fresh",
+            final_state={
+                "team_1": {"sets": 0, "scores": {"set_1": 0, "set_2": 0,
+                                                 "set_3": 0}},
+                "team_2": {"sets": 0, "scores": {"set_1": 0, "set_2": 0,
+                                                 "set_3": 0}},
+            },
+            customization={"Team 1 Name": "A", "Team 2 Name": "B"},
+            winning_team=None, sets_limit=3,
+        )
+        response = client.get(f"/match/{match_id}/report")
+        assert "Set 1" in response.text
+        assert "Set 2" not in response.text
+        assert "Set 3" not in response.text
+
     def test_played_set_count_clamps_to_sets_limit(self, client):
         # Defensive: a snapshot reporting set-4 scores in a best-of-3
         # match (data-corruption / mode-change scenario) shouldn't

--- a/tests/test_match_report.py
+++ b/tests/test_match_report.py
@@ -1,4 +1,6 @@
 """Tests for the print-friendly match report at /match/{match_id}/report."""
+import json
+import os
 import time
 
 import pytest
@@ -362,6 +364,193 @@ class TestMatchReportRichSections:
         assert "15m 00s" in response.text
         # The row label is i18n-driven.
         assert "Set durations" in response.text
+
+
+class TestMatchReportPregameTrim:
+    """Reset / pregame records must not anchor the report timeline."""
+
+    def _seed_audit(self, oid: str, records: list[dict]) -> None:
+        from app.api import action_log as _al
+        path = _al._path(oid)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            for r in records:
+                f.write(json.dumps(r) + "\n")
+
+    def test_relative_timestamps_anchor_at_first_point_not_reset(self, client):
+        # Reset 5 min before the first point; the first point must
+        # render as ``+0:00`` (anchoring restarts here) and the
+        # second point 60 s later as ``+1:00``. The reset line
+        # itself is trimmed and the audit_count drops to 2.
+        base_ts = time.time() - 1000
+        oid = "trim-1"
+        self._seed_audit(oid, [
+            {"ts": base_ts, "action": "reset", "params": {},
+             "result": {"current_set": 1, "team_1": {"score": 0},
+                        "team_2": {"score": 0}}},
+            {"ts": base_ts + 300, "action": "add_point",
+             "params": {"team": 1, "undo": False},
+             "result": {"current_set": 1, "team_1": {"score": 1},
+                        "team_2": {"score": 0}}},
+            {"ts": base_ts + 360, "action": "add_point",
+             "params": {"team": 2, "undo": False},
+             "result": {"current_set": 1, "team_1": {"score": 1},
+                        "team_2": {"score": 1}}},
+        ])
+        match_id = match_archive.archive_match(
+            oid=oid, final_state={
+                "team_1": {"sets": 0, "scores": {"set_1": 1}},
+                "team_2": {"sets": 0, "scores": {"set_1": 1}},
+            },
+            customization={"Team 1 Name": "A", "Team 2 Name": "B"},
+            started_at=base_ts, sets_limit=3,
+        )
+        response = client.get(f"/match/{match_id}/report")
+        # First scored point is the new anchor.
+        assert "+0:00" in response.text
+        assert "+1:00" in response.text
+        # Reset entry is gone from the rendered timeline.
+        assert ">Reset<" not in response.text
+        # ``Audit entries`` reflects the trimmed view (3 raw → 2 shown).
+        assert ">2</td>" in response.text
+
+    def test_started_at_uses_first_scoring_ts(self, client):
+        # Snapshot's ``started_at`` is 1000 s before wallclock-now;
+        # first point is 300 s after that. The "Started" row in the
+        # match-facts table should render the first-point timestamp,
+        # not the snapshot's ``started_at``.
+        import datetime as _dt
+        base_ts = time.time() - 1000
+        first_pt_ts = base_ts + 300
+        oid = "trim-started"
+        self._seed_audit(oid, [
+            {"ts": base_ts, "action": "reset", "params": {},
+             "result": {"current_set": 1, "team_1": {"score": 0},
+                        "team_2": {"score": 0}}},
+            {"ts": first_pt_ts, "action": "add_point",
+             "params": {"team": 1, "undo": False},
+             "result": {"current_set": 1, "team_1": {"score": 1},
+                        "team_2": {"score": 0}}},
+        ])
+        match_id = match_archive.archive_match(
+            oid=oid,
+            final_state={"team_1": {"scores": {"set_1": 1}},
+                         "team_2": {"scores": {"set_1": 0}}},
+            customization={"Team 1 Name": "A", "Team 2 Name": "B"},
+            started_at=base_ts, sets_limit=3,
+        )
+        response = client.get(f"/match/{match_id}/report")
+        first_pt_label = _dt.datetime.fromtimestamp(
+            first_pt_ts, _dt.timezone.utc,
+        ).strftime("%Y-%m-%d %H:%M UTC")
+        reset_label = _dt.datetime.fromtimestamp(
+            base_ts, _dt.timezone.utc,
+        ).strftime("%Y-%m-%d %H:%M UTC")
+        # Same minute? Skip the negative side of the assertion. Modulo
+        # that edge case the Started row should reflect the point time.
+        assert first_pt_label in response.text
+        if first_pt_label != reset_label:
+            assert response.text.count(reset_label) == 0
+
+    def test_timeline_omits_pregame_actions(self, client):
+        # Reset + a stray timeout before any point should both be
+        # trimmed; only the first scored point survives in the timeline.
+        oid = "trim-stray"
+        base = time.time() - 3000
+        self._seed_audit(oid, [
+            {"ts": base, "action": "reset", "params": {},
+             "result": {"current_set": 1, "team_1": {"score": 0},
+                        "team_2": {"score": 0}}},
+            {"ts": base + 30, "action": "add_timeout",
+             "params": {"team": 1, "undo": False},
+             "result": {"current_set": 1, "team_1": {"score": 0,
+                                                     "timeouts": 1},
+                        "team_2": {"score": 0, "timeouts": 0}}},
+            {"ts": base + 90, "action": "add_point",
+             "params": {"team": 1, "undo": False},
+             "result": {"current_set": 1, "team_1": {"score": 1},
+                        "team_2": {"score": 0}}},
+        ])
+        match_id = match_archive.archive_match(
+            oid=oid,
+            final_state={"team_1": {"scores": {"set_1": 1}},
+                         "team_2": {"scores": {"set_1": 0}}},
+            customization={"Team 1 Name": "A", "Team 2 Name": "B"},
+            started_at=base, sets_limit=3,
+        )
+        response = client.get(f"/match/{match_id}/report")
+        # Pregame timeout/reset shouldn't appear in the timeline. We
+        # check the action-label form (``Timeout — Team N``) so we
+        # don't false-match the ``Timeouts (final set)`` row label.
+        assert "Timeout — Team" not in response.text
+        assert ">Reset<" not in response.text
+        assert "Point — Team 1" in response.text
+
+
+class TestMatchReportEmptySets:
+    """A best-of-3 ending 2-0 must not render a Set 3 column / chart."""
+
+    def test_unplayed_trailing_sets_are_omitted(self, client):
+        # Final state: set 1 won 25-22, set 2 won 25-19, set 3 untouched
+        # (operator never reached the deciding set).
+        match_id = match_archive.archive_match(
+            oid="empty-3",
+            final_state={
+                "team_1": {"sets": 2, "scores": {"set_1": 25, "set_2": 25,
+                                                 "set_3": 0}},
+                "team_2": {"sets": 0, "scores": {"set_1": 22, "set_2": 19,
+                                                 "set_3": 0}},
+            },
+            customization={"Team 1 Name": "A", "Team 2 Name": "B"},
+            winning_team=1, sets_limit=3,
+        )
+        response = client.get(f"/match/{match_id}/report")
+        # Set headers and chart card titles use "Set N"; with set 3
+        # omitted, the substring shouldn't appear at all in the page.
+        assert "Set 1" in response.text
+        assert "Set 2" in response.text
+        assert "Set 3" not in response.text
+        # The "Best of 3" rule still appears — that's the match
+        # configuration, not the played-set count.
+        assert "Best of 3" in response.text
+
+    def test_full_three_sets_still_render_when_played(self, client):
+        # Best-of-3 going to a deciding set — every column / card
+        # must still render (this is the regression guard for the
+        # opt-in trimming).
+        match_id = match_archive.archive_match(
+            oid="empty-full",
+            final_state={
+                "team_1": {"sets": 2, "scores": {"set_1": 25, "set_2": 22,
+                                                 "set_3": 15}},
+                "team_2": {"sets": 1, "scores": {"set_1": 22, "set_2": 25,
+                                                 "set_3": 13}},
+            },
+            customization={"Team 1 Name": "A", "Team 2 Name": "B"},
+            winning_team=1, sets_limit=3,
+        )
+        response = client.get(f"/match/{match_id}/report")
+        for label in ("Set 1", "Set 2", "Set 3"):
+            assert label in response.text
+
+    def test_played_set_count_clamps_to_sets_limit(self, client):
+        # Defensive: a snapshot reporting set-4 scores in a best-of-3
+        # match (data-corruption / mode-change scenario) shouldn't
+        # render past the formal limit either, otherwise we'd paint a
+        # column the rules don't allow.
+        match_id = match_archive.archive_match(
+            oid="empty-overrun",
+            final_state={
+                "team_1": {"sets": 0, "scores": {"set_1": 25, "set_2": 0,
+                                                 "set_3": 0, "set_4": 25}},
+                "team_2": {"sets": 0, "scores": {"set_1": 22, "set_2": 0,
+                                                 "set_3": 0, "set_4": 19}},
+            },
+            customization={"Team 1 Name": "A", "Team 2 Name": "B"},
+            winning_team=1, sets_limit=3,
+        )
+        response = client.get(f"/match/{match_id}/report")
+        assert "Set 4" not in response.text
 
     def test_team_name_with_ampersand_is_not_double_escaped(self, client):
         # Regression: ``A & B`` was being html.escape'd twice — once


### PR DESCRIPTION
## Summary

Two reporting tweaks the operator asked for:

1. **Match start anchors at the first point, not the score reset.** Until the UI exposes a real "match start" marker, the audit log's first non-undo `add_point` / `set_score` becomes the match anchor: relative timestamps in the timeline restart from `+0:00` there, the "Started" row shows that timestamp, and the header duration is recomputed as `ended_at − first_scoring_ts`. Pregame records (`reset`, stray timeouts) vanish from the rendered timeline.

2. **Unplayed trailing sets stop rendering.** A best-of-3 ending 2-0 used to paint a Set 3 column, a Set 3 chart card, and a Set 3 duration cell — all reading `—`. Derive the played-set count from the final-state scores (highest N where either team has > 0 points) and iterate everything off that. The match `Format` row still says `Best of {sets_limit}`: the *rule* and the *played count* aren't the same number.

## How

Three new helpers keep the changes self-contained:

- `_first_scoring_index(audit)` — index of the first non-undo `add_point` / `set_score`.
- `_trim_pregame(audit)` — slice from that index onward.
- `_played_set_count(final_state, fallback)` — highest N with non-zero scoring data, clamped to `sets_limit`, floored at 1.

Every set-loop and every audit consumer in the route handler reads the trimmed audit / clamped count. `Format` row interpolation is unchanged (still passes `sets_limit`).

## Test plan

- [x] `pytest` — 656 / 656 (was 649; +7 cases on pregame anchoring + empty-set hiding)
- [x] `ruff check` clean
- [x] `python scripts/generate_openapi.py` + `npm run gen:types` — no drift (no public API change)
- [x] `npm run typecheck` clean
- [x] `npm test` — 277 / 277 (frontend unchanged)
- [ ] Manual: archive a 2-0 best-of-3 match → confirm Set 3 column / chart / duration are gone
- [ ] Manual: pre-game `reset` + 5 min idle + first point → confirm timeline starts at `+0:00`, duration excludes the idle window

https://claude.ai/code/session_018diFmfmUL9Brq1NxgAZJ1i

---
_Generated by [Claude Code](https://claude.ai/code/session_018diFmfmUL9Brq1NxgAZJ1i)_