### PR TITLE
refactor: dedupe and simplify across backend and frontend

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -20,7 +20,6 @@ variable to be set and the request to include a matching
 import logging
 import os
 import re
-import secrets
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException
@@ -28,7 +27,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 from starlette.concurrency import run_in_threadpool
 
-from app.env_vars_manager import EnvVarsManager
+from app.auth_utils import get_admin_password, require_admin_token
 
 logger = logging.getLogger(__name__)
 
@@ -58,30 +57,22 @@ class CustomOverlayCreate(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _get_admin_password() -> Optional[str]:
-    password = EnvVarsManager.get_env_var("OVERLAY_MANAGER_PASSWORD", None)
-    if password is None:
-        return None
-    password = password.strip()
-    return password or None
-
-
 def require_admin(authorization: str = Header(None)) -> None:
     """Validate the admin Bearer token."""
-    password = _get_admin_password()
-    if password is None:
-        raise HTTPException(
-            status_code=503,
-            detail="Overlay management is disabled. Set OVERLAY_MANAGER_PASSWORD to enable it.",
-        )
-    if not authorization or not authorization.startswith("Bearer "):
-        raise HTTPException(
-            status_code=401,
-            detail="Missing admin password. Use 'Authorization: Bearer <password>'.",
-        )
-    token = authorization.removeprefix("Bearer ").strip()
-    if not secrets.compare_digest(token, password):
-        raise HTTPException(status_code=403, detail="Invalid admin password.")
+    require_admin_token(
+        authorization,
+        token=None,
+        # Bandit B106 false positive: this is the error message shown
+        # when the password env var is unset, not a hardcoded credential.
+        missing_password_detail=(  # nosec B106
+            "Overlay management is disabled. "
+            "Set OVERLAY_MANAGER_PASSWORD to enable it."
+        ),
+        missing_token_detail=(  # nosec B106
+            "Missing admin password. Use 'Authorization: Bearer <password>'."
+        ),
+        invalid_token_detail="Invalid admin password.",  # nosec B106
+    )
 
 
 def _validate_overlay_id(value: str) -> str:
@@ -132,7 +123,7 @@ admin_router = APIRouter(prefix="/api/v1/admin", tags=["Admin"])
 @admin_router.get("/status")
 def admin_status():
     """Report whether overlay management is enabled on this server."""
-    return {"enabled": _get_admin_password() is not None}
+    return {"enabled": get_admin_password() is not None}
 
 
 @admin_router.post("/login")

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -176,13 +176,55 @@ class GameService:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def add_point(session, team: int, undo: bool = False) -> ActionResponse:
-        if not undo and session.game_manager.match_finished(session.sets_limit):
+    def _match_finished_response(session) -> Optional[ActionResponse]:
+        """Return the early-exit ``ActionResponse`` when the match is already over.
+
+        ``add_point`` / ``add_set`` / ``add_timeout`` all share the same
+        guard for non-undo actions — keep its message and shape in one
+        place so changes to the wording stay aligned.
+        """
+        if session.game_manager.match_finished(session.sets_limit):
             return ActionResponse(
                 success=False,
                 state=GameService.get_state(session),
                 message="Match is already finished.",
             )
+        return None
+
+    @staticmethod
+    def _ended_set_index(session) -> int:
+        """Set number that just ended (1-indexed).
+
+        ``current_set`` is advanced on a set win unless the match
+        finishes, so the just-ended set is ``current_set`` when the
+        match is over and ``current_set - 1`` otherwise. Shared by
+        ``add_point`` and ``add_set`` to keep the two ``set_end``
+        webhook payloads aligned.
+        """
+        if session.game_manager.match_finished(session.sets_limit):
+            return session.current_set
+        return session.current_set - 1
+
+    @staticmethod
+    def _fire_serve_change_if_changed(
+        session, serve_before, state_response: GameStateResponse
+    ) -> None:
+        """Fire a ``serve_change`` webhook when the current serve flipped."""
+        serve_after = session.game_manager.get_current_state().get_current_serve()
+        if serve_before != serve_after:
+            GameService._fire(
+                session, "serve_change", state_response,
+                {"serve": str(
+                    serve_after.value if hasattr(serve_after, "value") else serve_after
+                )},
+            )
+
+    @staticmethod
+    def add_point(session, team: int, undo: bool = False) -> ActionResponse:
+        if not undo:
+            blocked = GameService._match_finished_response(session)
+            if blocked is not None:
+                return blocked
 
         # Implicit match-start: scoring before the operator hit
         # ``Start match`` arms the timer here so the HUD timer and the
@@ -238,42 +280,25 @@ class GameService:
         if not undo:
             state_response = GameService.get_state(session)
             if set_won:
-                # ``session.current_set`` was already advanced above
-                # (when set_won and not match_finished), so the set
-                # that just *ended* is one less than the current
-                # one. When the match is finished, current_set is
-                # not advanced and is itself the set that just
-                # ended.
-                ended_set = (
-                    session.current_set
-                    if session.game_manager.match_finished(session.sets_limit)
-                    else session.current_set - 1
-                )
                 GameService._fire(session, "set_end", state_response, {
                     "team": team,
-                    "set_number": ended_set,
+                    "set_number": GameService._ended_set_index(session),
                 })
             if session.game_manager.match_finished(session.sets_limit) and not was_finished_before:
                 GameService._archive_if_finished(session, was_finished_before, team)
                 GameService._fire(session, "match_end", state_response, {
                     "winning_team": team,
                 })
-            serve_after = session.game_manager.get_current_state().get_current_serve()
-            if serve_before != serve_after:
-                GameService._fire(session, "serve_change", state_response, {
-                    "serve": str(serve_after.value if hasattr(serve_after, "value") else serve_after),
-                })
+            GameService._fire_serve_change_if_changed(session, serve_before, state_response)
 
         return ActionResponse(success=True, state=GameService.get_state(session))
 
     @staticmethod
     def add_set(session, team: int, undo: bool = False) -> ActionResponse:
-        if not undo and session.game_manager.match_finished(session.sets_limit):
-            return ActionResponse(
-                success=False,
-                state=GameService.get_state(session),
-                message="Match is already finished.",
-            )
+        if not undo:
+            blocked = GameService._match_finished_response(session)
+            if blocked is not None:
+                return blocked
 
         was_finished_before = session.game_manager.match_finished(session.sets_limit)
         # Same reasoning as add_point: capture before advance so the
@@ -301,17 +326,9 @@ class GameService:
 
         if not undo:
             state_response = GameService.get_state(session)
-            # Same reasoning as in add_point: ``current_set`` may
-            # have advanced inside ``add_set`` when the match isn't
-            # finished, so the set that just ended is one less.
-            ended_set = (
-                session.current_set
-                if session.game_manager.match_finished(session.sets_limit)
-                else session.current_set - 1
-            )
             GameService._fire(session, "set_end", state_response, {
                 "team": team,
-                "set_number": ended_set,
+                "set_number": GameService._ended_set_index(session),
             })
             if session.game_manager.match_finished(session.sets_limit) and not was_finished_before:
                 GameService._archive_if_finished(session, was_finished_before, team)
@@ -322,12 +339,10 @@ class GameService:
 
     @staticmethod
     def add_timeout(session, team: int, undo: bool = False) -> ActionResponse:
-        if not undo and session.game_manager.match_finished(session.sets_limit):
-            return ActionResponse(
-                success=False,
-                state=GameService.get_state(session),
-                message="Match is already finished.",
-            )
+        if not undo:
+            blocked = GameService._match_finished_response(session)
+            if blocked is not None:
+                return blocked
 
         popped = (
             action_log.pop_last_forward(
@@ -358,12 +373,9 @@ class GameService:
         session.game_manager.change_serve(team)
         GameService._save_and_broadcast(session)
         GameService._audit(session, "change_serve", {"team": team})
-        serve_after = session.game_manager.get_current_state().get_current_serve()
-        if serve_before != serve_after:
-            GameService._fire(
-                session, "serve_change", GameService.get_state(session),
-                {"serve": str(serve_after.value if hasattr(serve_after, "value") else serve_after)},
-            )
+        GameService._fire_serve_change_if_changed(
+            session, serve_before, GameService.get_state(session),
+        )
         return ActionResponse(success=True, state=GameService.get_state(session))
 
     @staticmethod

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -214,9 +214,7 @@ class GameService:
         if serve_before != serve_after:
             GameService._fire(
                 session, "serve_change", state_response,
-                {"serve": str(
-                    serve_after.value if hasattr(serve_after, "value") else serve_after
-                )},
+                {"serve": str(getattr(serve_after, "value", serve_after))},
             )
 
     @staticmethod

--- a/app/auth_utils.py
+++ b/app/auth_utils.py
@@ -1,0 +1,65 @@
+"""Shared admin-token helpers.
+
+Both the match-report routes (``app.match_report``) and the custom-overlay
+admin routes (``app.admin.routes``) gate access behind the same
+``OVERLAY_MANAGER_PASSWORD`` environment variable. Centralising the
+password lookup and the Bearer/``?token=`` resolution keeps the auth
+ladder (503 → 401 → 403) consistent across both surfaces while still
+letting each caller customise the error strings shown to the operator.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Optional
+
+from fastapi import HTTPException
+
+from app.env_vars_manager import EnvVarsManager
+
+_DEFAULT_MISSING_TOKEN_DETAIL = (  # nosec B105
+    "Authentication required. Pass Authorization: Bearer "
+    "<token> or ?token=<token> matching OVERLAY_MANAGER_PASSWORD."
+)
+_DEFAULT_INVALID_TOKEN_DETAIL = "Invalid token."  # nosec B105
+
+
+def get_admin_password() -> Optional[str]:
+    """Return the configured admin password, or ``None`` if unset/empty."""
+    raw = EnvVarsManager.get_env_var("OVERLAY_MANAGER_PASSWORD", None)
+    if raw is None:
+        return None
+    raw = str(raw).strip()
+    return raw or None
+
+
+def require_admin_token(
+    authorization: Optional[str],
+    token: Optional[str] = None,
+    *,
+    missing_password_detail: str,
+    missing_token_detail: str = _DEFAULT_MISSING_TOKEN_DETAIL,
+    invalid_token_detail: str = _DEFAULT_INVALID_TOKEN_DETAIL,
+) -> None:
+    """Raise unless the caller presents the admin token.
+
+    Resolves the bearer token from ``Authorization: Bearer <token>``
+    first, then from the ``token`` query parameter (when supplied).
+    Raises:
+
+    * ``503`` with *missing_password_detail* — ``OVERLAY_MANAGER_PASSWORD`` unset.
+    * ``401`` with *missing_token_detail* — no credential provided.
+    * ``403`` with *invalid_token_detail* — credential doesn't match.
+    """
+    expected = get_admin_password()
+    if expected is None:
+        raise HTTPException(status_code=503, detail=missing_password_detail)
+    provided: Optional[str] = None
+    if authorization and authorization.startswith("Bearer "):
+        provided = authorization.removeprefix("Bearer ").strip() or None
+    if provided is None and token:
+        provided = token.strip() or None
+    if provided is None:
+        raise HTTPException(status_code=401, detail=missing_token_detail)
+    if not secrets.compare_digest(provided, expected):
+        raise HTTPException(status_code=403, detail=invalid_token_detail)

--- a/app/match_report.py
+++ b/app/match_report.py
@@ -37,13 +37,13 @@ import datetime
 import html
 import logging
 import re
-import secrets
-from typing import Optional
+from typing import Optional, overload
 
 from fastapi import APIRouter, Header, HTTPException, Query, Response
 from fastapi.responses import HTMLResponse
 
 from app.api import match_archive
+from app.auth_utils import require_admin_token as _require_admin_token
 from app.env_vars_manager import EnvVarsManager
 from app.match_report_i18n import resolve_locale
 from app.match_report_i18n import t as _t
@@ -73,48 +73,6 @@ def _public_delete_enabled() -> bool:
     public read shouldn't silently authorise public destruction.
     """
     return _is_env_enabled("MATCH_REPORT_PUBLIC_DELETE")
-
-
-def _admin_password() -> Optional[str]:
-    raw = EnvVarsManager.get_env_var("OVERLAY_MANAGER_PASSWORD", None)
-    if raw is None:
-        return None
-    raw = str(raw).strip()
-    return raw or None
-
-
-def _require_admin_token(
-    authorization: Optional[str],
-    token: Optional[str],
-    *,
-    missing_password_detail: str,
-) -> None:
-    """Raise unless the caller presents the admin token.
-
-    Shared between :func:`_check_access` and :func:`_check_admin_access`.
-    Both flows need the same Bearer-or-``?token=`` resolution and the
-    same 503/401/403 ladder; only the 503 detail differs (read vs.
-    destructive copy), so callers pass that in.
-    """
-    expected = _admin_password()
-    if expected is None:
-        raise HTTPException(status_code=503, detail=missing_password_detail)
-    provided: Optional[str] = None
-    if authorization and authorization.startswith("Bearer "):
-        provided = authorization.removeprefix("Bearer ").strip() or None
-    if provided is None and token:
-        provided = token.strip() or None
-    if provided is None:
-        raise HTTPException(
-            status_code=401,
-            detail=(
-                "Authentication required. Pass Authorization: Bearer "
-                "<token> or ?token=<token> matching "
-                "OVERLAY_MANAGER_PASSWORD."
-            ),
-        )
-    if not secrets.compare_digest(provided, expected):
-        raise HTTPException(status_code=403, detail="Invalid token.")
 
 
 def _check_access(authorization: Optional[str], token: Optional[str]) -> None:
@@ -592,6 +550,27 @@ def _coerce_int(raw: object) -> Optional[int]:
     return None
 
 
+@overload
+def _safe_int(value: object) -> Optional[int]: ...
+@overload
+def _safe_int(value: object, default: int) -> int: ...
+@overload
+def _safe_int(value: object, default: None) -> Optional[int]: ...
+
+
+def _safe_int(value: object, default: Optional[int] = None) -> Optional[int]:
+    """Lenient ``int`` parse: like ``int(value)`` but returns *default* on failure.
+
+    Stricter callers should prefer :func:`_coerce_int`; this helper
+    mirrors the inline ``try: int(value) except (TypeError, ValueError)``
+    pattern that recurs across set/score parsing.
+    """
+    try:
+        return int(value)  # type: ignore[call-overload]
+    except (TypeError, ValueError):
+        return default
+
+
 def _result_score(record: dict, team: int) -> Optional[int]:
     """Pull the post-action score for *team* out of an audit ``result`` blob."""
     block = (record.get("result") or {}).get(f"team_{team}") or {}
@@ -673,14 +652,10 @@ def _played_set_count(final_state: dict, fallback: int) -> int:
         for key, value in scores.items():
             if not isinstance(key, str) or not key.startswith("set_"):
                 continue
-            try:
-                n = int(key.removeprefix("set_"))
-            except ValueError:
+            n = _safe_int(key.removeprefix("set_"))
+            if n is None:
                 continue
-            try:
-                v = int(value) if value is not None else 0
-            except (TypeError, ValueError):
-                continue
+            v = 0 if value is None else _safe_int(value, 0)
             if v > 0:
                 highest = max(highest, n)
     if highest == 0:

--- a/app/overlay_backends/base.py
+++ b/app/overlay_backends/base.py
@@ -3,9 +3,35 @@
 import logging
 from abc import ABC, abstractmethod
 
+from app.overlay_backends.utils import split_custom_oid
 from app.state import State
 
 logger = logging.getLogger(__name__)
+
+
+class CustomOidMixin:
+    """Shared OID parsing helpers for custom-overlay backends.
+
+    Both :class:`LocalOverlayBackend` and :class:`CustomOverlayBackend`
+    accept the ``id[/style]`` (and legacy ``C-id[/style]``) syntax. This
+    mixin avoids duplicating the same three accessors in each subclass.
+    The Uno backend stores opaque OIDs and does NOT inherit this mixin.
+    """
+
+    @staticmethod
+    def get_overlay_id(oid: str):
+        """Extract base_id and optional style from a custom OID."""
+        return split_custom_oid(oid)
+
+    def _custom_id(self, oid=None):
+        check_oid = oid if oid is not None else self.conf.oid
+        cid, _ = split_custom_oid(check_oid)
+        return cid
+
+    def _style(self, oid=None):
+        check_oid = oid if oid is not None else self.conf.oid
+        _, style = split_custom_oid(check_oid)
+        return style
 
 
 class OverlayBackend(ABC):

--- a/app/overlay_backends/custom.py
+++ b/app/overlay_backends/custom.py
@@ -8,14 +8,13 @@ import requests
 import requests.exceptions
 
 from app.env_vars_manager import EnvVarsManager
-from app.overlay_backends.base import OverlayBackend
-from app.overlay_backends.utils import split_custom_oid
+from app.overlay_backends.base import CustomOidMixin, OverlayBackend
 from app.state import State
 
 logger = logging.getLogger(__name__)
 
 
-class CustomOverlayBackend(OverlayBackend):
+class CustomOverlayBackend(CustomOidMixin, OverlayBackend):
     """Communicates with an external overlay server via WebSocket + HTTP fallback."""
 
     def __init__(self, conf, session: requests.Session):
@@ -25,12 +24,6 @@ class CustomOverlayBackend(OverlayBackend):
         self._obs_client_count = 0
         # Build overlay payload callback — set by Backend after construction
         self._build_payload = None
-
-    # Backwards-compatible static helper (used elsewhere in the codebase).
-    @staticmethod
-    def get_overlay_id(oid: str):
-        """Extract base_id and optional style from a custom OID."""
-        return split_custom_oid(oid)
 
     def _base_url(self):
         return EnvVarsManager.get_custom_overlay_url().rstrip('/')
@@ -46,16 +39,6 @@ class CustomOverlayBackend(OverlayBackend):
         if token and token.strip():
             return {"Authorization": f"Bearer {token.strip()}"}
         return {}
-
-    def _custom_id(self, oid=None):
-        check_oid = oid if oid is not None else self.conf.oid
-        cid, _ = split_custom_oid(check_oid)
-        return cid
-
-    def _style(self, oid=None):
-        check_oid = oid if oid is not None else self.conf.oid
-        _, style = split_custom_oid(check_oid)
-        return style
 
     def _ws_send_raw_config(self, payload):
         """Send raw_config via WS if connected, else HTTP POST."""

--- a/app/overlay_backends/local.py
+++ b/app/overlay_backends/local.py
@@ -4,14 +4,13 @@ import copy
 import logging
 
 from app.env_vars_manager import EnvVarsManager
-from app.overlay_backends.base import OverlayBackend
-from app.overlay_backends.utils import split_custom_oid
+from app.overlay_backends.base import CustomOidMixin, OverlayBackend
 from app.state import State
 
 logger = logging.getLogger(__name__)
 
 
-class LocalOverlayBackend(OverlayBackend):
+class LocalOverlayBackend(CustomOidMixin, OverlayBackend):
     """In-process overlay backend — no external server needed.
 
     Manages overlay state directly via the ``app.overlay`` package instead
@@ -22,22 +21,6 @@ class LocalOverlayBackend(OverlayBackend):
         self.conf = conf
         # Build overlay payload callback — set by Backend after construction
         self._build_payload = None
-
-    # Backwards-compatible static helper (used elsewhere in the codebase).
-    @staticmethod
-    def get_overlay_id(oid: str):
-        """Extract base_id and optional style from a custom OID."""
-        return split_custom_oid(oid)
-
-    def _custom_id(self, oid=None):
-        check_oid = oid if oid is not None else self.conf.oid
-        cid, _ = split_custom_oid(check_oid)
-        return cid
-
-    def _style(self, oid=None):
-        check_oid = oid if oid is not None else self.conf.oid
-        _, style = split_custom_oid(check_oid)
-        return style
 
     def _store(self):
         from app.overlay import overlay_state_store

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import {
   FONT_SCALES,
 } from './theme';
 import { HUD_AUTO_HIDE_MS } from './constants';
+import { asColor, asString } from './utils/coerce';
 
 type Team = 1 | 2;
 
@@ -333,11 +334,6 @@ export default function App() {
     [dialog, actions, currentSet]
   );
 
-  const asColor = (v: unknown, fallback: string): string =>
-    typeof v === 'string' && v ? v : fallback;
-  const asLogo = (v: unknown): string | null =>
-    typeof v === 'string' && v ? v : null;
-
   const btnColorA = settings.followTeamColors
     ? asColor(customization?.['Team 1 Color'], TEAM_A_COLOR)
     : (settings.team1BtnColor ?? TEAM_A_COLOR);
@@ -351,8 +347,8 @@ export default function App() {
     ? asColor(customization?.['Team 2 Text Color'], '#ffffff')
     : (settings.team2BtnText ?? '#ffffff');
 
-  const iconLogoA = settings.showIcon ? asLogo(customization?.['Team 1 Logo']) : null;
-  const iconLogoB = settings.showIcon ? asLogo(customization?.['Team 2 Logo']) : null;
+  const iconLogoA = settings.showIcon ? asString(customization?.['Team 1 Logo']) : null;
+  const iconLogoB = settings.showIcon ? asString(customization?.['Team 2 Logo']) : null;
 
   const fontStyle = useMemo<ScoreButtonFontStyle>(() => {
     const fontScales = FONT_SCALES as Record<string, FontScale>;

--- a/frontend/src/components/ConfigPanel.tsx
+++ b/frontend/src/components/ConfigPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useMemo, useRef, lazy, Suspense } fro
 import { useI18n } from '../i18n';
 import { useSettings, type ThemePreference } from '../hooks/useSettings';
 import { useOrientation } from '../hooks/useOrientation';
+import { useAsyncAction } from '../hooks/useAsyncAction';
 import * as api from '../api/client';
 import ConfigSkeleton from './ConfigSkeleton';
 import type { ConfigModel, PredefinedTeams } from './TeamCard';
@@ -97,8 +98,6 @@ export default function ConfigPanel({
   const { isPortrait } = useOrientation();
 
   const [model, setModel] = useState<ConfigModel>(() => ({ ...(customization ?? {}) }));
-  const [saving, setSaving] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
     if (customization) {
@@ -154,21 +153,17 @@ export default function ConfigPanel({
     window.history.back();
   }, []);
 
-  const handleSave = useCallback(async () => {
-    setSaving(true);
-    setSaveError(null);
-    try {
+  const { run: handleSave, pending: saving, error: saveError } = useAsyncAction(
+    async () => {
       await api.updateCustomization(oid, model);
       if (onCustomizationSaved) await onCustomizationSaved();
       bypassConfirmRef.current = true;
       window.history.back();
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : t('config.failedToSave');
-      setSaveError(msg);
-    } finally {
-      setSaving(false);
-    }
-  }, [oid, model, onCustomizationSaved, t]);
+    },
+    {
+      formatError: (e) => e instanceof Error ? e.message : t('config.failedToSave'),
+    },
+  );
 
   useEffect(() => {
     window.history.pushState({ configOpen: true }, '');

--- a/frontend/src/components/TeamCard.tsx
+++ b/frontend/src/components/TeamCard.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useI18n } from '../i18n';
 import ColorPicker from './ColorPicker';
+import { asString } from '../utils/coerce';
 
 export type ConfigModel = Record<string, unknown>;
 
@@ -19,10 +20,6 @@ export interface TeamCardProps {
   predefinedTeams: PredefinedTeams;
 }
 
-function asString(v: unknown, fallback = ''): string {
-  return typeof v === 'string' ? v : fallback;
-}
-
 /**
  * Team customization card — logo preview, team name selector, colors.
  */
@@ -35,8 +32,8 @@ export default function TeamCard({ teamId, model, updateField, predefinedTeams }
   const colorKey = `${prefix} Color`;
   const textColorKey = `${prefix} Text Color`;
   const logoKey = `${prefix} Logo`;
-  const logoUrl = asString(model[logoKey]);
-  const currentName = asString(model[nameKey]);
+  const logoUrl = asString(model[logoKey], '');
+  const currentName = asString(model[nameKey], '');
   const [editing, setEditing] = useState(false);
 
   const teamNames = Object.keys(predefinedTeams);

--- a/frontend/src/components/config/BehaviorSection.tsx
+++ b/frontend/src/components/config/BehaviorSection.tsx
@@ -1,4 +1,5 @@
 import { useI18n } from '../../i18n';
+import { ConfigRange, ConfigSwitch } from './fields';
 
 export interface BehaviorSettings {
   autoHide: boolean;
@@ -25,27 +26,26 @@ export default function BehaviorSection({ settings, setSetting }: BehaviorSectio
   const { t, lang, setLanguage, languages } = useI18n();
   return (
     <div className="config-section-behavior">
-      <div className="config-switch-row">
-        <label className="config-switch-label">
-          <input type="checkbox" checked={settings.autoHide}
-            onChange={(e) => setSetting('autoHide', e.target.checked)} />
-          {t('behavior.autoHide')}
-        </label>
-      </div>
+      <ConfigSwitch
+        label={t('behavior.autoHide')}
+        checked={settings.autoHide}
+        onChange={(v) => setSetting('autoHide', v)}
+      />
       {settings.autoHide && (
-        <div className="config-range-row">
-          <label className="config-label">{t('behavior.hideAfter', { value: settings.autoHideSeconds })}</label>
-          <input type="range" min={1} max={15} step={1} value={settings.autoHideSeconds}
-            onChange={(e) => setSetting('autoHideSeconds', Number(e.target.value))} className="config-range" />
-        </div>
+        <ConfigRange
+          label={t('behavior.hideAfter', { value: settings.autoHideSeconds })}
+          value={settings.autoHideSeconds}
+          min={1}
+          max={15}
+          step={1}
+          onChange={(v) => setSetting('autoHideSeconds', v)}
+        />
       )}
-      <div className="config-switch-row">
-        <label className="config-switch-label">
-          <input type="checkbox" checked={settings.autoSimple}
-            onChange={(e) => setSetting('autoSimple', e.target.checked)} />
-          {t('behavior.autoSimple')}
-        </label>
-      </div>
+      <ConfigSwitch
+        label={t('behavior.autoSimple')}
+        checked={settings.autoSimple}
+        onChange={(v) => setSetting('autoSimple', v)}
+      />
       {settings.autoSimple && (
         <div className="config-switch-row" style={{ paddingLeft: '1.5rem' }}>
           <label className="config-switch-label">

--- a/frontend/src/components/config/ButtonsSection.tsx
+++ b/frontend/src/components/config/ButtonsSection.tsx
@@ -1,6 +1,6 @@
 import { useI18n } from '../../i18n';
-import ColorPicker from '../ColorPicker';
 import FontSelector from '../FontSelector';
+import { ConfigColorField, ConfigRange, ConfigSwitch } from './fields';
 
 export interface ButtonsSettings {
   followTeamColors: boolean;
@@ -22,41 +22,39 @@ export default function ButtonsSection({ settings, setSetting }: ButtonsSectionP
   const { t } = useI18n();
   return (
     <div className="config-section-buttons">
-      <div className="config-switch-row">
-        <label className="config-switch-label">
-          <input type="checkbox" checked={settings.followTeamColors}
-            onChange={(e) => setSetting('followTeamColors', e.target.checked)}
-            data-testid="follow-team-colors-switch" />
-          {t('buttons.followTeamColors')}
-        </label>
-      </div>
+      <ConfigSwitch
+        label={t('buttons.followTeamColors')}
+        checked={settings.followTeamColors}
+        onChange={(v) => setSetting('followTeamColors', v)}
+        testId="follow-team-colors-switch"
+      />
       {!settings.followTeamColors && (
         <>
           <div className="config-color-grid-2x2">
-            <div className="config-color-group">
-              <label className="config-label">{t('buttons.t1Btn')}</label>
-              <ColorPicker color={settings.team1BtnColor}
-                onChange={(c) => setSetting('team1BtnColor', c)}
-                data-testid="color-picker-team-1-btn" />
-            </div>
-            <div className="config-color-group">
-              <label className="config-label">{t('buttons.t1Text')}</label>
-              <ColorPicker color={settings.team1BtnText}
-                onChange={(c) => setSetting('team1BtnText', c)}
-                data-testid="color-picker-team-1-text" />
-            </div>
-            <div className="config-color-group">
-              <label className="config-label">{t('buttons.t2Btn')}</label>
-              <ColorPicker color={settings.team2BtnColor}
-                onChange={(c) => setSetting('team2BtnColor', c)}
-                data-testid="color-picker-team-2-btn" />
-            </div>
-            <div className="config-color-group">
-              <label className="config-label">{t('buttons.t2Text')}</label>
-              <ColorPicker color={settings.team2BtnText}
-                onChange={(c) => setSetting('team2BtnText', c)}
-                data-testid="color-picker-team-2-text" />
-            </div>
+            <ConfigColorField
+              label={t('buttons.t1Btn')}
+              color={settings.team1BtnColor}
+              onChange={(c) => setSetting('team1BtnColor', c)}
+              testId="color-picker-team-1-btn"
+            />
+            <ConfigColorField
+              label={t('buttons.t1Text')}
+              color={settings.team1BtnText}
+              onChange={(c) => setSetting('team1BtnText', c)}
+              testId="color-picker-team-1-text"
+            />
+            <ConfigColorField
+              label={t('buttons.t2Btn')}
+              color={settings.team2BtnColor}
+              onChange={(c) => setSetting('team2BtnColor', c)}
+              testId="color-picker-team-2-btn"
+            />
+            <ConfigColorField
+              label={t('buttons.t2Text')}
+              color={settings.team2BtnText}
+              onChange={(c) => setSetting('team2BtnText', c)}
+              testId="color-picker-team-2-text"
+            />
           </div>
           <button className="config-icon-btn" data-testid="reset-colors-button" title={t('buttons.resetColors')}
             onClick={() => {
@@ -70,20 +68,21 @@ export default function ButtonsSection({ settings, setSetting }: ButtonsSectionP
         </>
       )}
       <div className="config-separator" />
-      <div className="config-switch-row">
-        <label className="config-switch-label">
-          <input type="checkbox" checked={settings.showIcon}
-            onChange={(e) => setSetting('showIcon', e.target.checked)}
-            data-testid="show-team-icon-switch" />
-          {t('buttons.showTeamIcon')}
-        </label>
-      </div>
+      <ConfigSwitch
+        label={t('buttons.showTeamIcon')}
+        checked={settings.showIcon}
+        onChange={(v) => setSetting('showIcon', v)}
+        testId="show-team-icon-switch"
+      />
       {settings.showIcon && (
-        <div className="config-range-row">
-          <label className="config-label">{t('buttons.opacity', { value: settings.iconOpacity })}</label>
-          <input type="range" min={10} max={100} step={10} value={settings.iconOpacity}
-            onChange={(e) => setSetting('iconOpacity', Number(e.target.value))} className="config-range" />
-        </div>
+        <ConfigRange
+          label={t('buttons.opacity', { value: settings.iconOpacity })}
+          value={settings.iconOpacity}
+          min={10}
+          max={100}
+          step={10}
+          onChange={(v) => setSetting('iconOpacity', v)}
+        />
       )}
       <div className="config-separator" />
       <div className="config-field-row">

--- a/frontend/src/components/config/MatchRulesSection.tsx
+++ b/frontend/src/components/config/MatchRulesSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useI18n } from '../../i18n';
 import * as api from '../../api/client';
+import { useAsyncAction } from '../../hooks/useAsyncAction';
 
 export interface MatchRulesSectionProps {
   oid: string;
@@ -38,26 +39,18 @@ export default function MatchRulesSection({
   onChanged,
 }: MatchRulesSectionProps) {
   const { t } = useI18n();
-  const [pending, setPending] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [pointsDraft, setPointsDraft] = useState<number | null>(pointsLimit);
   const [pointsLastDraft, setPointsLastDraft] = useState<number | null>(pointsLimitLastSet);
 
   useEffect(() => { setPointsDraft(pointsLimit); }, [pointsLimit]);
   useEffect(() => { setPointsLastDraft(pointsLimitLastSet); }, [pointsLimitLastSet]);
 
-  async function call(payload: api.SetRulesPayload) {
-    setPending(true);
-    setError(null);
-    try {
+  const { run: call, pending, error } = useAsyncAction<[api.SetRulesPayload]>(
+    async (payload) => {
       await api.setRules(oid, payload);
       onChanged?.();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setPending(false);
-    }
-  }
+    },
+  );
 
   function handleModeChange(newMode: api.MatchMode) {
     if (newMode === mode) return;

--- a/frontend/src/components/config/OverlaySection.tsx
+++ b/frontend/src/components/config/OverlaySection.tsx
@@ -1,6 +1,7 @@
 import { useI18n } from '../../i18n';
-import ColorPicker from '../ColorPicker';
 import type { ConfigModel } from './TeamsSection';
+import { asBool, asString } from '../../utils/coerce';
+import { ConfigColorField } from './fields';
 
 export type OverlayThemes = Record<string, unknown>;
 
@@ -13,14 +14,6 @@ export interface OverlaySectionProps {
   setSelectedTheme: (name: string) => void;
   onApplyTheme: (name: string) => void;
   isCustomOverlay: boolean;
-}
-
-function asBool(v: unknown): boolean {
-  return v === 'true' || v === true;
-}
-
-function asString(v: unknown, fallback: string): string {
-  return typeof v === 'string' ? v : fallback;
 }
 
 export default function OverlaySection({
@@ -60,26 +53,26 @@ export default function OverlaySection({
         )}
       </div>
       <div className="config-color-grid-2x2">
-        <div className="config-color-group">
-          <label className="config-label">{t('overlay.setColor')}</label>
-          <ColorPicker color={asString(model['Color 1'], '#2a2f35')}
-            onChange={(c) => updateField('Color 1', c)} />
-        </div>
-        <div className="config-color-group">
-          <label className="config-label">{t('overlay.setText')}</label>
-          <ColorPicker color={asString(model['Text Color 1'], '#ffffff')}
-            onChange={(c) => updateField('Text Color 1', c)} />
-        </div>
-        <div className="config-color-group">
-          <label className="config-label">{t('overlay.gameColor')}</label>
-          <ColorPicker color={asString(model['Color 2'], '#ffffff')}
-            onChange={(c) => updateField('Color 2', c)} />
-        </div>
-        <div className="config-color-group">
-          <label className="config-label">{t('overlay.gameText')}</label>
-          <ColorPicker color={asString(model['Text Color 2'], '#2a2f35')}
-            onChange={(c) => updateField('Text Color 2', c)} />
-        </div>
+        <ConfigColorField
+          label={t('overlay.setColor')}
+          color={asString(model['Color 1'], '#2a2f35')}
+          onChange={(c) => updateField('Color 1', c)}
+        />
+        <ConfigColorField
+          label={t('overlay.setText')}
+          color={asString(model['Text Color 1'], '#ffffff')}
+          onChange={(c) => updateField('Text Color 1', c)}
+        />
+        <ConfigColorField
+          label={t('overlay.gameColor')}
+          color={asString(model['Color 2'], '#ffffff')}
+          onChange={(c) => updateField('Color 2', c)}
+        />
+        <ConfigColorField
+          label={t('overlay.gameText')}
+          color={asString(model['Text Color 2'], '#2a2f35')}
+          onChange={(c) => updateField('Text Color 2', c)}
+        />
       </div>
       {(hasStyles || hasThemes) && (
         <div className="config-theme-inline">

--- a/frontend/src/components/config/fields.tsx
+++ b/frontend/src/components/config/fields.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from 'react';
+import ColorPicker from '../ColorPicker';
+
+export interface ConfigSwitchProps {
+  label: ReactNode;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  testId?: string;
+}
+
+export function ConfigSwitch({ label, checked, onChange, testId }: ConfigSwitchProps) {
+  return (
+    <div className="config-switch-row">
+      <label className="config-switch-label">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+          data-testid={testId}
+        />
+        {label}
+      </label>
+    </div>
+  );
+}
+
+export interface ConfigColorFieldProps {
+  label: ReactNode;
+  color: string;
+  onChange: (color: string) => void;
+  testId?: string;
+}
+
+export function ConfigColorField({ label, color, onChange, testId }: ConfigColorFieldProps) {
+  return (
+    <div className="config-color-group">
+      <label className="config-label">{label}</label>
+      <ColorPicker color={color} onChange={onChange} data-testid={testId} />
+    </div>
+  );
+}
+
+export interface ConfigRangeProps {
+  label: ReactNode;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  onChange: (value: number) => void;
+}
+
+export function ConfigRange({ label, value, min, max, step = 1, onChange }: ConfigRangeProps) {
+  return (
+    <div className="config-range-row">
+      <label className="config-label">{label}</label>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="config-range"
+      />
+    </div>
+  );
+}

--- a/frontend/src/hooks/useAsyncAction.ts
+++ b/frontend/src/hooks/useAsyncAction.ts
@@ -1,0 +1,54 @@
+import { useCallback, useRef, useState } from 'react';
+
+export interface UseAsyncActionOptions {
+  formatError?: (err: unknown) => string;
+}
+
+export interface UseAsyncActionResult<T extends unknown[]> {
+  run: (...args: T) => Promise<void>;
+  pending: boolean;
+  error: string | null;
+  clearError: () => void;
+}
+
+function defaultFormatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Wrap an async callback with the standard pending / error scaffolding
+ * (`setPending(true) / try / catch / finally setPending(false)`).
+ *
+ * The returned `run` keeps a stable identity across renders; the latest
+ * `fn` is invoked via a ref so callers don't need to memoise it.
+ */
+export function useAsyncAction<T extends unknown[]>(
+  fn: (...args: T) => Promise<void>,
+  options?: UseAsyncActionOptions,
+): UseAsyncActionResult<T> {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+  const formatRef = useRef<((err: unknown) => string) | undefined>(
+    options?.formatError,
+  );
+  formatRef.current = options?.formatError;
+
+  const run = useCallback(async (...args: T) => {
+    setPending(true);
+    setError(null);
+    try {
+      await fnRef.current(...args);
+    } catch (e) {
+      const fmt = formatRef.current ?? defaultFormatError;
+      setError(fmt(e));
+    } finally {
+      setPending(false);
+    }
+  }, []);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  return { run, pending, error, clearError };
+}

--- a/frontend/src/utils/coerce.ts
+++ b/frontend/src/utils/coerce.ts
@@ -2,6 +2,21 @@ export function toNumber(v: unknown): number {
   return typeof v === 'number' ? v : typeof v === 'string' ? Number(v) || 0 : 0;
 }
 
-export function asString(v: unknown): string | null {
-  return typeof v === 'string' && v ? v : null;
+export function asString(v: unknown): string | null;
+export function asString(v: unknown, fallback: string): string;
+export function asString(v: unknown, fallback?: string): string | null {
+  if (typeof v !== 'string') return fallback ?? null;
+  if (fallback === undefined) return v ? v : null;
+  return v;
+}
+
+export function asColor(v: unknown, fallback: string): string {
+  return typeof v === 'string' && v ? v : fallback;
+}
+
+export function asBool(v: unknown, fallback = false): boolean {
+  if (typeof v === 'boolean') return v;
+  if (v === 'true') return true;
+  if (v === 'false') return false;
+  return fallback;
 }


### PR DESCRIPTION
Backend (app/):
- Add `_safe_int` helper in match_report.py and use it in
  `_played_set_count` to replace inline try/except int parsing.
- Extract `_match_finished_response`, `_ended_set_index`, and
  `_fire_serve_change_if_changed` in `GameService` to remove the
  duplicated guard and webhook-firing logic across `add_point`,
  `add_set`, `add_timeout`, and `change_serve`.
- Lift the duplicated `get_overlay_id`, `_custom_id`, and `_style`
  helpers from `LocalOverlayBackend` and `CustomOverlayBackend` into a
  shared `CustomOidMixin` in `overlay_backends.base`.
- Move admin Bearer/`?token=` validation to a new `app/auth_utils.py`
  shared by `match_report.py` and `admin/routes.py`. Preserves all
  existing 503/401/403 responses and error messages.

Frontend (frontend/src/):
- Extend `utils/coerce.ts` with overloaded `asString`, plus `asBool`
  and `asColor`. Replace local copies in `App.tsx`, `TeamCard.tsx`,
  and `OverlaySection.tsx`.
- Add `useAsyncAction` hook and apply it in `MatchRulesSection.tsx`
  and `ConfigPanel.tsx` to drop repeated pending/error scaffolding.
- Add small `ConfigSwitch`, `ConfigColorField`, `ConfigRange` field
  components in `components/config/fields.tsx` and use them in
  `BehaviorSection`, `ButtonsSection`, and `OverlaySection`.

Behavior is unchanged. All 679 backend and 324 frontend tests pass;
mypy error count is unchanged from the baseline.

https://claude.ai/code/session_01R9k3DhxqGnwhSLopcX8KGJ