### PR TITLE
feat(ui): replace horizontal set selector with current-set indicator

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -575,54 +575,18 @@ body {
   color: initial;
 }
 
-/* ── Set pagination ──────────────────────────────────────────────────── */
+/* ── Current set indicator ──────────────────────────────────────────── */
 
-.set-pagination {
+.current-set-indicator {
   display: flex;
   align-items: center;
-  gap: 4px;
-}
-
-.pagination-arrow {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  padding: 2px;
-  display: flex;
-  align-items: center;
-  border-radius: 4px;
-  transition: background 0.15s;
-}
-
-.pagination-arrow:disabled {
-  opacity: 0.3;
-  cursor: not-allowed;
-}
-
-.pagination-arrow:not(:disabled):hover {
-  background: var(--surface-light);
-}
-
-.pagination-page {
-  width: 28px;
-  height: 28px;
-  border: none;
-  border-radius: 50%;
-  background: transparent;
-  color: var(--text-muted);
-  font-size: 0.8rem;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-}
-
-.pagination-page:hover {
-  background: var(--surface-light);
-}
-
-.pagination-page-active {
-  background: #009688;
-  color: #fff;
+  justify-content: center;
+  align-self: center;
+  min-width: 28px;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text);
 }
 
 /* ── Control buttons bar ─────────────────────────────────────────────── */

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -254,14 +254,6 @@ export default function App() {
     setActiveTab('scoreboard');
   }, []);
 
-  const handleSetChange = useCallback(
-    (set: number) => {
-      const clamped = Math.max(1, Math.min(set, setsLimit));
-      setCurrentSet(clamped);
-    },
-    [setsLimit]
-  );
-
   // Per-team double-tap undoes the most recent forward of the
   // same (action, team). The server-side per-type undo path now
   // pops the matching forward from the audit log on its own, so
@@ -406,7 +398,6 @@ export default function App() {
           onDoubleTapTimeout={handleDoubleTapTimeout}
           onLongPressScore={handleLongPressScore}
           onLongPressSet={handleLongPressSet}
-          onSetChange={handleSetChange}
           onToggleVisibility={handleToggleVisibility}
           onToggleSimpleMode={handleToggleSimpleMode}
           onUndoLast={handleUndoLast}

--- a/frontend/src/components/CenterPanel.tsx
+++ b/frontend/src/components/CenterPanel.tsx
@@ -35,7 +35,6 @@ export interface CenterPanelProps {
   fontStyle?: ScoreButtonFontStyle;
   onAddSet: (teamId: 1 | 2) => void;
   onLongPressSet: (teamId: 1 | 2) => void;
-  onSetChange: (set: number) => void;
 }
 
 const PREVIEW_CARD_WIDTH = 300;
@@ -52,7 +51,6 @@ export default function CenterPanel({
   fontStyle,
   onAddSet,
   onLongPressSet,
-  onSetChange,
 }: CenterPanelProps) {
   // Hooks must run before any early return — the hook itself handles
   // a null/undefined state by returning ``false``.
@@ -94,6 +92,9 @@ export default function CenterPanel({
                 teamId={1}
               />
             </div>
+            <div className="current-set-indicator" data-testid="current-set-indicator">
+              {currentSet}
+            </div>
             <div className="team-score-column">
               {logo2 && (
                 <img src={logo2} alt="Team 2" className="team-logo" data-testid="team-2-logo" />
@@ -108,6 +109,12 @@ export default function CenterPanel({
           </div>
         )}
 
+        {isPortrait && (
+          <div className="current-set-indicator" data-testid="current-set-indicator">
+            {currentSet}
+          </div>
+        )}
+
         <ScoreButton
           text={String(t2Sets)}
           color="#424242"
@@ -119,32 +126,6 @@ export default function CenterPanel({
           onLongPress={() => onLongPressSet(2)}
           data-testid="team-2-sets"
         />
-      </div>
-
-      <div className="set-pagination" data-testid="set-selector">
-        <button
-          className="pagination-arrow"
-          disabled={currentSet <= 1}
-          onClick={() => onSetChange(currentSet - 1)}
-        >
-          <span className="material-icons">chevron_left</span>
-        </button>
-        {Array.from({ length: setsLimit }, (_, i) => i + 1).map((num) => (
-          <button
-            key={num}
-            className={`pagination-page ${num === currentSet ? 'pagination-page-active' : ''}`}
-            onClick={() => onSetChange(num)}
-          >
-            {num}
-          </button>
-        ))}
-        <button
-          className="pagination-arrow"
-          disabled={currentSet >= setsLimit}
-          onClick={() => onSetChange(currentSet + 1)}
-        >
-          <span className="material-icons">chevron_right</span>
-        </button>
       </div>
 
       <div className="match-alerts-row" data-testid="match-alerts-row">

--- a/frontend/src/components/ScoreboardView.tsx
+++ b/frontend/src/components/ScoreboardView.tsx
@@ -49,7 +49,6 @@ export interface ScoreboardViewProps {
   onDoubleTapTimeout: (teamId: 1 | 2) => void;
   onLongPressScore: (teamId: 1 | 2) => void;
   onLongPressSet: (teamId: 1 | 2) => void;
-  onSetChange: (set: number) => void;
   onToggleVisibility: () => void;
   onToggleSimpleMode: () => void;
   onUndoLast: () => void;
@@ -89,7 +88,6 @@ export default function ScoreboardView({
   onDoubleTapTimeout,
   onLongPressScore,
   onLongPressSet,
-  onSetChange,
   onToggleVisibility,
   onToggleSimpleMode,
   onUndoLast,
@@ -138,7 +136,6 @@ export default function ScoreboardView({
           fontStyle={fontStyle}
           onAddSet={onAddSet}
           onLongPressSet={onLongPressSet}
-          onSetChange={onSetChange}
         />
 
         <TeamPanel

--- a/frontend/src/test/CenterPanel.test.tsx
+++ b/frontend/src/test/CenterPanel.test.tsx
@@ -13,7 +13,6 @@ const defaultProps = {
   previewData: null,
   onAddSet: vi.fn(),
   onLongPressSet: vi.fn(),
-  onSetChange: vi.fn(),
 };
 
 describe('CenterPanel', () => {
@@ -46,61 +45,23 @@ describe('CenterPanel', () => {
     expect(defaultProps.onAddSet).toHaveBeenCalledWith(2);
   });
 
-  it('renders set pagination with correct number of pages', () => {
+  it('does not render the legacy set selector', () => {
     renderWithI18n(<CenterPanel {...defaultProps} />);
-    const selector = screen.getByTestId('set-selector');
-    // Should have 5 page buttons + 2 arrows
-    const buttons = selector.querySelectorAll('button');
-    expect(buttons).toHaveLength(7);
+    expect(screen.queryByTestId('set-selector')).not.toBeInTheDocument();
   });
 
-  it('highlights current set in pagination', () => {
-    renderWithI18n(<CenterPanel {...defaultProps} currentSet={3} />);
-    const selector = screen.getByTestId('set-selector');
-    const activePages = selector.querySelectorAll('.pagination-page-active');
-    expect(activePages).toHaveLength(1);
-    expect(activePages[0]).toHaveTextContent('3');
+  it('renders the current set indicator with the active set number in landscape', () => {
+    renderWithI18n(<CenterPanel {...defaultProps} currentSet={3} isPortrait={false} />);
+    const indicators = screen.getAllByTestId('current-set-indicator');
+    expect(indicators).toHaveLength(1);
+    expect(indicators[0]).toHaveTextContent('3');
   });
 
-  it('calls onSetChange when pagination button clicked', () => {
-    renderWithI18n(<CenterPanel {...defaultProps} currentSet={2} />);
-    const selector = screen.getByTestId('set-selector');
-    const pageButtons = selector.querySelectorAll('.pagination-page');
-    // Click page 4
-    fireEvent.click(pageButtons[3]);
-    expect(defaultProps.onSetChange).toHaveBeenCalledWith(4);
-  });
-
-  it('disables left arrow when on first set', () => {
-    renderWithI18n(<CenterPanel {...defaultProps} currentSet={1} />);
-    const selector = screen.getByTestId('set-selector');
-    const arrows = selector.querySelectorAll('.pagination-arrow');
-    expect(arrows[0]).toBeDisabled();
-    expect(arrows[1]).not.toBeDisabled();
-  });
-
-  it('disables right arrow when on last set', () => {
-    renderWithI18n(<CenterPanel {...defaultProps} currentSet={5} />);
-    const selector = screen.getByTestId('set-selector');
-    const arrows = selector.querySelectorAll('.pagination-arrow');
-    expect(arrows[0]).not.toBeDisabled();
-    expect(arrows[1]).toBeDisabled();
-  });
-
-  it('calls onSetChange with decremented value on left arrow click', () => {
-    renderWithI18n(<CenterPanel {...defaultProps} currentSet={3} />);
-    const selector = screen.getByTestId('set-selector');
-    const arrows = selector.querySelectorAll('.pagination-arrow');
-    fireEvent.click(arrows[0]);
-    expect(defaultProps.onSetChange).toHaveBeenCalledWith(2);
-  });
-
-  it('calls onSetChange with incremented value on right arrow click', () => {
-    renderWithI18n(<CenterPanel {...defaultProps} currentSet={3} />);
-    const selector = screen.getByTestId('set-selector');
-    const arrows = selector.querySelectorAll('.pagination-arrow');
-    fireEvent.click(arrows[1]);
-    expect(defaultProps.onSetChange).toHaveBeenCalledWith(4);
+  it('renders the current set indicator with the active set number in portrait', () => {
+    renderWithI18n(<CenterPanel {...defaultProps} currentSet={4} isPortrait={true} />);
+    const indicators = screen.getAllByTestId('current-set-indicator');
+    expect(indicators).toHaveLength(1);
+    expect(indicators[0]).toHaveTextContent('4');
   });
 
   it('shows logos in landscape mode when customization has logos', () => {


### PR DESCRIPTION
## Summary

- Drops the row of pagination buttons (`set-pagination`) that let the user navigate to past sets to edit their scores. With the server-side undo log (`POST /game/undo`) any correction is now made by undoing rather than by manually editing a past set, and `currentSet` is autocomputed from the match state anyway, so the selector no longer serves a purpose.
- Adds a small read-only number centered between the team set markers (Option A from `docs/set-indicator-mockups.md` on `claude/redesign-set-selector-9s4z6`): inserted between the two `ScoreTable` columns in landscape, between the two big set buttons in portrait.
- Recovers ~32 px of vertical space below the sets row without making the score history table grow taller.

## Changes

| File | Δ |
|---|---|
| `frontend/src/components/CenterPanel.tsx` | Remove `set-pagination` block; add `current-set-indicator` in both layouts; drop `onSetChange` prop |
| `frontend/src/App.css` | Drop `.set-pagination` / `.pagination-*` rules; add `.current-set-indicator` |
| `frontend/src/components/ScoreboardView.tsx` | Drop `onSetChange` from props and pass-through |
| `frontend/src/App.tsx` | Drop `handleSetChange`; keep `currentSet` autocomputed (still consumed by `ScoreTable`, `TeamPanel`, `useIndoorMidpointAlert`, score-edit dialog) |
| `frontend/src/test/CenterPanel.test.tsx` | Remove 6 pagination tests; add 3 indicator tests |

Net diff: **+30 / −136**.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 286/286 pass
- [x] `npm run build` ok
- [ ] Manual: `npm run dev`, verify in browser:
  - [ ] Portrait — number appears centered between the two big set buttons
  - [ ] Landscape — number appears between the two score-history columns, no extra vertical height vs. before
  - [ ] Landscape compact (mobile landscape) — alert pills no longer pushed off bottom
  - [ ] Long-press on score still opens the edit dialog and edits the running set

https://claude.ai/code/session_01U9fLf5LCtfhaoAp7jcEcai

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9fLf5LCtfhaoAp7jcEcai)_