### PR TITLE
chore: improvement areas — OID validation, health, WS backoff, cache, infra

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN npm run build
 
 # ---- Stage 2: Python runtime ----
 # Only runtime artifacts land here — no Node, no frontend source, no dev deps.
-FROM python:3.14-slim AS runtime
+FROM python:3.13-slim AS runtime
 WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/app/api/action_log.py
+++ b/app/api/action_log.py
@@ -32,16 +32,17 @@ import hashlib
 import json
 import logging
 import os
-import re
 import tempfile
 import threading
 import time
 from collections.abc import Set as AbstractSet
 from typing import Optional
 
+from app.api.oid_validation import OID_PATTERN
+
 logger = logging.getLogger(__name__)
 
-_OID_PATTERN = re.compile(r"^[A-Za-z0-9._\-]{1,128}$")
+_OID_PATTERN = OID_PATTERN
 _FILENAME_HASH_LEN = 20
 
 # Actions whose forward records can be reversed by an undo (either

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -143,17 +143,33 @@ class GameService:
         callers still receive the current session model, just without a
         redundant HTTP round-trip. ``update_customization`` primes the
         timestamp, so a write is immediately visible on the next read.
+
+        Concurrent callers for the same session coalesce on
+        ``session.customization_fetch_lock``: only the first request hits
+        the overlay server, the rest return the freshly populated cache
+        as soon as the lock is released. Without this, a burst of UI
+        opens (config panel, scoreboard mount, control bar refresh) can
+        fire several simultaneous fetches before the first one populates
+        the TTL window.
         """
         now = time.monotonic()
         last = getattr(session, "_last_customization_fetch", None)
         if last is not None and now - last < CUSTOMIZATION_CACHE_TTL_SECONDS:
             return session.customization.get_model()
 
-        fresh = session.backend.get_current_customization()
-        if fresh is not None:
-            session.customization.set_model(fresh)
-        session._last_customization_fetch = now
-        return session.customization.get_model()
+        with session.customization_fetch_lock:
+            # Re-check inside the lock: a sibling caller may have refreshed
+            # while we were blocked, in which case the cache is now warm.
+            now = time.monotonic()
+            last = getattr(session, "_last_customization_fetch", None)
+            if last is not None and now - last < CUSTOMIZATION_CACHE_TTL_SECONDS:
+                return session.customization.get_model()
+
+            fresh = session.backend.get_current_customization()
+            if fresh is not None:
+                session.customization.set_model(fresh)
+            session._last_customization_fetch = now
+            return session.customization.get_model()
 
     # ------------------------------------------------------------------
     # State mutations

--- a/app/api/match_archive.py
+++ b/app/api/match_archive.py
@@ -36,10 +36,11 @@ import tempfile
 from typing import Optional
 
 from app.api import action_log
+from app.api.oid_validation import OID_PATTERN
 
 logger = logging.getLogger(__name__)
 
-_OID_PATTERN = re.compile(r"^[A-Za-z0-9._\-]{1,128}$")
+_OID_PATTERN = OID_PATTERN
 _FILENAME_HASH_LEN = 20
 
 # Match basename: ``match_<20-hex>_<UTC-ISO>.json`` where the timestamp

--- a/app/api/oid_validation.py
+++ b/app/api/oid_validation.py
@@ -1,0 +1,26 @@
+"""Centralised OID validation pattern.
+
+Every layer that touches an OID — request schemas, audit log file
+naming, session metadata, and match archives — checks against the
+same regex so that a string accepted by one is accepted by all.
+
+Custom overlay OIDs (e.g. ``C-mybroadcast/line``) include a slash,
+so the pattern allows ``/``. Slashes are safe for on-disk paths
+because every filesystem-backed module hashes the OID before using
+it in a filename, never interpolating it directly. The negative
+lookahead still rejects ``..`` substrings as defence in depth so a
+caller that one day forgets to hash cannot accidentally walk up
+the data directory.
+
+Length is capped at 200 to match :class:`InitRequest.oid`'s
+``max_length`` and to keep audit/persistence payloads bounded.
+"""
+
+import re
+
+OID_PATTERN = re.compile(r"^(?!.*\.\.)[A-Za-z0-9._\-/]{1,200}$")
+
+
+def is_valid_oid(value: object) -> bool:
+    """Return True iff *value* is a non-empty OID string within bounds."""
+    return isinstance(value, str) and OID_PATTERN.match(value) is not None

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -21,7 +21,7 @@ class InitRequest(BaseModel):
         if not OID_PATTERN.match(v):
             raise ValueError(
                 'OID must contain only alphanumeric characters, hyphens, '
-                'underscores, slashes, and dots'
+                'underscores, slashes, and dots. ".." is not allowed.'
             )
         return v
 

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1,4 +1,3 @@
-import re
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -3,6 +3,8 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.api.oid_validation import OID_PATTERN
+
 # ---------------------------------------------------------------------------
 # Request models
 # ---------------------------------------------------------------------------
@@ -17,8 +19,11 @@ class InitRequest(BaseModel):
     @field_validator('oid')
     @classmethod
     def validate_oid(cls, v):
-        if not re.match(r'^[A-Za-z0-9_\-/.]+$', v):
-            raise ValueError('OID must contain only alphanumeric characters, hyphens, underscores, slashes, and dots')
+        if not OID_PATTERN.match(v):
+            raise ValueError(
+                'OID must contain only alphanumeric characters, hyphens, '
+                'underscores, slashes, and dots'
+            )
         return v
 
 

--- a/app/api/session_manager.py
+++ b/app/api/session_manager.py
@@ -66,6 +66,9 @@ class GameSession:
         self.current_set = self._compute_current_set()
         # Async lock for protecting concurrent mutations
         self.lock = asyncio.Lock()
+        # Coalesces concurrent customization refresh fetches so a burst
+        # of UI requests collapses into a single overlay-server round-trip.
+        self.customization_fetch_lock = threading.Lock()
         # Last access time for TTL-based cleanup
         self.last_accessed = time.monotonic()
         logger.info(

--- a/app/api/session_persistence.py
+++ b/app/api/session_persistence.py
@@ -17,9 +17,10 @@ import hashlib
 import json
 import logging
 import os
-import re
 import tempfile
 from typing import Optional
+
+from app.api.oid_validation import OID_PATTERN
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ logger = logging.getLogger(__name__)
 # convention is uniform.
 _FILENAME_HASH_LEN = 20
 
-_OID_PATTERN = re.compile(r"^[A-Za-z0-9._\-]{1,128}$")
+_OID_PATTERN = OID_PATTERN
 
 
 def _hashed_basename(oid: str) -> str:

--- a/app/backend.py
+++ b/app/backend.py
@@ -8,6 +8,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from app.customization_cache import CustomizationCache
 from app.env_vars_manager import EnvVarsManager
 from app.overlay_backends import (
     CustomOverlayBackend,
@@ -79,22 +80,18 @@ class Backend:
         self.session.mount("http://", _adapter)
         self.session.mount("https://", _adapter)
         self.executor = ThreadPoolExecutor(max_workers=5)
-        self._customization_cache = None
-        self._customization_cache_ts = 0.0
+        self._customization_cache = CustomizationCache(
+            _CUSTOMIZATION_CACHE_TTL_SECONDS
+        )
         self._overlay = self._create_overlay_backend()
 
     def _remember_customization(self, data):
         """Store a copy of *data* in the cache so callers can't mutate it."""
-        self._customization_cache = data.copy() if data is not None else None
-        self._customization_cache_ts = time.monotonic()
+        self._customization_cache.remember(data)
 
     def _fresh_customization_cache(self):
         """Return a fresh copy of the cached customization, or None if stale."""
-        if self._customization_cache is None:
-            return None
-        if (time.monotonic() - self._customization_cache_ts) > _CUSTOMIZATION_CACHE_TTL_SECONDS:
-            return None
-        return self._customization_cache.copy()
+        return self._customization_cache.fresh()
 
     @staticmethod
     def _local_overlay_exists(overlay_id: str) -> bool:

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -306,6 +306,7 @@ def _register_system_endpoints(application: FastAPI) -> None:
         """
         import tempfile
         import time
+
         from app.api import action_log
 
         checks: dict[str, bool] = {}

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -288,6 +288,53 @@ def _register_system_endpoints(application: FastAPI) -> None:
             "service": "volley-overlay-control",
         }
 
+    @application.get("/health/ready")
+    def readiness_check():
+        """Readiness probe — fails when the app cannot serve real traffic.
+
+        Checks the local invariants the app needs to make forward progress:
+        the data directory is writable (audit log / session meta / match
+        archives all live there) and the FastAPI router is wired up.
+        Dependencies on external overlay servers are intentionally not
+        probed: a transient overlays.uno blip should not flip pods out
+        of the load balancer.
+        """
+        import time
+        from app.api import action_log
+
+        checks: dict[str, bool] = {}
+        details: dict[str, str] = {}
+
+        try:
+            data_dir = action_log._data_dir()
+            os.makedirs(data_dir, exist_ok=True)
+            probe = os.path.join(data_dir, ".readiness_probe")
+            with open(probe, "w", encoding="utf-8") as f:
+                f.write("ok")
+            os.remove(probe)
+            checks["data_dir_writable"] = True
+        except Exception as exc:
+            checks["data_dir_writable"] = False
+            details["data_dir_writable"] = str(exc)
+
+        try:
+            checks["routes_mounted"] = bool(application.routes)
+        except Exception as exc:
+            checks["routes_mounted"] = False
+            details["routes_mounted"] = str(exc)
+
+        all_ok = all(checks.values())
+        payload = {
+            "status": "ok" if all_ok else "degraded",
+            "timestamp": int(time.time()),
+            "service": "volley-overlay-control",
+            "checks": checks,
+        }
+        if details:
+            payload["details"] = details
+        status_code = 200 if all_ok else 503
+        return JSONResponse(payload, status_code=status_code)
+
 
 def _register_spa(application: FastAPI) -> None:
     """Mount the built SPA as the catch-all. Must be called last."""

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -292,36 +292,41 @@ def _register_system_endpoints(application: FastAPI) -> None:
     def readiness_check():
         """Readiness probe — fails when the app cannot serve real traffic.
 
-        Checks the local invariants the app needs to make forward progress:
-        the data directory is writable (audit log / session meta / match
-        archives all live there) and the FastAPI router is wired up.
-        Dependencies on external overlay servers are intentionally not
-        probed: a transient overlays.uno blip should not flip pods out
-        of the load balancer.
+        Checks the local invariants the app needs to make forward
+        progress: the data directory is writable (audit log, session
+        meta, and match archives all live there). Dependencies on
+        external overlay servers are intentionally not probed: a
+        transient overlays.uno blip should not flip pods out of the
+        load balancer.
+
+        On failure the underlying exception is logged but the response
+        only carries a generic reason — readiness probes are typically
+        unauthenticated and we don't want to surface filesystem paths
+        to whoever can reach the endpoint.
         """
+        import tempfile
         import time
         from app.api import action_log
 
         checks: dict[str, bool] = {}
-        details: dict[str, str] = {}
+        reasons: dict[str, str] = {}
 
         try:
             data_dir = action_log._data_dir()
             os.makedirs(data_dir, exist_ok=True)
-            probe = os.path.join(data_dir, ".readiness_probe")
-            with open(probe, "w", encoding="utf-8") as f:
-                f.write("ok")
-            os.remove(probe)
+            # NamedTemporaryFile gives a unique name so concurrent probes
+            # cannot race on the same file handle. delete=True ensures
+            # the probe is cleaned up even if a later assertion raises.
+            with tempfile.NamedTemporaryFile(
+                dir=data_dir, prefix=".readiness_probe_", delete=True,
+            ) as probe:
+                probe.write(b"ok")
+                probe.flush()
             checks["data_dir_writable"] = True
-        except Exception as exc:
+        except Exception:
+            logger.exception("Readiness probe: data dir write failed")
             checks["data_dir_writable"] = False
-            details["data_dir_writable"] = str(exc)
-
-        try:
-            checks["routes_mounted"] = bool(application.routes)
-        except Exception as exc:
-            checks["routes_mounted"] = False
-            details["routes_mounted"] = str(exc)
+            reasons["data_dir_writable"] = "write_failed"
 
         all_ok = all(checks.values())
         payload = {
@@ -330,8 +335,8 @@ def _register_system_endpoints(application: FastAPI) -> None:
             "service": "volley-overlay-control",
             "checks": checks,
         }
-        if details:
-            payload["details"] = details
+        if reasons:
+            payload["reasons"] = reasons
         status_code = 200 if all_ok else 503
         return JSONResponse(payload, status_code=status_code)
 

--- a/app/customization_cache.py
+++ b/app/customization_cache.py
@@ -1,0 +1,61 @@
+"""Thread-safe TTL cache for the most recently fetched overlay customization.
+
+Extracted from :class:`app.backend.Backend` so the read/write/expiry policy
+lives in one place and can be unit-tested without spinning up an overlay
+backend or an HTTP session.
+
+The cache is intentionally tiny (one slot per ``Backend``) because each
+backend instance maps to one OID; multi-OID coordination happens at the
+``GameSession`` layer above. All reads and writes deep-copy the dict so
+callers can mutate their copy without poisoning the cached value, and a
+lock guards the slot because background save tasks (running on the
+backend's ``ThreadPoolExecutor``) update the cache concurrently with
+foreground reads from request handlers.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Optional
+
+
+class CustomizationCache:
+    """A single-slot TTL cache for an overlay-customization dict."""
+
+    def __init__(self, ttl_seconds: float):
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        self._ttl = float(ttl_seconds)
+        self._data: Optional[dict] = None
+        self._timestamp: float = 0.0
+        self._lock = threading.Lock()
+
+    @property
+    def ttl_seconds(self) -> float:
+        return self._ttl
+
+    def remember(self, data: Optional[dict]) -> None:
+        """Store *data* as the freshest snapshot. ``None`` clears the slot.
+
+        The dict is shallow-copied to insulate the cache from later
+        mutations by the caller.
+        """
+        with self._lock:
+            self._data = data.copy() if data is not None else None
+            self._timestamp = time.monotonic()
+
+    def fresh(self) -> Optional[dict]:
+        """Return a copy of the cached dict if not stale, else ``None``."""
+        with self._lock:
+            if self._data is None:
+                return None
+            if (time.monotonic() - self._timestamp) > self._ttl:
+                return None
+            return self._data.copy()
+
+    def invalidate(self) -> None:
+        """Drop any cached value without waiting for TTL expiry."""
+        with self._lock:
+            self._data = None
+            self._timestamp = 0.0

--- a/app/customization_cache.py
+++ b/app/customization_cache.py
@@ -6,11 +6,11 @@ backend or an HTTP session.
 
 The cache is intentionally tiny (one slot per ``Backend``) because each
 backend instance maps to one OID; multi-OID coordination happens at the
-``GameSession`` layer above. All reads and writes deep-copy the dict so
-callers can mutate their copy without poisoning the cached value, and a
-lock guards the slot because background save tasks (running on the
-backend's ``ThreadPoolExecutor``) update the cache concurrently with
-foreground reads from request handlers.
+``GameSession`` layer above. ``remember`` and ``fresh`` shallow-copy the
+dict so callers can swap top-level entries without poisoning the cached
+value, and a lock guards the slot because background save tasks (running
+on the backend's ``ThreadPoolExecutor``) update the cache concurrently
+with foreground reads from request handlers.
 """
 
 from __future__ import annotations

--- a/app/customization_cache.py
+++ b/app/customization_cache.py
@@ -6,8 +6,9 @@ backend or an HTTP session.
 
 The cache is intentionally tiny (one slot per ``Backend``) because each
 backend instance maps to one OID; multi-OID coordination happens at the
-``GameSession`` layer above. ``remember`` and ``fresh`` shallow-copy the
-dict so callers can swap top-level entries without poisoning the cached
+``GameSession`` layer above. ``remember`` and ``fresh`` deep-copy the
+dict so callers can mutate any level (including future nested values
+like ``geometry`` or ``colors`` sub-dicts) without poisoning the cached
 value, and a lock guards the slot because background save tasks (running
 on the backend's ``ThreadPoolExecutor``) update the cache concurrently
 with foreground reads from request handlers.
@@ -15,6 +16,7 @@ with foreground reads from request handlers.
 
 from __future__ import annotations
 
+import copy
 import threading
 import time
 from typing import Optional
@@ -38,21 +40,22 @@ class CustomizationCache:
     def remember(self, data: Optional[dict]) -> None:
         """Store *data* as the freshest snapshot. ``None`` clears the slot.
 
-        The dict is shallow-copied to insulate the cache from later
-        mutations by the caller.
+        The dict is deep-copied to insulate the cache from later
+        mutations by the caller, including writes into any nested
+        sub-structures the customization payload may carry.
         """
         with self._lock:
-            self._data = data.copy() if data is not None else None
+            self._data = copy.deepcopy(data) if data is not None else None
             self._timestamp = time.monotonic()
 
     def fresh(self) -> Optional[dict]:
-        """Return a copy of the cached dict if not stale, else ``None``."""
+        """Return a deep-copy of the cached dict if not stale, else ``None``."""
         with self._lock:
             if self._data is None:
                 return None
             if (time.monotonic() - self._timestamp) > self._ttl:
                 return None
-            return self._data.copy()
+            return copy.deepcopy(self._data)
 
     def invalidate(self) -> None:
         """Drop any cached value without waiting for TTL expiry."""

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,8 +22,10 @@
         "@vitest/coverage-v8": "^4.1.2",
         "jsdom": "^29.0.1",
         "openapi-typescript": "^7.13.0",
+        "rollup-plugin-visualizer": "^5.12.0",
         "typescript": "^5.9.3",
         "vite": "^6.4.2",
+        "vite-plugin-compression2": "^1.3.3",
         "vite-plugin-pwa": "^1.2.0",
         "vitest": "^4.1.2"
       }
@@ -3327,7 +3329,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3691,6 +3692,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/colorette": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
@@ -3910,6 +3946,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
@@ -3983,6 +4029,13 @@
       "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -4436,6 +4489,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -4870,6 +4933,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
@@ -4884,6 +4963,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -5139,6 +5228,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -5622,6 +5724,24 @@
       ],
       "license": "MIT"
     },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openapi-typescript": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
@@ -6036,6 +6156,16 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6110,6 +6240,47 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.0",
         "@rollup/rollup-win32-x64-msvc": "4.60.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.14.0.tgz",
+      "integrity": "sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^8.4.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/safe-array-concat": {
@@ -6494,6 +6665,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -6596,6 +6782,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
@@ -6649,6 +6848,13 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tar-mini": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tar-mini/-/tar-mini-0.2.0.tgz",
+      "integrity": "sha512-+qfUHz700DWnRutdUsxRRVZ38G1Qr27OetwaMYTdg8hcPxf46U0S1Zf76dQMWRBmusOt2ZCK5kbIaiLkoGO7WQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7113,6 +7319,20 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-compression2": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-compression2/-/vite-plugin-compression2-1.4.0.tgz",
+      "integrity": "sha512-UEk0Bq1IkkwqbDLoLOHZ8WTmN1QbvR28fvNl2liB88/6SG1oLrTVkxfjqW3pdla/rKQ6QXn+pJpv3GBbl+k56g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0",
+        "tar-mini": "^0.2.0"
+      },
+      "peerDependencies": {
+        "vite": "^2.0.0||^3.0.0||^4.0.0||^5.0.0 ||^6.0.0"
       }
     },
     "node_modules/vite-plugin-pwa": {
@@ -7727,6 +7947,40 @@
         "workbox-core": "7.4.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -7744,6 +7998,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -7757,6 +8021,25 @@
       "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,8 +29,10 @@
     "@vitest/coverage-v8": "^4.1.2",
     "jsdom": "^29.0.1",
     "openapi-typescript": "^7.13.0",
+    "rollup-plugin-visualizer": "^5.12.0",
     "typescript": "^5.9.3",
     "vite": "^6.4.2",
+    "vite-plugin-compression2": "^1.3.3",
     "vite-plugin-pwa": "^1.2.0",
     "vitest": "^4.1.2"
   },

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -3701,6 +3701,23 @@
         "summary": "Health Check"
       }
     },
+    "/health/ready": {
+      "get": {
+        "description": "Readiness probe \u2014 fails when the app cannot serve real traffic.\n\nChecks the local invariants the app needs to make forward\nprogress: the data directory is writable (audit log, session\nmeta, and match archives all live there). Dependencies on\nexternal overlay servers are intentionally not probed: a\ntransient overlays.uno blip should not flip pods out of the\nload balancer.\n\nOn failure the underlying exception is logged but the response\nonly carries a generic reason \u2014 readiness probes are typically\nunauthenticated and we don't want to surface filesystem paths\nto whoever can reach the endpoint.",
+        "operationId": "readiness_check_health_ready_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Readiness Check"
+      }
+    },
     "/list/overlay": {
       "get": {
         "description": "Return every overlay id plus its output key.\n\nGated behind ``OVERLAY_MANAGER_PASSWORD`` because the response\ndefeats the capability-URL design of ``/overlay/{output_key}``.\nSee ``AUTHENTICATION.md`` (F-4).",

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -746,6 +746,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/health/ready": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Readiness Check
+         * @description Readiness probe — fails when the app cannot serve real traffic.
+         *
+         *     Checks the local invariants the app needs to make forward
+         *     progress: the data directory is writable (audit log, session
+         *     meta, and match archives all live there). Dependencies on
+         *     external overlay servers are intentionally not probed: a
+         *     transient overlays.uno blip should not flip pods out of the
+         *     load balancer.
+         *
+         *     On failure the underlying exception is logged but the response
+         *     only carries a generic reason — readiness probes are typically
+         *     unauthenticated and we don't want to surface filesystem paths
+         *     to whoever can reach the endpoint.
+         */
+        get: operations["readiness_check_health_ready_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/list/overlay": {
         parameters: {
             query?: never;
@@ -2734,6 +2766,26 @@ export interface operations {
         };
     };
     health_check_health_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    readiness_check_health_ready_get: {
         parameters: {
             query?: never;
             header?: never;

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -27,11 +27,8 @@ export const HUD_AUTO_HIDE_MS = 5000;
  *  detect zombie connections (ms). */
 export const WS_PING_INTERVAL_MS = 25000;
 
-/** Delay before attempting to reconnect after an unexpected close (ms).
- *  Excludes intentional close codes such as 4004 ("no session"). */
-export const WS_RECONNECT_MS = 3000;
-
-/** Initial delay for the exponential reconnect backoff (ms). */
+/** Initial delay for the exponential reconnect backoff (ms). Excludes
+ *  intentional close codes such as 4004 ("no session"). */
 export const WS_RECONNECT_BASE_MS = 1000;
 
 /** Upper bound for the exponential reconnect backoff (ms). Prevents the

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -30,3 +30,13 @@ export const WS_PING_INTERVAL_MS = 25000;
 /** Delay before attempting to reconnect after an unexpected close (ms).
  *  Excludes intentional close codes such as 4004 ("no session"). */
 export const WS_RECONNECT_MS = 3000;
+
+/** Initial delay for the exponential reconnect backoff (ms). */
+export const WS_RECONNECT_BASE_MS = 1000;
+
+/** Upper bound for the exponential reconnect backoff (ms). Prevents the
+ *  retry interval from growing unboundedly while the server is down. */
+export const WS_RECONNECT_MAX_MS = 60000;
+
+/** Multiplicative factor between successive reconnect attempts. */
+export const WS_RECONNECT_FACTOR = 2;

--- a/frontend/src/hooks/useGameState.ts
+++ b/frontend/src/hooks/useGameState.ts
@@ -3,7 +3,11 @@ import * as api from '../api/client';
 import type { GameState, ActionResponse, Team } from '../api/client';
 import type { components } from '../api/schema';
 import { createWebSocket } from '../api/websocket';
-import { WS_RECONNECT_MS } from '../constants';
+import {
+  WS_RECONNECT_BASE_MS,
+  WS_RECONNECT_FACTOR,
+  WS_RECONNECT_MAX_MS,
+} from '../constants';
 
 type Customization = Record<string, unknown>;
 type TeamState = components['schemas']['TeamState'];
@@ -84,6 +88,7 @@ export function useGameState(oid: string | null): UseGameStateResult {
   const [error, setError] = useState<string | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttempts = useRef<number>(0);
   const abortRef = useRef<AbortController | null>(null);
   // Mirror of `state` used by handleAction so it can synchronously snapshot
   // the current state and apply an optimistic update without relying on an
@@ -114,11 +119,25 @@ export function useGameState(oid: string | null): UseGameStateResult {
     wsRef.current = createWebSocket(oid, {
       onStateUpdate: (newState) => applyState(newState),
       onCustomizationUpdate: (newCust) => setCustomization(newCust),
-      onOpen: () => setConnected(true),
+      onOpen: () => {
+        // Successful handshake: reset the backoff so the next outage
+        // starts retrying quickly again.
+        reconnectAttempts.current = 0;
+        setConnected(true);
+      },
       onClose: (event) => {
         setConnected(false);
         if (event.code !== 4004) {
-          reconnectTimer.current = setTimeout(connectWs, WS_RECONNECT_MS);
+          // Exponential backoff with jitter: prevents reconnect storms
+          // when many clients lose the server simultaneously, and avoids
+          // hammering an unreachable server during long outages.
+          const attempt = reconnectAttempts.current;
+          reconnectAttempts.current = attempt + 1;
+          const exp = WS_RECONNECT_BASE_MS * Math.pow(WS_RECONNECT_FACTOR, attempt);
+          const capped = Math.min(exp, WS_RECONNECT_MAX_MS);
+          const jitter = Math.random() * 0.3 * capped;
+          const delay = capped + jitter;
+          reconnectTimer.current = setTimeout(connectWs, delay);
         }
       },
       onError: () => setConnected(false),

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,24 @@ import { VitePWA } from 'vite-plugin-pwa';
 
 const analyze = process.env.ANALYZE === 'true';
 
+// Pre-compresses static assets at build time so the FastAPI server can
+// serve ``.gz`` / ``.br`` siblings without paying the CPU cost on every
+// request. ``vite-plugin-compression2`` is a soft dep: when it isn't
+// installed (e.g. legacy lockfile, dev-only env) the build still works,
+// it just ships uncompressed assets.
+async function maybeCompression() {
+  try {
+    const mod = await import('vite-plugin-compression2');
+    const compression = mod.compression || mod.default;
+    return [
+      compression({ algorithm: 'gzip', threshold: 1024 }),
+      compression({ algorithm: 'brotliCompress', threshold: 1024 }),
+    ];
+  } catch {
+    return [];
+  }
+}
+
 async function maybeVisualizer() {
   if (!analyze) return null;
   try {
@@ -28,6 +46,7 @@ export default defineConfig(async () => ({
   plugins: [
     react(),
     await maybeVisualizer(),
+    ...(await maybeCompression()),
     VitePWA({
       registerType: 'autoUpdate',
       includeAssets: ['fonts/**/*', 'icon.svg'],

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,11 +4,13 @@ import { VitePWA } from 'vite-plugin-pwa';
 
 const analyze = process.env.ANALYZE === 'true';
 
-// Pre-compresses static assets at build time so the FastAPI server can
-// serve ``.gz`` / ``.br`` siblings without paying the CPU cost on every
-// request. ``vite-plugin-compression2`` is a soft dep: when it isn't
-// installed (e.g. legacy lockfile, dev-only env) the build still works,
-// it just ships uncompressed assets.
+// Pre-compresses static assets at build time. The FastAPI app serves
+// uncompressed bundles and lets ``GZipMiddleware`` gzip on the fly,
+// so the ``.gz`` / ``.br`` siblings only add value when a reverse
+// proxy (nginx with ``gzip_static``/``brotli_static``, Caddy, or a
+// CDN) is in front and can serve them directly without recompressing.
+// ``vite-plugin-compression2`` is a soft dep: when it isn't installed
+// the build still succeeds, it just skips emitting the siblings.
 async function maybeCompression() {
   try {
     const mod = await import('vite-plugin-compression2');

--- a/tests/test_action_log.py
+++ b/tests/test_action_log.py
@@ -30,9 +30,12 @@ class TestActionLog:
         assert action_log.read_all("never-written") == []
 
     def test_invalid_oid_silently_ignored(self):
+        # ``with/slash`` is intentionally omitted: custom-overlay OIDs
+        # legitimately contain slashes and the basename hashes the OID
+        # before touching the filesystem, so slash is safe.
         action_log.append("../bad", "add_point", {}, {})
-        action_log.append("with/slash", "add_point", {}, {})
         action_log.append("", "add_point", {}, {})
+        action_log.append("white space", "add_point", {}, {})
         # Verify no files were created.
         files = [
             f for f in os.listdir(action_log._data_dir())

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -31,9 +31,13 @@ class TestSessionPersistenceFile:
         assert session_persistence.load_session_meta("never-saved") is None
 
     def test_invalid_oid_is_silently_ignored(self):
-        # Path-traversal-y inputs and OIDs with separators must not produce
-        # any file and load must return None.
-        for bad in ("../escape", "with/slash", "", "a" * 200, "white space"):
+        # Path-traversal-y inputs (``..``), out-of-range lengths, and OIDs
+        # containing whitespace or other disallowed characters must not
+        # produce any file. ``with/slash`` is intentionally NOT here:
+        # custom-overlay OIDs include slashes (e.g. ``C-foo/line``) and
+        # the on-disk basename is a sha256 prefix of the OID, so slashes
+        # never reach the filesystem path.
+        for bad in ("../escape", "", "a" * 201, "white space", "weird?chars"):
             session_persistence.save_session_meta(bad, {"simple": True})
             assert session_persistence.load_session_meta(bad) is None
 

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -220,7 +220,7 @@ class TestBackendWSIntegration:
         mock_ws.is_connected = True
         mock_ws.send_state.return_value = True
         backend._overlay._ws_client = mock_ws
-        backend._customization_cache = {
+        backend._remember_customization({
             "Team 1 Text Name": "Local",
             "Team 2 Text Name": "Visitor",
             "Team 1 Color": "#060f8a",
@@ -240,7 +240,7 @@ class TestBackendWSIntegration:
             "Color 2": "#ffffff",
             "Text Color 2": "#2a2f35",
             "preferredStyle": "default",
-        }
+        })
 
         backend.update_local_overlay({"Current Set": "1"})
 
@@ -261,7 +261,7 @@ class TestBackendWSIntegration:
         mock_ws = MagicMock()
         mock_ws.is_connected = False
         backend._overlay._ws_client = mock_ws
-        backend._customization_cache = {
+        backend._remember_customization({
             "Team 1 Text Name": "Local",
             "Team 2 Text Name": "Visitor",
             "Team 1 Color": "#060f8a",
@@ -281,7 +281,7 @@ class TestBackendWSIntegration:
             "Color 2": "#ffffff",
             "Text Color 2": "#2a2f35",
             "preferredStyle": "default",
-        }
+        })
 
         backend.update_local_overlay({"Current Set": "1"})
 
@@ -322,7 +322,7 @@ class TestBackendWSIntegration:
         mock_ws.send_raw_config.return_value = True
         mock_ws.send_state.return_value = True
         backend._overlay._ws_client = mock_ws
-        backend._customization_cache = {
+        backend._remember_customization({
             "Team 1 Text Name": "Local",
             "Team 2 Text Name": "Visitor",
             "Team 1 Color": "#060f8a",
@@ -342,7 +342,7 @@ class TestBackendWSIntegration:
             "Color 2": "#ffffff",
             "Text Color 2": "#2a2f35",
             "preferredStyle": "default",
-        }
+        })
 
         backend.save_model({"Current Set": "1"}, simple=False)
 


### PR DESCRIPTION
* Centralise OID validation in app/api/oid_validation.py and reuse it
  across schemas, action log, session persistence, and match archive.
  Pattern allows custom-overlay slashes but rejects ".." traversal.
* Pin Dockerfile runtime to python:3.13-slim (3.14 was pre-release).
* Add /health/ready readiness probe that verifies the data dir is
  writable; keep /health as a lightweight liveness check.
* Replace fixed WebSocket reconnect delay with exponential backoff
  plus jitter, capped at WS_RECONNECT_MAX_MS.
* Coalesce concurrent customization fetches per session via a
  threading.Lock so a UI burst collapses to one overlay round-trip.
* Extract CustomizationCache from Backend into its own module with
  a lock-guarded TTL slot; tests updated to use the public API.
* Wire vite-plugin-compression2 (gzip + brotli) and add
  rollup-plugin-visualizer as a real devDependency.