### PR TITLE
fix(hud): show Reset on finished match; relayout primary action with text label

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -748,6 +748,23 @@ body {
   color: var(--green, #2e7d32);
 }
 
+/* Wider variant for buttons that pair an icon with a text label —
+   the bare-icon ``.control-btn`` is locked to a 36-px square, which
+   would clip the label. Used by the Start-match / Reset toggle on
+   the left edge of the HUD. */
+.control-btn-text {
+  width: auto;
+  min-width: 36px;
+  padding: 0 12px;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.control-btn-text .material-icons {
+  font-size: 1.1rem;
+}
+
 /* Live MM:SS counter rendered inside the bottom-bar spacer once the
    match is armed. Tabular numerals so the digits stop "dancing" when
    the seconds rollover. */

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -713,6 +713,15 @@ body {
   box-shadow: 0 -4px 12px var(--shadow);
 }
 
+/* Centre the match-timer chip inside the HUD's middle spacer.
+   ``.spacer`` is shared (ConfigPanel / TeamPanel use it as a pure
+   ``flex: 1`` filler), so override only inside the control bar. */
+.control-buttons .spacer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .control-btn {
   width: 36px;
   height: 36px;

--- a/frontend/src/components/ControlButtons.tsx
+++ b/frontend/src/components/ControlButtons.tsx
@@ -17,10 +17,20 @@ export interface ControlButtonsProps {
   showPreview: boolean;
   /**
    * Match start timestamp (Unix seconds), or ``null`` when the match
-   * is unarmed. Drives the Start-match / Reset toggle and the live
-   * timer in the spacer.
+   * is unarmed. Drives the live timer in the spacer and one half of
+   * the Start-match / Reset toggle.
    */
   matchStartedAt: number | null | undefined;
+  /**
+   * ``true`` once the match transitions to finished. Combined with
+   * ``matchStartedAt`` to decide which side of the Start/Reset
+   * toggle to render: the archive path clears
+   * ``matchStartedAt`` to prep the next match, but the operator
+   * still sees the just-played scoreboard and needs to hit Reset
+   * before the next start can be armed — so a finished match
+   * forces the Reset face regardless of the timer field.
+   */
+  matchFinished: boolean;
   onToggleVisibility: () => void;
   onToggleSimpleMode: () => void;
   onUndoLast: () => void;
@@ -30,11 +40,16 @@ export interface ControlButtonsProps {
 }
 
 /**
- * Bottom HUD control bar: visibility, preview, simple-mode, undo,
- * a live match timer (when armed), and a start-match / reset toggle
- * on the right edge. Theme + fullscreen toggles live in the config
- * panel — they're once-per-session decisions, so they don't earn
- * a permanent slot in the in-game HUD.
+ * Bottom HUD control bar. Layout, left → right:
+ *   * Start-match / Reset toggle (with text label) — primary
+ *     operator action, parked on the dominant side.
+ *   * Live match timer (when armed).
+ *   * Visibility, preview, simple-mode, undo — secondary toggles
+ *     pushed to the right edge so they don't crowd the primary
+ *     action.
+ *
+ * Theme + fullscreen toggles live in the config panel; they're
+ * once-per-session decisions and don't earn a permanent slot here.
  */
 export default function ControlButtons({
   visible,
@@ -42,6 +57,7 @@ export default function ControlButtons({
   canUndo,
   showPreview,
   matchStartedAt,
+  matchFinished,
   onToggleVisibility,
   onToggleSimpleMode,
   onUndoLast,
@@ -50,10 +66,40 @@ export default function ControlButtons({
   onReset,
 }: ControlButtonsProps) {
   const { t } = useI18n();
-  const isArmed = matchStartedAt != null;
+  // ``matchFinished`` keeps the Reset face up after a match ends —
+  // ``_archive_if_finished`` zeroes ``matchStartedAt`` to prep the
+  // next match but the operator still sees the just-played
+  // scoreboard, so the next required action is Reset, not Start.
+  const showReset = matchStartedAt != null || matchFinished;
 
   return (
     <div className="control-buttons">
+      {showReset ? (
+        <button
+          className="control-btn control-btn-text control-btn-reset"
+          onClick={onReset}
+          title={t('ctrl.reset')}
+          data-testid="reset-button"
+        >
+          <span className="material-icons">restart_alt</span>
+          <span>{t('ctrl.reset')}</span>
+        </button>
+      ) : (
+        <button
+          className="control-btn control-btn-text control-btn-start"
+          onClick={onStartMatch}
+          title={t('ctrl.startMatch')}
+          data-testid="start-match-button"
+        >
+          <span className="material-icons">play_arrow</span>
+          <span>{t('ctrl.startMatch')}</span>
+        </button>
+      )}
+
+      <div className="spacer">
+        <MatchTimer startedAt={matchStartedAt} />
+      </div>
+
       <button
         className="control-btn"
         style={{
@@ -113,30 +159,6 @@ export default function ControlButtons({
       >
         <span className="material-icons">undo</span>
       </button>
-
-      <div className="spacer">
-        <MatchTimer startedAt={matchStartedAt} />
-      </div>
-
-      {isArmed ? (
-        <button
-          className="control-btn control-btn-reset"
-          onClick={onReset}
-          title={t('ctrl.reset')}
-          data-testid="reset-button"
-        >
-          <span className="material-icons">restart_alt</span>
-        </button>
-      ) : (
-        <button
-          className="control-btn control-btn-start"
-          onClick={onStartMatch}
-          title={t('ctrl.startMatch')}
-          data-testid="start-match-button"
-        >
-          <span className="material-icons">play_arrow</span>
-        </button>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/ScoreboardView.tsx
+++ b/frontend/src/components/ScoreboardView.tsx
@@ -190,6 +190,7 @@ export default function ScoreboardView({
             canUndo={canUndo}
             showPreview={showPreview}
             matchStartedAt={state.match_started_at}
+            matchFinished={state.match_finished}
             onToggleVisibility={onToggleVisibility}
             onToggleSimpleMode={onToggleSimpleMode}
             onUndoLast={onUndoLast}

--- a/frontend/src/test/ControlButtons.test.tsx
+++ b/frontend/src/test/ControlButtons.test.tsx
@@ -11,6 +11,7 @@ const defaultProps = {
   canUndo: true,
   showPreview: false,
   matchStartedAt: null as number | null,
+  matchFinished: false,
   onToggleVisibility: vi.fn(),
   onToggleSimpleMode: vi.fn(),
   onUndoLast: vi.fn(),
@@ -136,6 +137,34 @@ describe('ControlButtons', () => {
     );
     fireEvent.click(screen.getByTestId('reset-button'));
     expect(onReset).toHaveBeenCalledOnce();
+  });
+
+  it('shows Reset (not Start) once the match is finished, even if matchStartedAt is null', () => {
+    // Regression: ``_archive_if_finished`` clears
+    // ``match_started_at`` to prep the next match, but the
+    // operator still sees the just-played scoreboard. The next
+    // required action is Reset, not Start — otherwise clicking
+    // Start would arm a fresh timer over the visible (finished)
+    // scores.
+    renderWithI18n(
+      <ControlButtons
+        {...defaultProps}
+        matchStartedAt={null}
+        matchFinished={true}
+      />,
+    );
+    expect(screen.getByTestId('reset-button')).toBeInTheDocument();
+    expect(screen.queryByTestId('start-match-button')).toBeNull();
+  });
+
+  it('renders the start/reset button with a visible text label', () => {
+    // The primary action sits on the left edge of the HUD with an
+    // icon *and* text — ``ctrl.startMatch`` / ``ctrl.reset`` from
+    // the i18n catalogue. Bare-icon mode is reserved for the
+    // secondary toggles on the right.
+    renderWithI18n(<ControlButtons {...defaultProps} matchStartedAt={null} />);
+    const start = screen.getByTestId('start-match-button');
+    expect(start.textContent).toMatch(/Start match/i);
   });
 
   // ── Match timer ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Three operator-requested HUD tweaks:

1. **Bug fix**: with `match_finished=true` the HUD was showing **Start match** instead of **Reset**. `_archive_if_finished` clears `session.match_started_at` to prep the next match, so the toggle's `isArmed = matchStartedAt != null` check flipped back to Start while the operator was still looking at the just-played scoreboard. Add a new `matchFinished` prop and combine: `showReset = matchStartedAt != null || matchFinished`.
2. **Layout**: move the **Start / Reset** primary action to the **left edge** with an icon + text label. It's the dominant operator action and deserves a dedicated spot away from the secondary toggles.
3. **Layout**: move **visibility / preview / simple-mode / undo** (the secondary toggles) to the **right** of the spacer. Final order: `[primary + label] [spacer + timer] [secondary toggles]`.

A new `.control-btn-text` CSS variant unlocks the 36-px square width so the label fits.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — **288 / 288** (was 286; +2 new cases — Reset shown when `matchFinished` despite `matchStartedAt=null`, and start/reset carries a visible text label)
- [x] No backend or schema changes
- [ ] Manual: finish a match → Reset button visible on the left with text. Reset → Start match on the left. Score a point → Reset takes its place. Visibility/preview/simple-mode/undo all on the right.

https://claude.ai/code/session_018diFmfmUL9Brq1NxgAZJ1i

---
_Generated by [Claude Code](https://claude.ai/code/session_018diFmfmUL9Brq1NxgAZJ1i)_