### PR TITLE
sec: auto-generate OVERLAY_SERVER_TOKEN on first start

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -218,13 +218,25 @@ When adding a new route, add a matching entry in this test file.
 
 ## 5. Release notes
 
-One deployment-visible change operators should be aware of:
+Two deployment-visible changes operators should be aware of:
 
-1. **`OVERLAY_SERVER_TOKEN` is recommended** — set it on any deployment
-   that exposes overlay routes (the default in-process overlay server
-   setup). Control apps pointed at an external overlay server via
-   `APP_CUSTOM_OVERLAY_URL` must also set it to the same value. Leaving
-   it unset is backward-compatible but triggers a startup warning.
+1. **`OVERLAY_SERVER_TOKEN` is now auto-generated.** When the env var
+   is unset on first start, the bootstrap mints a random token,
+   persists it to `data/.overlay_server_token` (mode `0o600`), and
+   exposes it via `os.environ` so the rest of the app picks it up
+   transparently. Subsequent restarts read the same file, so the
+   token stays stable. Operators pairing this app with an external
+   overlay server (`APP_CUSTOM_OVERLAY_URL`) must either set
+   `OVERLAY_SERVER_TOKEN` explicitly on both sides, or read the
+   generated value from the persisted file. Set
+   `OVERLAY_SERVER_TOKEN_DISABLED=true` to opt back into the legacy
+   unauthenticated behaviour (only safe on a trusted LAN); the
+   bootstrap logs a `CRITICAL` warning when this opt-out is active.
+2. **`SCOREBOARD_USERS` unset now triggers a startup warning.** The
+   API still works without auth — backwards compatible — but the
+   open-API posture is now visible in the startup tail. Set
+   `SCOREBOARD_USERS_DISABLED=true` to silence the warning for
+   trusted-LAN deployments.
 
 ## 6. Defence-in-depth middleware
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ once a first tagged release ships.
 
 ### Security
 
+- ``OVERLAY_SERVER_TOKEN`` is now **auto-generated and persisted on
+  first start** instead of leaving the seven overlay-server mutation
+  endpoints (``POST /api/state/{id}``, ``/create/overlay/{id}``,
+  ``/delete/overlay/{id}``, ``/api/raw_config/{id}``,
+  ``/api/theme/{id}/{name}``) unauthenticated by default. Resolution
+  order at startup:
+  1. ``OVERLAY_SERVER_TOKEN_DISABLED=true`` keeps the legacy
+     fail-open behaviour and logs a ``CRITICAL`` startup warning.
+  2. ``OVERLAY_SERVER_TOKEN=<value>`` already set wins.
+  3. Otherwise the bootstrap reads / mints a token at
+     ``data/.overlay_server_token`` (mode ``0o600``) and injects it
+     into ``os.environ`` so the rest of the app picks it up
+     transparently. The same value is reused across restarts so an
+     external ``CustomOverlayBackend`` peer does not need to be
+     re-configured.
+
+  **Operator action:** when an external overlay server points at this
+  app via ``APP_CUSTOM_OVERLAY_URL``, both sides must use the same
+  ``OVERLAY_SERVER_TOKEN``. Either set it explicitly on both, or read
+  the auto-generated value from ``data/.overlay_server_token`` after
+  the first start. To restore the previous unauthenticated behaviour
+  on a trusted LAN, set ``OVERLAY_SERVER_TOKEN_DISABLED=true``.
+- ``SCOREBOARD_USERS`` left unset now emits a startup ``WARNING``
+  (previously silent) so the open-API posture is visible in the
+  startup tail. ``SCOREBOARD_USERS_DISABLED=true`` silences the
+  warning for trusted-LAN deployments.
 - New ``SecurityHeadersMiddleware`` adds baseline response headers on
   every request: ``X-Content-Type-Options: nosniff``,
   ``Referrer-Policy: strict-origin-when-cross-origin``, and a

--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ Configure the application using the following environment variables:
 | `PREDEFINED_OVERLAYS` | JSON with a list of preconfigured overlays. | |
 | `HIDE_CUSTOM_OVERLAY_WHEN_PREDEFINED` | If `true`, hides the option to manually enter an overlay. | `false` |
 | `OVERLAY_MANAGER_PASSWORD` | Password that unlocks the custom overlay manager page at `/manage` (also required to read `/list/overlay`). Leave empty to disable the page. | |
-| `OVERLAY_SERVER_TOKEN` | *(Recommended)* Bearer token required by the built-in overlay server's mutation and config endpoints (`/api/state/{id}`, `/api/raw_config/{id}`, `/api/config/{id}`, `/create/overlay/{id}`, `/delete/overlay/{id}`, `/api/theme/{id}/{name}`). When unset the endpoints stay open and a warning is logged at startup. If you also run the control app against an **external** overlay server via `APP_CUSTOM_OVERLAY_URL`, set the same value on both sides. See [AUTHENTICATION.md](AUTHENTICATION.md) (F-3, F-5). | |
+| `OVERLAY_SERVER_TOKEN` | Bearer token required by the built-in overlay server's mutation and config endpoints (`/api/state/{id}`, `/api/raw_config/{id}`, `/api/config/{id}`, `/create/overlay/{id}`, `/delete/overlay/{id}`, `/api/theme/{id}/{name}`). **Auto-generated and persisted to `data/.overlay_server_token` on first start when unset.** Set explicitly here to override (e.g. when an external `CustomOverlayBackend` peer must use the same value). See [AUTHENTICATION.md](AUTHENTICATION.md) §5. | *(auto)* |
+| `OVERLAY_SERVER_TOKEN_DISABLED` | If `true`, opts back into legacy unauthenticated overlay-server endpoints. The bootstrap logs a `CRITICAL` startup warning when active. Only safe on a trusted LAN. | `false` |
+| `SCOREBOARD_USERS_DISABLED` | If `true`, silences the startup warning emitted when `SCOREBOARD_USERS` is unset. The API still allows unauthenticated requests; this flag only acknowledges the choice. | `false` |
 | `APP_THEMES` | JSON with a list of customization themes. | |
 | `REMOTE_CONFIG_URL` | URL to a remote JSON file with the configuration. | |
 | `SINGLE_OVERLAY_MODE` | If `true`, restricts the app to a single active overlay at a time. | `true` |
@@ -311,9 +313,8 @@ OVERLAY_MANAGER_PASSWORD=change-me
 ### Overlay server token (`OVERLAY_SERVER_TOKEN`)
 
 When the built-in overlay server is mounted (i.e. the `overlay_templates/`
-directory is present), its mutation and config endpoints can be gated behind
-a Bearer token. Set `OVERLAY_SERVER_TOKEN` to any non-empty value and every
-request to the following routes must include
+directory is present), its mutation and config endpoints are gated behind
+a Bearer token. Every request to the following routes must include
 `Authorization: Bearer <token>`:
 
 - `POST /api/state/{id}`
@@ -323,13 +324,18 @@ request to the following routes must include
 - `GET /api/config/{id}`
 - `POST /api/theme/{id}/{name}`
 
-When the variable is unset the routes stay open and a warning is logged at
-startup — existing deployments keep working unchanged.
+The token is **auto-generated and persisted to `data/.overlay_server_token`
+on first start**. Subsequent restarts reuse the same value, so an external
+`CustomOverlayBackend` peer pointed at this app via
+`APP_CUSTOM_OVERLAY_URL` only needs to be configured once: read the value
+from the persisted file or set `OVERLAY_SERVER_TOKEN` explicitly on both
+sides.
 
-If the control app is pointed at an **external** overlay server via
-`APP_CUSTOM_OVERLAY_URL`, set `OVERLAY_SERVER_TOKEN` to the same value on
-both sides. The control app's `CustomOverlayBackend` forwards the token in
-every request it makes to the overlay server.
+To opt back into the legacy unauthenticated behaviour (e.g. for a
+trusted-LAN install or local debugging), set
+`OVERLAY_SERVER_TOKEN_DISABLED=true`. A `CRITICAL` startup warning is
+logged whenever this opt-out is active so the choice is visible in the
+startup tail.
 
 The OBS capability URLs (`/overlay/{output_key}` and `/ws/{output_key}`) are
 intentionally **not** gated by this token — they are the public-by-design

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -30,6 +30,7 @@ from app.api.middleware.security_headers import SecurityHeadersMiddleware
 from app.app_config import get_app_title
 from app.authentication import PasswordAuthenticator
 from app.match_report import match_report_router
+from app.security_bootstrap import run_security_bootstrap
 
 logger = logging.getLogger(__name__)
 
@@ -206,13 +207,10 @@ def _register_overlay_routes(application: FastAPI) -> None:
     )
     application.include_router(overlay_router)
     logger.info("Overlay routes mounted (templates: %s)", OVERLAY_TEMPLATES_DIR)
-
-    if not os.environ.get("OVERLAY_SERVER_TOKEN", "").strip():
-        logger.warning(
-            "OVERLAY_SERVER_TOKEN is not set — overlay server mutation "
-            "and config endpoints are unauthenticated. See "
-            "AUTHENTICATION.md (F-3, F-5) for details."
-        )
+    # The bootstrap.run_security_bootstrap call earlier in create_app
+    # has already either populated OVERLAY_SERVER_TOKEN (auto-generated
+    # or persisted) or logged the fail-open opt-out warning, so no
+    # additional warning is needed here.
 
 
 def _register_static_mounts(application: FastAPI) -> None:
@@ -379,6 +377,11 @@ def create_app() -> FastAPI:
     registered before the SPA catch-all mount, otherwise the SPA consumes
     every unmatched path.
     """
+    # Resolve / mint credentials BEFORE any router is included so the
+    # auth dependencies see the same token that the rest of the app does.
+    # ``run_security_bootstrap`` mutates os.environ in place; idempotent
+    # across repeated create_app calls (e.g. in tests).
+    run_security_bootstrap()
     application = FastAPI(title="Volley Overlay Control", lifespan=_lifespan)
     _register_auth(application)
     _register_api_routes(application)

--- a/app/overlay/routes.py
+++ b/app/overlay/routes.py
@@ -39,10 +39,14 @@ def _get_overlay_server_token() -> Optional[str]:
 def require_overlay_server_token(authorization: str = Header(None)) -> None:
     """Gate overlay-server mutation / leaky read endpoints.
 
-    When ``OVERLAY_SERVER_TOKEN`` is unset the check is a no-op so
-    existing deployments keep working (with a startup warning; see
-    ``AUTHENTICATION.md`` F-3 and F-5). When the env var is set, the
-    request must include ``Authorization: Bearer <token>``.
+    ``OVERLAY_SERVER_TOKEN`` is normally populated at startup by
+    :func:`app.security_bootstrap.ensure_overlay_server_token` (auto-
+    generated on first run, persisted to ``data/.overlay_server_token``).
+    When the env var is set the request must include
+    ``Authorization: Bearer <token>``. The dependency stays a no-op
+    only when the operator explicitly opted into legacy fail-open
+    via ``OVERLAY_SERVER_TOKEN_DISABLED=true`` — see
+    ``AUTHENTICATION.md`` §5 for the migration notes.
     """
     token = _get_overlay_server_token()
     if token is None:

--- a/app/security_bootstrap.py
+++ b/app/security_bootstrap.py
@@ -1,0 +1,224 @@
+"""Startup security bootstrap — fail-closed defaults for credentials.
+
+The original posture was "fail-open if unset": ``OVERLAY_SERVER_TOKEN``
+and ``SCOREBOARD_USERS`` would both default to "no auth required" with
+only a startup log line warning the operator. That is hostile to the
+common ``docker compose up`` install where the operator never reads
+the warning, and it leaves the seven mutation endpoints on the
+overlay router (``POST /api/state/{id}``, ``/create/overlay``,
+``/delete/overlay``, ``/api/raw_config``, ``/api/theme``) open to
+anyone who can reach the port.
+
+This module flips that default for ``OVERLAY_SERVER_TOKEN`` only —
+``SCOREBOARD_USERS`` is left fail-open because it gates user-level
+auth and forcing every "Friday-night team" deployment into a mandatory
+account model would be a real downgrade. We log loudly when it's
+unset instead.
+
+For ``OVERLAY_SERVER_TOKEN``, the resolution order at startup is:
+
+1. ``OVERLAY_SERVER_TOKEN_DISABLED=true`` → keep legacy fail-open.
+   Logs a critical warning so the choice is visible in the startup
+   tail. Useful for trusted-LAN deployments and local debugging.
+2. ``OVERLAY_SERVER_TOKEN=<value>`` already set → honour it.
+3. ``data/.overlay_server_token`` exists on disk → load it. This
+   keeps the auto-generated token stable across restarts so an
+   external ``CustomOverlayBackend`` peer doesn't lose its
+   credential every time the container reboots.
+4. None of the above → generate ``secrets.token_urlsafe(32)``,
+   persist with mode ``0o600`` to the data dir, and inject into
+   ``os.environ`` so the rest of the app picks it up via
+   ``EnvVarsManager.get_env_var``. Log the path once at INFO so
+   operators can capture the value (the log line itself does not
+   contain the token).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+import stat
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+_TOKEN_FILENAME = ".overlay_server_token"
+_TOKEN_BYTES = 32  # → 43-char URL-safe string
+
+_TRUTHY = ("1", "true", "t", "yes", "on")
+
+
+def _is_truthy_env(value: Optional[str]) -> bool:
+    return isinstance(value, str) and value.strip().lower() in _TRUTHY
+
+
+def _data_dir() -> str:
+    """Return the data directory used by the rest of the app.
+
+    Re-derives the path the same way :func:`app.api.action_log._data_dir`
+    does (``<repo>/data``) instead of importing it, because the bootstrap
+    runs before the API package is fully wired and we want to avoid
+    pulling in optional dependencies just to read a path.
+    """
+    here = Path(__file__).resolve().parent
+    return str(here.parent / "data")
+
+
+def _token_path() -> Path:
+    return Path(_data_dir()) / _TOKEN_FILENAME
+
+
+def _read_persisted_token(path: Path) -> Optional[str]:
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        logger.warning(
+            "Could not read persisted overlay-server token from %s: %s",
+            path, exc,
+        )
+        return None
+    return text or None
+
+
+def _write_persisted_token(path: Path, token: str) -> bool:
+    """Atomically write *token* to *path* with ``0o600`` permissions.
+
+    Returns ``True`` on success, ``False`` on any I/O error. Failures
+    are logged but never raise — the in-memory token still works for
+    this process; we just lose persistence across restart.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Write to a temp file first so a crash mid-write cannot leave a
+        # truncated token on disk. ``os.replace`` is atomic on POSIX.
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        # Write with restrictive perms from the start by opening through
+        # ``os.open`` with O_CREAT + O_EXCL + mode 0o600.
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        # Some platforms ignore the mode arg on subsequent opens, so
+        # chmod after-the-fact as a belt-and-suspenders.
+        fd = os.open(str(tmp), flags, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(token)
+        except BaseException:
+            try:
+                os.unlink(str(tmp))
+            except OSError:
+                pass
+            raise
+        try:
+            os.chmod(str(tmp), stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+        os.replace(str(tmp), str(path))
+    except OSError as exc:
+        logger.warning(
+            "Could not persist overlay-server token to %s: %s",
+            path, exc,
+        )
+        return False
+    return True
+
+
+def ensure_overlay_server_token() -> Optional[str]:
+    """Resolve / mint / persist the overlay-server token.
+
+    Returns the active token string, or ``None`` when fail-open mode is
+    explicitly enabled. Mutates ``os.environ`` so downstream callers
+    that read via :class:`EnvVarsManager` pick the value up
+    transparently.
+    """
+    if _is_truthy_env(os.environ.get("OVERLAY_SERVER_TOKEN_DISABLED")):
+        # Operator opted into the legacy fail-open behaviour. Make the
+        # choice loud so it shows up in the startup tail.
+        logger.critical(
+            "OVERLAY_SERVER_TOKEN_DISABLED=true — overlay server "
+            "mutation/config endpoints are UNAUTHENTICATED. Anyone "
+            "who can reach this port can mutate overlay state. Set "
+            "OVERLAY_SERVER_TOKEN to enable authentication."
+        )
+        return None
+
+    existing = (os.environ.get("OVERLAY_SERVER_TOKEN") or "").strip()
+    if existing:
+        return existing
+
+    path = _token_path()
+    persisted = _read_persisted_token(path)
+    if persisted:
+        os.environ["OVERLAY_SERVER_TOKEN"] = persisted
+        logger.info(
+            "Loaded persisted OVERLAY_SERVER_TOKEN from %s "
+            "(set OVERLAY_SERVER_TOKEN env var to override).",
+            path,
+        )
+        return persisted
+
+    new_token = secrets.token_urlsafe(_TOKEN_BYTES)
+    persisted_ok = _write_persisted_token(path, new_token)
+    os.environ["OVERLAY_SERVER_TOKEN"] = new_token
+    if persisted_ok:
+        logger.warning(
+            "Auto-generated OVERLAY_SERVER_TOKEN and persisted to %s. "
+            "External CustomOverlayBackend peers must use the same "
+            "value (read it from the file or set OVERLAY_SERVER_TOKEN "
+            "explicitly). Set OVERLAY_SERVER_TOKEN_DISABLED=true to "
+            "opt out and run unauthenticated.",
+            path,
+        )
+    else:
+        logger.warning(
+            "Auto-generated OVERLAY_SERVER_TOKEN but could not persist "
+            "to disk; the token will rotate on every restart. Set "
+            "OVERLAY_SERVER_TOKEN explicitly to fix."
+        )
+    return new_token
+
+
+def warn_if_open_scoreboard() -> None:
+    """Emit a loud startup warning when the scoreboard API is unauthenticated.
+
+    Unlike :func:`ensure_overlay_server_token`, we do not auto-generate
+    user records: ``SCOREBOARD_USERS`` is a JSON map of user→password
+    pairs and forcing one onto every fresh install would lock the
+    operator out of their own scoreboard. The right posture is "loud
+    warning by default, opt-out for trusted LANs".
+    """
+    raw = (os.environ.get("SCOREBOARD_USERS") or "").strip()
+    if raw:
+        return
+    if _is_truthy_env(os.environ.get("SCOREBOARD_USERS_DISABLED")):
+        # Same opt-out shape as the overlay token — operator
+        # acknowledged the open posture, no need to warn again.
+        return
+    logger.warning(
+        "SCOREBOARD_USERS is not set — every /api/v1/* scoreboard "
+        "endpoint is reachable without authentication. Configure "
+        "SCOREBOARD_USERS as a JSON map of {username: {password: ...}} "
+        "to require Bearer auth, or set SCOREBOARD_USERS_DISABLED=true "
+        "to silence this warning on trusted-LAN deployments."
+    )
+
+
+def run_security_bootstrap() -> None:
+    """Entry point invoked from :func:`app.bootstrap.create_app`.
+
+    Centralises the calls so future credential bootstraps (admin
+    password rotation, hashed-credential migration) only need a single
+    hook. Best-effort: a failure here logs but does not block startup,
+    because a missing token is not worse than a broken process.
+    """
+    try:
+        ensure_overlay_server_token()
+    except Exception:
+        logger.exception("ensure_overlay_server_token failed")
+    try:
+        warn_if_open_scoreboard()
+    except Exception:
+        logger.exception("warn_if_open_scoreboard failed")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,14 @@ services:
       - PREDEFINED_OVERLAYS=${PREDEFINED_OVERLAYS:-}
       - HIDE_CUSTOM_OVERLAY_WHEN_PREDEFINED=${HIDE_CUSTOM_OVERLAY_WHEN_PREDEFINED:-}
       - OVERLAY_MANAGER_PASSWORD=${OVERLAY_MANAGER_PASSWORD:-} #Optional: unlocks the /manage admin page
-      - OVERLAY_SERVER_TOKEN=${OVERLAY_SERVER_TOKEN:-} #Optional: bearer token for the external overlay server
+      # OVERLAY_SERVER_TOKEN is auto-generated and persisted to data/.overlay_server_token
+      # on first start. Set it explicitly here to override (e.g. when an external
+      # CustomOverlayBackend peer must use the same value), or set
+      # OVERLAY_SERVER_TOKEN_DISABLED=true to opt back into legacy unauthenticated
+      # behaviour (only safe on a trusted LAN).
+      - OVERLAY_SERVER_TOKEN=${OVERLAY_SERVER_TOKEN:-}
+      - OVERLAY_SERVER_TOKEN_DISABLED=${OVERLAY_SERVER_TOKEN_DISABLED:-} #Optional: opt out of overlay-server auth
+      - SCOREBOARD_USERS_DISABLED=${SCOREBOARD_USERS_DISABLED:-} #Optional: silence the open-API startup warning
       - MATCH_REPORT_PUBLIC=${MATCH_REPORT_PUBLIC:-false} #Optional: open match-report routes to anonymous reads
       - SCOREBOARD_USERS=${SCOREBOARD_USERS:-}
       - REST_USER_AGENT=${REST_USER_AGENT:-}

--- a/tests/test_security_bootstrap.py
+++ b/tests/test_security_bootstrap.py
@@ -1,0 +1,226 @@
+"""Coverage for :mod:`app.security_bootstrap`.
+
+Pins the four resolution paths of :func:`ensure_overlay_server_token`
+plus the open-scoreboard warning:
+
+1. ``OVERLAY_SERVER_TOKEN_DISABLED=true`` → returns ``None`` and
+   logs CRITICAL; ``os.environ`` is not touched.
+2. ``OVERLAY_SERVER_TOKEN`` already set → returned verbatim.
+3. Persisted file exists → loaded and injected into ``os.environ``.
+4. Nothing set, nothing persisted → mint a fresh token, persist with
+   ``0o600`` permissions, inject into ``os.environ``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from app import security_bootstrap
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch):
+    monkeypatch.delenv("OVERLAY_SERVER_TOKEN", raising=False)
+    monkeypatch.delenv("OVERLAY_SERVER_TOKEN_DISABLED", raising=False)
+    monkeypatch.delenv("SCOREBOARD_USERS", raising=False)
+    monkeypatch.delenv("SCOREBOARD_USERS_DISABLED", raising=False)
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    """Redirect the bootstrap's data dir to a per-test tmp dir.
+
+    Avoids touching the repo's real ``data/`` directory and lets us
+    inspect the persisted token file directly.
+    """
+    monkeypatch.setattr(security_bootstrap, "_data_dir", lambda: str(tmp_path))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Path 1 — explicit opt-out
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_opt_out_returns_none(isolated_data_dir, monkeypatch, caplog):
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN_DISABLED", "true")
+    with caplog.at_level(logging.CRITICAL, logger="app.security_bootstrap"):
+        result = security_bootstrap.ensure_overlay_server_token()
+    assert result is None
+    # Env var must not be set even by mistake — the operator chose
+    # fail-open and the rest of the app gates on emptiness.
+    assert os.environ.get("OVERLAY_SERVER_TOKEN") is None
+    # Persisted file must not be created either.
+    assert not (isolated_data_dir / ".overlay_server_token").exists()
+    # The opt-out is logged at CRITICAL so it surfaces in the startup tail.
+    assert any("UNAUTHENTICATED" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.parametrize("flag", ["1", "true", "TRUE", "yes", "on"])
+def test_opt_out_accepts_truthy_aliases(flag, isolated_data_dir, monkeypatch):
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN_DISABLED", flag)
+    assert security_bootstrap.ensure_overlay_server_token() is None
+
+
+# ---------------------------------------------------------------------------
+# Path 2 — already configured
+# ---------------------------------------------------------------------------
+
+
+def test_existing_env_var_is_passthrough(isolated_data_dir, monkeypatch):
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN", "operator-supplied")
+    result = security_bootstrap.ensure_overlay_server_token()
+    assert result == "operator-supplied"
+    assert os.environ["OVERLAY_SERVER_TOKEN"] == "operator-supplied"
+    # Pre-set tokens must not be persisted — operator already manages
+    # the value via env, persisting would shadow a future change.
+    assert not (isolated_data_dir / ".overlay_server_token").exists()
+
+
+def test_whitespace_only_env_treated_as_unset(isolated_data_dir, monkeypatch):
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN", "   ")
+    result = security_bootstrap.ensure_overlay_server_token()
+    # Falls through to mint a fresh token rather than honouring "   ".
+    assert result is not None and len(result) > 10
+    assert os.environ["OVERLAY_SERVER_TOKEN"] == result
+
+
+# ---------------------------------------------------------------------------
+# Path 3 — persisted file
+# ---------------------------------------------------------------------------
+
+
+def test_persisted_token_is_loaded(isolated_data_dir, monkeypatch):
+    persisted = isolated_data_dir / ".overlay_server_token"
+    persisted.write_text("from-disk-token", encoding="utf-8")
+    result = security_bootstrap.ensure_overlay_server_token()
+    assert result == "from-disk-token"
+    assert os.environ["OVERLAY_SERVER_TOKEN"] == "from-disk-token"
+
+
+def test_persisted_token_with_trailing_whitespace_is_trimmed(
+    isolated_data_dir, monkeypatch,
+):
+    persisted = isolated_data_dir / ".overlay_server_token"
+    persisted.write_text("trimmed-token\n", encoding="utf-8")
+    assert security_bootstrap.ensure_overlay_server_token() == "trimmed-token"
+
+
+def test_empty_persisted_file_falls_through_to_generation(
+    isolated_data_dir, monkeypatch,
+):
+    persisted = isolated_data_dir / ".overlay_server_token"
+    persisted.write_text("", encoding="utf-8")
+    result = security_bootstrap.ensure_overlay_server_token()
+    assert result is not None and len(result) > 10
+    # The empty file should have been overwritten with the new token.
+    assert persisted.read_text(encoding="utf-8") == result
+
+
+# ---------------------------------------------------------------------------
+# Path 4 — auto-generation
+# ---------------------------------------------------------------------------
+
+
+def test_auto_generates_persists_and_sets_env(isolated_data_dir):
+    result = security_bootstrap.ensure_overlay_server_token()
+    assert result is not None
+    assert len(result) >= 32  # token_urlsafe(32) → ~43 chars
+    assert os.environ["OVERLAY_SERVER_TOKEN"] == result
+    persisted = isolated_data_dir / ".overlay_server_token"
+    assert persisted.exists()
+    assert persisted.read_text(encoding="utf-8") == result
+
+
+def test_persisted_file_has_owner_only_permissions(isolated_data_dir):
+    security_bootstrap.ensure_overlay_server_token()
+    persisted = isolated_data_dir / ".overlay_server_token"
+    mode = persisted.stat().st_mode
+    # Group and other bits must be cleared — the token is a credential.
+    assert not (mode & stat.S_IRGRP)
+    assert not (mode & stat.S_IWGRP)
+    assert not (mode & stat.S_IROTH)
+    assert not (mode & stat.S_IWOTH)
+
+
+def test_subsequent_calls_are_idempotent(isolated_data_dir):
+    """A second call must reuse the persisted token rather than rotating it."""
+    first = security_bootstrap.ensure_overlay_server_token()
+    # Simulate a process restart by clearing the env var only — the
+    # file on disk should drive the next resolution.
+    del os.environ["OVERLAY_SERVER_TOKEN"]
+    second = security_bootstrap.ensure_overlay_server_token()
+    assert first == second
+
+
+def test_generation_failure_to_persist_still_returns_token(
+    isolated_data_dir, monkeypatch, caplog,
+):
+    """If the data dir is unwritable, the in-memory token still works."""
+    def fail_write(path: Path, token: str) -> bool:
+        return False
+
+    monkeypatch.setattr(security_bootstrap, "_write_persisted_token", fail_write)
+    with caplog.at_level(logging.WARNING, logger="app.security_bootstrap"):
+        result = security_bootstrap.ensure_overlay_server_token()
+    assert result is not None
+    assert os.environ["OVERLAY_SERVER_TOKEN"] == result
+    assert any("could not persist" in rec.message.lower()
+               for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# SCOREBOARD_USERS warning
+# ---------------------------------------------------------------------------
+
+
+def test_scoreboard_warning_when_unset(monkeypatch, caplog):
+    with caplog.at_level(logging.WARNING, logger="app.security_bootstrap"):
+        security_bootstrap.warn_if_open_scoreboard()
+    assert any("SCOREBOARD_USERS" in rec.message for rec in caplog.records)
+
+
+def test_scoreboard_no_warning_when_set(monkeypatch, caplog):
+    monkeypatch.setenv("SCOREBOARD_USERS", '{"alice": {"password": "x"}}')
+    with caplog.at_level(logging.WARNING, logger="app.security_bootstrap"):
+        security_bootstrap.warn_if_open_scoreboard()
+    assert not any("SCOREBOARD_USERS" in rec.message
+                   for rec in caplog.records)
+
+
+def test_scoreboard_no_warning_when_explicitly_disabled(monkeypatch, caplog):
+    monkeypatch.setenv("SCOREBOARD_USERS_DISABLED", "true")
+    with caplog.at_level(logging.WARNING, logger="app.security_bootstrap"):
+        security_bootstrap.warn_if_open_scoreboard()
+    assert not any("SCOREBOARD_USERS" in rec.message
+                   for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+def test_run_security_bootstrap_swallows_exceptions(monkeypatch, caplog):
+    """A failure in one bootstrap step must not block startup."""
+    def boom() -> None:
+        raise RuntimeError("simulated")
+
+    monkeypatch.setattr(
+        security_bootstrap, "ensure_overlay_server_token", boom,
+    )
+    monkeypatch.setattr(
+        security_bootstrap, "warn_if_open_scoreboard", boom,
+    )
+    with caplog.at_level(logging.ERROR, logger="app.security_bootstrap"):
+        security_bootstrap.run_security_bootstrap()
+    # Both failures should have been logged via logger.exception.
+    failure_records = [
+        rec for rec in caplog.records if "failed" in rec.message.lower()
+    ]
+    assert len(failure_records) >= 2


### PR DESCRIPTION
## Summary

PR 2 of the security plan (PR 1 = #258, merged). Flips the default posture of `OVERLAY_SERVER_TOKEN` from **fail-open if unset** to **auto-secure if unset**, and adds a startup warning for the same gap on `SCOREBOARD_USERS`. Existing deployments that set the env var explicitly (recommended) are unaffected; deployments that left it unset will pick up an auto-generated, persisted token transparently.

## What changes

- **New `app/security_bootstrap.py`** — runs once from `create_app()` and resolves `OVERLAY_SERVER_TOKEN` in this order:
  1. `OVERLAY_SERVER_TOKEN_DISABLED=true` → keep legacy fail-open, log `CRITICAL`.
  2. `OVERLAY_SERVER_TOKEN=<value>` → honour it.
  3. `data/.overlay_server_token` exists → load it.
  4. Nothing set → `secrets.token_urlsafe(32)`, persisted to disk with mode `0o600`, injected into `os.environ`.

  All paths are idempotent across restarts and across repeated `create_app()` calls (tests).

- **`SCOREBOARD_USERS` startup warning** — logged when unset, silenced via `SCOREBOARD_USERS_DISABLED=true`. The API still allows unauthenticated requests; the flag only acknowledges the open posture so it's visible in the startup tail.

- **Wired into `app/bootstrap.py:create_app`** before any router is included so `verify_overlay_server_token` and the rest of the app see the same token.

- **Docs** — `AUTHENTICATION.md` §5 release notes, `README.md` env-var table + Overlay-server-token section, `CHANGELOG.md` `[Unreleased] / Security`. `docker-compose.yml` env-var hints updated.

## Operator migration

| Scenario | Action |
|---|---|
| Single self-hosted instance (in-process overlay) | None. Auto-generated token works invisibly. |
| External `CustomOverlayBackend` peer via `APP_CUSTOM_OVERLAY_URL` | Either set `OVERLAY_SERVER_TOKEN` explicitly on both sides, or copy the generated value from `data/.overlay_server_token` after the first start. |
| Trusted LAN, deliberately unauthenticated | Set `OVERLAY_SERVER_TOKEN_DISABLED=true`. A `CRITICAL` startup log makes the choice visible. |

## Test plan

- [x] `pytest tests/` — **761 passing** (was 742 + 19 new in `tests/test_security_bootstrap.py`).
- [x] `ruff check app/ tests/` — clean.
- [x] New tests cover: explicit opt-out (returns `None`, no env or file mutation, logs CRITICAL); truthy-alias parsing (`1`, `true`, `TRUE`, `yes`, `on`); pre-set env var (passthrough, no persist); whitespace-only env var (treated as unset); persisted-file load + trim; empty file falls through to generation; auto-generated token is mode `0o600` (group/other bits cleared); idempotency across simulated restart; write-failure fallback (token still works in-memory); `SCOREBOARD_USERS` warning matrix (set / unset / disabled); `run_security_bootstrap` swallows exceptions in either step.
- [ ] Manual smoke: a fresh container start populates `data/.overlay_server_token` and the auto-generated value rejects an unauthenticated `POST /api/state/{id}`.
- [ ] Manual smoke: setting `OVERLAY_SERVER_TOKEN_DISABLED=true` restores legacy unauthenticated access.

## Out of scope (still queued for later PRs)

- H‑4 query-string token leakage on WS auth and `/match/{id}/report?token=`.
- H‑5 hashed credential storage at rest.
- M‑4 `TrustedHostMiddleware`, M‑5 CORS scaffolding.

https://claude.ai/code/session_01BPyiEJ4eyUz9NHZy6zbRhy

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPyiEJ4eyUz9NHZy6zbRhy)_