### PR TITLE
fix(ui): defer audit refetch until state is server-confirmed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,19 @@ once a first tagged release ships.
   (``cardHeight`` hoisted to the shared scope), so the iframe no
   longer renders at a different aspect than what the broadcast
   output will show.
+- Points history strip occasionally missed the chip for the action
+  that just happened — it would only surface together with the next
+  action's chip. Root cause was a race between the optimistic state
+  update in ``useGameState.addPoint`` and the audit ``GET`` that
+  ``useRecentEvents`` fires when its ``scoringKey`` changes: the
+  optimistic write bumped the key immediately, the GET often beat
+  the in-flight ``POST``'s ``action_log.append``, and the follow-up
+  WS broadcast carried the same state so the key didn't change
+  again. Fixed by introducing a separate ``confirmedState`` slot in
+  ``useGameState`` that only advances on authoritative updates
+  (initial fetch, action response, WS push) and feeding *that* to
+  ``useRecentEvents`` — so the audit refetch trigger no longer
+  outruns the server's acknowledgement.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# CLAUDE.md
+
+Project context for Claude Code lives in [`AGENTS.md`](./AGENTS.md). Read it
+before making changes — it covers the architecture (FastAPI backend, React
+control UI, overlay serving engine), the test/lint expectations (pytest +
+ruff + mypy on the backend, vitest + tsc on the frontend), the release
+flow (CHANGELOG entry on every user-visible change, screenshot regeneration
+when operator-facing surfaces change), and conventions specific to this
+repo (per-OID audit log, optimistic state in `useGameState`, WS broadcast
+ordering, etc.).
+
+When `AGENTS.md` and this file disagree, `AGENTS.md` is the source of truth.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -84,6 +84,7 @@ export default function App() {
 
   const {
     state,
+    confirmedState,
     customization,
     error,
     initialize,
@@ -102,10 +103,15 @@ export default function App() {
 
   // Filled only while the preview is hidden, so the centre column shows
   // a momentum strip in place of the empty preview gap.
+  // Uses ``confirmedState`` (not ``state``) so the audit refetch is triggered
+  // only after the server has acknowledged a change. Depending on the
+  // optimistically-updated ``state`` would race the audit GET against the
+  // in-flight POST and silently drop the chip for the action that just
+  // happened — it would only surface together with the next confirmed event.
   const recentEvents = useRecentEvents(
     oid,
     !settings.showPreview,
-    state,
+    confirmedState,
     compactLandscape ? 5 : 8,
   );
 

--- a/frontend/src/hooks/useGameState.ts
+++ b/frontend/src/hooks/useGameState.ts
@@ -68,6 +68,15 @@ export interface GameActions {
 
 export interface UseGameStateResult {
   state: GameState | null;
+  /**
+   * Mirror of ``state`` that excludes optimistic predictions — only updated
+   * from authoritative sources (initial fetch, action response, WS push).
+   * Consumers that derive cache keys from state (e.g. the recent-events
+   * hook) should depend on this instead of ``state`` to avoid racing the
+   * optimistic update against the network round-trip that would actually
+   * make the prediction observable on the server.
+   */
+  confirmedState: GameState | null;
   customization: Customization | null;
   connected: boolean;
   error: string | null;
@@ -83,6 +92,7 @@ export interface UseGameStateResult {
  */
 export function useGameState(oid: string | null): UseGameStateResult {
   const [state, setState] = useState<GameState | null>(null);
+  const [confirmedState, setConfirmedState] = useState<GameState | null>(null);
   const [customization, setCustomization] = useState<Customization | null>(null);
   const [connected, setConnected] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
@@ -95,10 +105,23 @@ export function useGameState(oid: string | null): UseGameStateResult {
   // impure setState updater. Updated eagerly on every state write.
   const stateRef = useRef<GameState | null>(null);
 
-  const applyState = useCallback((next: GameState | null) => {
-    stateRef.current = next;
-    setState(next);
-  }, []);
+  const applyState = useCallback(
+    (next: GameState | null, confirmed: boolean = true) => {
+      stateRef.current = next;
+      setState(next);
+      // ``confirmedState`` deliberately excludes optimistic writes so cache
+      // keys derived from it (e.g. the recent-events refetch trigger) do
+      // not advance until the server has acknowledged the change. Without
+      // this gate the optimistic add-point bumps the scoring key
+      // immediately, the audit refetch races the in-flight POST, and the
+      // newly-appended audit row is missed — producing the "chip appears
+      // one action late" symptom.
+      if (confirmed) {
+        setConfirmedState(next);
+      }
+    },
+    [],
+  );
 
   const closeWs = useCallback(() => {
     if (reconnectTimer.current) {
@@ -202,19 +225,19 @@ export function useGameState(oid: string | null): UseGameStateResult {
     const snapshot = stateRef.current;
     const shouldApplyOptimistic = Boolean(optimisticUpdater && snapshot);
     if (shouldApplyOptimistic && snapshot && optimisticUpdater) {
-      applyState(optimisticUpdater(snapshot));
+      applyState(optimisticUpdater(snapshot), false);
     }
     try {
       const res = await actionFn();
       if (res.success && res.state) {
         applyState(res.state);
       } else if (!res.success && shouldApplyOptimistic) {
-        applyState(snapshot);
+        applyState(snapshot, false);
       }
       return res;
     } catch (e) {
       if (shouldApplyOptimistic) {
-        applyState(snapshot);
+        applyState(snapshot, false);
       }
       const message = e instanceof Error ? e.message : String(e);
       setError(message);
@@ -257,6 +280,7 @@ export function useGameState(oid: string | null): UseGameStateResult {
 
   return {
     state,
+    confirmedState,
     customization,
     connected,
     error,

--- a/frontend/src/test/useGameState.test.ts
+++ b/frontend/src/test/useGameState.test.ts
@@ -134,6 +134,51 @@ describe('useGameState', () => {
     expect(result.current.state).toEqual(updatedState);
   });
 
+  it('addPoint applies optimistic to state but defers confirmedState until response', async () => {
+    // Mirrors the audit-strip refetch race. Consumers that key off
+    // ``confirmedState`` (e.g. the recent-events hook) should not advance
+    // their cache key until the server has acknowledged the action —
+    // otherwise their refetch races the in-flight POST and misses the
+    // freshly-appended audit row.
+    const updatedState = {
+      ...mockState,
+      team_1: { ...mockState.team_1, scores: { set_1: 1 } },
+    } as unknown as GameState;
+    let resolveAddPoint: (value: { success: true; state: GameState }) => void = () => {};
+    vi.mocked(api.addPoint).mockReturnValue(
+      new Promise((resolve) => {
+        resolveAddPoint = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() => useGameState('oid'));
+    await act(async () => {
+      await result.current.initialize();
+    });
+
+    const stateBefore = result.current.state;
+    const confirmedBefore = result.current.confirmedState;
+    expect(confirmedBefore).toEqual(mockState);
+
+    let actionPromise: Promise<unknown> = Promise.resolve();
+    act(() => {
+      actionPromise = result.current.actions.addPoint(1);
+    });
+
+    // Optimistic phase: state has advanced, confirmedState has not.
+    expect(result.current.state).not.toEqual(stateBefore);
+    expect(result.current.confirmedState).toEqual(confirmedBefore);
+
+    await act(async () => {
+      resolveAddPoint({ success: true, state: updatedState });
+      await actionPromise;
+    });
+
+    // Confirmation phase: confirmedState catches up to the server's truth.
+    expect(result.current.state).toEqual(updatedState);
+    expect(result.current.confirmedState).toEqual(updatedState);
+  });
+
   it('addPoint with undo passes undo flag', async () => {
     vi.mocked(api.addPoint).mockResolvedValue({ success: true, state: mockState });
     const { result } = renderHook(() => useGameState('oid'));


### PR DESCRIPTION
## Summary

Brings the audit-strip race fix into the 5.1.1 release. Two commits:

- **`4e5ad54`** `fix(ui): defer audit refetch until state is server-confirmed` — adds a `confirmedState` slot in `useGameState` that excludes optimistic writes; `useRecentEvents` now keys off it so the audit `GET` no longer races the in-flight `POST /game/add-point`. Includes a hook test pinning the contract.
- **`6707143`** `docs(changelog): record audit-strip race fix under v5.1.1` — adds a Fixed entry under `[5.1.1] - 2026-05-04` describing the bug and fix.

### Why this needs to ship in 5.1.1

The bug was reported against the new points history strip on `dev`. Symptom: occasionally a chip would not appear when the operator scored a point, then surface together with the next point's chip. Without this fix, 5.1.1 would tag with the regression visible.

## Test plan

- [x] `npm run typecheck` clean
- [x] Full vitest suite green (325/325, includes the new pinning test)
- [ ] Manual repro check on `dev`: rapidly add points and confirm every chip appears with its action, no "doubled-up" delivery on the next point

https://claude.ai/code/session_01KbUvGXL5gogSZkTFqiGyWi

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbUvGXL5gogSZkTFqiGyWi)_