### PR TITLE
feat(ui): keep HUD visible while match is pending

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -105,10 +105,22 @@ export default function App() {
     }
   }, [hasRoomForPersistentControls]);
 
+  // Reveal the bar whenever the match flips back to the pending state
+  // (initial load or post-reset) so the operator can see the Start button.
+  const matchStartedAt = state?.match_started_at ?? null;
+  useEffect(() => {
+    if (matchStartedAt == null) {
+      setShowControls(true);
+    }
+  }, [matchStartedAt]);
+
   useEffect(() => {
     // On tablets/desktops the control bar fits without covering scoreboard
     // elements, so skip the inactivity timer entirely.
     if (hasRoomForPersistentControls) return;
+    // Keep the bar visible while the match is pending — only arm the
+    // inactivity timer once ``match_started_at`` is stamped.
+    if (state && state.match_started_at == null) return;
     if (showControls && activeTab === 'scoreboard' && state) {
       resetHideTimer();
       window.addEventListener('pointerdown', resetHideTimer, { passive: true });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -112,16 +112,17 @@ export default function App() {
     if (matchStartedAt == null) {
       setShowControls(true);
     }
-  }, [matchStartedAt]);
+  }, [matchStartedAt, setShowControls]);
 
   useEffect(() => {
     // On tablets/desktops the control bar fits without covering scoreboard
     // elements, so skip the inactivity timer entirely.
     if (hasRoomForPersistentControls) return;
     // Keep the bar visible while the match is pending — only arm the
-    // inactivity timer once ``match_started_at`` is stamped.
-    if (state && state.match_started_at == null) return;
-    if (showControls && activeTab === 'scoreboard' && state) {
+    // inactivity timer once ``match_started_at`` is stamped. Also covers
+    // the pre-init case where ``state`` itself is still null.
+    if (state?.match_started_at == null) return;
+    if (showControls && activeTab === 'scoreboard') {
       resetHideTimer();
       window.addEventListener('pointerdown', resetHideTimer, { passive: true });
     }

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen, fireEvent, waitFor, act } from '@testing-library/react';
 import App from '../App';
 import * as api from '../api/client';
 import { renderWithI18n, mockGameState, mockCustomization } from './helpers';
+import { HUD_AUTO_HIDE_MS } from '../constants';
 
 vi.mock('../api/client', () => ({
   initSession: vi.fn(),
@@ -160,5 +161,50 @@ describe('App', () => {
     renderWithI18n(<App />);
     const input = screen.getByPlaceholderText('my-overlay') as HTMLInputElement;
     expect(input.value).toBe('alias-oid');
+  });
+
+  describe('HUD auto-hide', () => {
+    // Shrink the viewport below the persistent-controls breakpoint so the
+    // inactivity timer is actually engaged.
+    beforeEach(() => {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: 400 });
+      Object.defineProperty(window, 'innerHeight', { configurable: true, value: 700 });
+      vi.useFakeTimers();
+    });
+    afterEach(() => { vi.useRealTimers(); });
+
+    async function bootApp() {
+      renderWithI18n(<App />);
+      const input = screen.getByPlaceholderText('my-overlay');
+      fireEvent.change(input, { target: { value: 'auto-hide-oid' } });
+      fireEvent.submit(input.closest('form')!);
+      await vi.waitFor(() => {
+        expect(screen.getByTestId('team-1-sets')).toBeInTheDocument();
+      });
+    }
+
+    it('keeps the HUD visible while the match is pending (no match_started_at)', async () => {
+      vi.mocked(api.initSession).mockResolvedValue({
+        success: true,
+        state: { ...mockGameState, match_started_at: null },
+      });
+      await bootApp();
+      const hud = document.querySelector('.hud-controls')!;
+      expect(hud.classList.contains('ui-hidden')).toBe(false);
+      act(() => { vi.advanceTimersByTime(HUD_AUTO_HIDE_MS + 500); });
+      expect(hud.classList.contains('ui-hidden')).toBe(false);
+    });
+
+    it('auto-hides the HUD after inactivity once the match has started', async () => {
+      vi.mocked(api.initSession).mockResolvedValue({
+        success: true,
+        state: { ...mockGameState, match_started_at: 1700000000 },
+      });
+      await bootApp();
+      const hud = document.querySelector('.hud-controls')!;
+      expect(hud.classList.contains('ui-hidden')).toBe(false);
+      act(() => { vi.advanceTimersByTime(HUD_AUTO_HIDE_MS + 500); });
+      expect(hud.classList.contains('ui-hidden')).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
The bottom HUD's inactivity timer used to fire even before the operator
had started the match, hiding the Start button after 5s on phones. Skip
the timer while ``match_started_at`` is null and force-show the bar on
the pending → started → pending flip (e.g. post-reset) so the Start
control stays reachable. Once the match is stamped, the existing
auto-hide kicks in normally.

https://claude.ai/code/session_01XVkwTuYjwMPhRHhVZN78EP