### PR TITLE
docs(changelog): cut release v5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+## [5.1.1] - 2026-05-04
+
 ### Added
 
 - React control UI: when the overlay preview is hidden, the centre
@@ -89,6 +91,26 @@ once a first tagged release ships.
     circle. ``max`` is set to ``8`` on desktop / portrait and
     ``5`` on landscape phones (compact layout) so the strip
     never overflows the centre slot.
+
+### Changed
+
+- React control UI: replaced the horizontal set selector with a
+  compact current-set indicator, freeing horizontal space in the
+  centre column for the new points history strip.
+- Points-history chips now use a stable composite key
+  (``ts/team/kind/value``) instead of the array index, so the
+  sliding window no longer remounts every chip when the oldest
+  event drops off — preserves chip state and avoids unnecessary
+  reconciliation.
+- README screenshots regenerated; the portrait capture now shows
+  the points history strip in the centre slot.
+
+### Fixed
+
+- UNO overlay preview size now matches the custom overlays
+  (``cardHeight`` hoisted to the shared scope), so the iframe no
+  longer renders at a different aspect than what the broadcast
+  output will show.
 
 ---
 


### PR DESCRIPTION
## Summary

Cuts release **v5.1.1** by promoting the `[Unreleased]` section to `[5.1.1] - 2026-05-04` and filling in the Changed / Fixed entries for the dev cycle that PR #251 just shipped to `main`.

Entries under 5.1.1:

- **Added** — points history strip (PR #249).
- **Changed** — compact current-set indicator (PR #248), stable composite React keys for points history chips (PR #251 follow-up), regenerated README screenshots.
- **Fixed** — UNO overlay preview size alignment with custom overlays (PR #250).

Once this lands in `main`, tag `v5.1.1` from the merge commit to publish the release.

## Test plan

- [ ] Confirm CHANGELOG renders cleanly on GitHub
- [ ] After merge, tag `v5.1.1` on `main` and verify the release workflow picks it up

https://claude.ai/code/session_01KbUvGXL5gogSZkTFqiGyWi

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbUvGXL5gogSZkTFqiGyWi)_