### PR TITLE
refactor(report): drop Match-winner badge from scoreboard panel

### DIFF
--- a/app/match_report.py
+++ b/app/match_report.py
@@ -234,7 +234,6 @@ _REPORT_TEMPLATE = """<!doctype html>
   }}
   .team .name {{ font-weight: 600; font-size: 18px; }}
   .team .sets {{ font-size: 56px; line-height: 1; font-weight: 700; }}
-  .team .winner {{ font-size: 12px; opacity: 0.85; margin-top: 4px; }}
   .vs {{ font-size: 24px; font-weight: 600; color: var(--muted); }}
   table {{
     width: 100%;
@@ -363,14 +362,12 @@ _REPORT_TEMPLATE = """<!doctype html>
     {team1_logo}
     <div class="name">{team1_name}</div>
     <div class="sets">{team1_sets}</div>
-    {team1_winner_badge}
   </div>
   <div class="vs">{versus}</div>
   <div class="team t2">
     {team2_logo}
     <div class="name">{team2_name}</div>
     <div class="sets">{team2_sets}</div>
-    {team2_winner_badge}
   </div>
 </section>
 
@@ -1463,13 +1460,6 @@ async def match_report(
         f"{html.escape(team2_name)}: {timeouts_t2 if timeouts_t2 is not None else '—'}"
     )
 
-    winning_team = payload.get("winning_team")
-    winner_badge = (
-        f'<div class="winner">{html.escape(_t(locale, "matchWinner"))}</div>'
-    )
-    team1_winner = winner_badge if winning_team == 1 else ""
-    team2_winner = winner_badge if winning_team == 2 else ""
-
     # ``match_label`` and ``permalink`` are kept raw here — every
     # consumer escapes at insertion time. Pre-escaping the source
     # would push the title through ``html.escape`` twice (once here,
@@ -1493,8 +1483,6 @@ async def match_report(
         team1_fg=t1_fg,
         team2_color=t2_color,
         team2_fg=t2_fg,
-        team1_winner_badge=team1_winner,
-        team2_winner_badge=team2_winner,
         set_count=played_sets,
         set_headers=set_headers,
         team1_set_cells=_team_set_cells(team1),

--- a/app/match_report_i18n.py
+++ b/app/match_report_i18n.py
@@ -27,7 +27,6 @@ _TRANSLATIONS: dict[str, dict[str, str]] = {
     "en": {
         "title": "Match report — {label}",
         "duration": "Duration",
-        "matchWinner": "Match winner",
         "setByset": "Set-by-set",
         "team": "Team",
         "timeoutsLabel": "Timeouts (final set)",
@@ -73,7 +72,6 @@ _TRANSLATIONS: dict[str, dict[str, str]] = {
     "es": {
         "title": "Informe del partido — {label}",
         "duration": "Duración",
-        "matchWinner": "Ganador del partido",
         "setByset": "Set a set",
         "team": "Equipo",
         "timeoutsLabel": "Tiempos muertos (set final)",
@@ -119,7 +117,6 @@ _TRANSLATIONS: dict[str, dict[str, str]] = {
     "pt": {
         "title": "Relatório do jogo — {label}",
         "duration": "Duração",
-        "matchWinner": "Vencedor do jogo",
         "setByset": "Set a set",
         "team": "Equipa",
         "timeoutsLabel": "Tempos mortos (set final)",
@@ -165,7 +162,6 @@ _TRANSLATIONS: dict[str, dict[str, str]] = {
     "it": {
         "title": "Referto della partita — {label}",
         "duration": "Durata",
-        "matchWinner": "Vincitore della partita",
         "setByset": "Set per set",
         "team": "Squadra",
         "timeoutsLabel": "Time-out (set finale)",
@@ -211,7 +207,6 @@ _TRANSLATIONS: dict[str, dict[str, str]] = {
     "fr": {
         "title": "Rapport du match — {label}",
         "duration": "Durée",
-        "matchWinner": "Vainqueur du match",
         "setByset": "Set par set",
         "team": "Équipe",
         "timeoutsLabel": "Temps morts (set décisif)",
@@ -257,7 +252,6 @@ _TRANSLATIONS: dict[str, dict[str, str]] = {
     "de": {
         "title": "Spielbericht — {label}",
         "duration": "Dauer",
-        "matchWinner": "Spielsieger",
         "setByset": "Satz für Satz",
         "team": "Team",
         "timeoutsLabel": "Auszeiten (entscheidender Satz)",

--- a/tests/test_match_report.py
+++ b/tests/test_match_report.py
@@ -194,10 +194,13 @@ class TestMatchReport:
 
     def test_renders_final_score(self, client, archived_match):
         response = client.get(f"/match/{archived_match}/report")
-        # Match winner team 1 with 3-1 sets.
+        # Match winner is team 1 with 3-1 sets — the score blocks
+        # carry both numbers; the winner badge itself was dropped
+        # from the scoreboard panel (the score on its own conveys
+        # the same information without an extra label).
         assert ">3<" in response.text
         assert ">1<" in response.text
-        assert "Match winner" in response.text
+        assert "Match winner" not in response.text
 
     def test_renders_set_by_set_table(self, client, archived_match):
         response = client.get(f"/match/{archived_match}/report")


### PR DESCRIPTION
## Summary

Operator feedback: the "Match winner" / "Ganador del partido" badge under the scoreboard's score block in the single-match report was redundant — the higher set count already conveys who won. Strip it.

- Remove `{team1_winner_badge}` / `{team2_winner_badge}` from the report template.
- Drop the variable construction in the route handler.
- Remove the unused `matchWinner` i18n key across all six locales.
- Remove the dead `.team .winner` CSS rule.
- The matches-index page keeps its separate `.winner` class on the winning set count (different surface; not what the operator was flagging).

## Test plan

- [x] `pytest` — 72 / 72 (`test_renders_final_score` now asserts "Match winner" is **not** present)
- [x] `ruff check` clean
- [x] No frontend / schema changes

https://claude.ai/code/session_018diFmfmUL9Brq1NxgAZJ1i

---
_Generated by [Claude Code](https://claude.ai/code/session_018diFmfmUL9Brq1NxgAZJ1i)_