### PR TITLE
sec: take credentials off the URL line (signed match URLs + WS subprotocol)

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -62,7 +62,7 @@ via `get_session` (or explicitly inside the handler).
 | `GET` | `/themes` | Y | |
 | `GET` | `/links` | Y + OID | |
 | `GET` | `/styles` | Y + OID | |
-| `WS` | `/ws` | Y + OID | Explicit `check_oid_access`; accepts token via `?token=…` query param |
+| `WS` | `/ws` | Y + OID | Explicit `check_oid_access`; accepts token via `Sec-WebSocket-Protocol: bearer, <token>` (preferred) or `?token=…` query param (deprecated, kept for legacy clients) |
 
 ### 2.2 Admin — `admin_router` + `admin_page_router` (`app/admin/routes.py`)
 
@@ -71,6 +71,7 @@ via `get_session` (or explicitly inside the handler).
 | `GET` | `/manage` | — | Static HTML page; JS prompts for password client-side and keeps it in a closure variable only. |
 | `GET` | `/api/v1/admin/status` | — | Returns `{"enabled": bool}` only — does not leak the password itself. |
 | `POST` | `/api/v1/admin/login` | `require_admin` | Used by the management page to validate the password. |
+| `POST` | `/api/v1/admin/match/{match_id}/sign-url` | `require_admin` | Mints an HMAC-signed capability URL for the gated match report. Body: `{"ttl_seconds": int}`. Response: `{"url", "expires_at", "expires_in"}`. The URL embeds `?exp=&sig=` — never the admin password. |
 | `GET` | `/api/v1/admin/custom-overlays` | `require_admin` | Lists custom overlays managed by the in-process engine. |
 | `POST` | `/api/v1/admin/custom-overlays` | `require_admin` | Creates a custom overlay (optional `copy_from` to clone). |
 | `DELETE` | `/api/v1/admin/custom-overlays/{id}` | `require_admin` | Deletes a custom overlay and its persisted state. |
@@ -299,3 +300,58 @@ Operators can override individual headers via env vars:
 (opt-in HSTS, off by default so non-HTTPS deployments are not
 locked out). Existing handler-level `Cache-Control` headers are
 always preserved.
+
+## 7. Credential transport patterns
+
+This section documents how each credential travels on the wire, and
+the H-4 hardening that flipped two of them away from the URL line.
+
+### 7.1 Match report: signed capability URLs
+
+The legacy share flow for the gated match report was
+``/match/{id}/report?token=$OVERLAY_MANAGER_PASSWORD``. Pasting
+the URL into chat tools, browser bookmarks, or anywhere a
+``Referer`` header could be sent leaked the actual admin password.
+
+Operators should now mint a capability URL via
+``POST /api/v1/admin/match/{match_id}/sign-url`` (admin Bearer
+required). The response carries a URL of the form
+``/match/{id}/report?exp=<unix_seconds>&sig=<hmac_hex>``. The
+signing key is derived from ``OVERLAY_MANAGER_PASSWORD``, so:
+
+* Anyone who holds the URL can read the report until ``exp``
+  passes.
+* The admin password itself never leaves the server.
+* Rotating ``OVERLAY_MANAGER_PASSWORD`` invalidates every
+  outstanding signed URL — the desired behaviour after a suspected
+  leak.
+* TTL is bounded to ``[60 s, 30 days]``; the default is one day.
+
+The legacy ``?token=`` flow is preserved for backwards
+compatibility but should be considered deprecated. The matches
+index (``/matches/index.html``) deliberately does *not* honour
+signed URLs — it would need a separate list-all capability that
+also unlocks per-row deletion, and that feature is intentionally
+not provided yet.
+
+### 7.2 `/api/v1/ws`: Bearer subprotocol auth
+
+WebSocket connections from JavaScript clients cannot set custom
+headers. The legacy workaround was a ``?token=<value>`` query
+parameter, which leaks via every reverse-proxy access log.
+
+The route now resolves auth in this order:
+
+1. ``Sec-WebSocket-Protocol: bearer, <token>`` — preferred.
+   Browser clients open the socket with
+   ``new WebSocket(url, ["bearer", token])``. The server
+   selects the ``bearer`` subprotocol and echoes it back during
+   the handshake (RFC 6455 §4.1).
+2. ``Authorization: Bearer <token>`` header — for non-browser
+   clients that can set headers on the upgrade request.
+3. ``?token=<value>`` query parameter — legacy fallback. Kept
+   so existing CLI / script clients keep working; documented as
+   deprecated in the OpenAPI schema.
+
+The token never appears in the request line for browser clients
+that adopt path 1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ once a first tagged release ships.
 
 ### Security
 
+- **Capability-style signed URLs for the gated match report.** New
+  endpoint ``POST /api/v1/admin/match/{match_id}/sign-url`` (admin
+  Bearer auth) returns a short-lived URL of the form
+  ``/match/{id}/report?exp=<unix>&sig=<hmac>``. The legacy
+  ``?token=<OVERLAY_MANAGER_PASSWORD>`` flow is preserved for
+  backwards compatibility but operators should switch over: signed
+  URLs do not embed the admin password, expire automatically (TTL
+  bounded to ``[60, 30 days]``, default ``86 400 s``), and rotating
+  the password invalidates every outstanding signature.
+- **Bearer subprotocol auth on ``/api/v1/ws``.** The WebSocket route
+  now prefers ``Sec-WebSocket-Protocol: bearer, <token>`` over the
+  legacy ``?token=`` query parameter. The handshake echoes the
+  selected subprotocol so browser clients accept the connection.
+  Resolution order: subprotocol → ``Authorization`` header → legacy
+  ``?token=`` query (deprecated). Tokens no longer need to appear
+  in URL access logs or HTTP ``Referer`` headers for browser clients.
+
 - ``OVERLAY_SERVER_TOKEN`` is now **auto-generated and persisted on
   first start** instead of leaving the seven overlay-server mutation
   endpoints (``POST /api/state/{id}``, ``/create/overlay/{id}``,

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Import configuration from an external resource via `REMOTE_CONFIG_URL`. The appl
 | `/api/v1/matches[?oid=X]` | `GET` — list summaries of archived matches, newest first (optional OID filter). |
 | `/api/v1/matches/{match_id}` | `GET` — full archived match snapshot (final state, customization, audit log, config). |
 | `/api/v1/game/undo` | `POST` — pop the last forward `add_point`/`add_set`/`add_timeout` from the audit log and reverse it. Returns 200 with `success=false` and `message="Nothing to undo."` when the log is empty. |
-| `/match/{match_id}/report` | `GET` — print-friendly HTML match report. Gated by `OVERLAY_MANAGER_PASSWORD` (Bearer header or `?token=`) unless `MATCH_REPORT_PUBLIC=true`. Returns 503 when neither is configured. |
+| `/match/{match_id}/report` | `GET` — print-friendly HTML match report. Gated by `OVERLAY_MANAGER_PASSWORD` unless `MATCH_REPORT_PUBLIC=true`. Auth modes: `Authorization: Bearer <password>` header, `?exp=&sig=` signed URL minted via `POST /api/v1/admin/match/{id}/sign-url` (preferred), or legacy `?token=<password>` query (deprecated — leaks the admin password into URL access logs). Returns 503 when neither password nor public mode is configured. |
 | `/matches/index.html?oid=X` | `GET` — browseable HTML list of every archived match for the OID (date, sets, duration, link to each report). Same auth gate as `/match/{id}/report`; the `?token=` query is propagated to the per-match report links. |
 | `/matches/{match_id}` | `DELETE` — remove a single archived snapshot. Gated by `OVERLAY_MANAGER_PASSWORD` unless `MATCH_REPORT_PUBLIC_DELETE=true`. |
 | `/overlay/{id}` | Overlay HTML for OBS browser sources (built-in engine). `?style=mosaic` renders a preview grid of every selectable style. |

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -20,6 +20,7 @@ variable to be set and the request to include a matching
 import logging
 import os
 import re
+import time
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
@@ -259,11 +260,10 @@ def sign_match_report_url(
         f"{base_url}/match/{match_id}/report"
         f"?exp={signed['exp']}&sig={signed['sig']}"
     )
-    import time as _time
     return MatchSignUrlResponse(
         url=url,
         expires_at=signed["expires_at"],
-        expires_in=max(0, signed["expires_at"] - int(_time.time())),
+        expires_in=max(0, signed["expires_at"] - int(time.time())),
     )
 
 

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -22,12 +22,18 @@ import os
 import re
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 from starlette.concurrency import run_in_threadpool
 
 from app.auth_utils import get_admin_password, require_admin_token
+from app.match_report_signing import (
+    DEFAULT_TTL_SECONDS,
+    MAX_TTL_SECONDS,
+    MIN_TTL_SECONDS,
+    make_signed_query,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +55,35 @@ class CustomOverlayCreate(BaseModel):
     copy_from: Optional[str] = Field(
         None,
         description="Optional existing overlay id to clone configuration from",
+    )
+
+
+class MatchSignUrlRequest(BaseModel):
+    ttl_seconds: Optional[int] = Field(
+        default=None,
+        ge=MIN_TTL_SECONDS,
+        le=MAX_TTL_SECONDS,
+        description=(
+            "URL lifetime in seconds. Bounded to "
+            f"[{MIN_TTL_SECONDS}, {MAX_TTL_SECONDS}]; defaults to "
+            f"{DEFAULT_TTL_SECONDS}."
+        ),
+    )
+
+
+class MatchSignUrlResponse(BaseModel):
+    url: str = Field(
+        ...,
+        description=(
+            "Absolute capability URL — anyone holding it can read "
+            "the report until ``expires_at``."
+        ),
+    )
+    expires_at: int = Field(
+        ..., description="Unix-seconds expiry the URL was signed for.",
+    )
+    expires_in: int = Field(
+        ..., description="Seconds remaining until expiry, at mint time.",
     )
 
 
@@ -177,6 +212,59 @@ def create_custom_overlay(payload: CustomOverlayCreate):
         "oid": name,
         "output_key": store.get_output_key(name),
     }
+
+
+@admin_router.post(
+    "/match/{match_id}/sign-url",
+    response_model=MatchSignUrlResponse,
+    dependencies=[Depends(require_admin)],
+    summary="Mint a short-lived signed URL for a match report",
+)
+def sign_match_report_url(
+    match_id: str,
+    payload: MatchSignUrlRequest,
+    request: Request,
+):
+    """Return a capability URL the operator can paste into chat tools.
+
+    The legacy share flow (``/match/{id}/report?token=<password>``)
+    embeds the actual ``OVERLAY_MANAGER_PASSWORD`` in the URL —
+    every browser bookmark, server log, or HTTP ``Referer`` that
+    touches the link leaks the credential. This endpoint replaces
+    that flow with an HMAC-signed URL of the form
+    ``/match/{id}/report?exp=<ts>&sig=<hex>``: the password stays
+    on the server and the URL expires automatically.
+
+    Rotating the admin password invalidates every outstanding
+    signed URL — that's the desired behaviour, since rotations are
+    typically motivated by suspected leaks.
+
+    The endpoint deliberately does *not* check whether the
+    ``match_id`` exists: a 404 here would be a free oracle for
+    enumerating archived matches by anyone holding the admin
+    password (who could already do far worse anyway). Signing a
+    bogus match id just produces a URL that 404s on use.
+    """
+    signed = make_signed_query(match_id, payload.ttl_seconds)
+    if signed is None:
+        # Should be unreachable — require_admin already 503's when
+        # the password is unset — but guard anyway in case a future
+        # refactor decouples the two.
+        raise HTTPException(
+            status_code=503,
+            detail="Match-report signing requires OVERLAY_MANAGER_PASSWORD.",
+        )
+    base_url = str(request.base_url).rstrip("/")
+    url = (
+        f"{base_url}/match/{match_id}/report"
+        f"?exp={signed['exp']}&sig={signed['sig']}"
+    )
+    import time as _time
+    return MatchSignUrlResponse(
+        url=url,
+        expires_at=signed["expires_at"],
+        expires_in=max(0, signed["expires_at"] - int(_time.time())),
+    )
 
 
 @admin_router.delete("/custom-overlays/{name}", dependencies=[Depends(require_admin)])

--- a/app/api/routes/websocket.py
+++ b/app/api/routes/websocket.py
@@ -15,6 +15,51 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+# Subprotocol convention: the client opens the WebSocket with the
+# subprotocols ``["bearer", "<token>"]``. The server picks
+# ``bearer`` as the chosen subprotocol (echoed in the handshake) and
+# uses the second list entry as the token. This is the RFC 6455
+# pattern that browser ``new WebSocket(url, [...])`` clients can
+# use without exposing the credential in the URL.
+_BEARER_SUBPROTOCOL = "bearer"
+
+
+def _resolve_ws_auth(ws: WebSocket) -> tuple[str, str | None]:
+    """Return ``(authorization_header, selected_subprotocol)``.
+
+    Resolution order:
+
+    1. ``Sec-WebSocket-Protocol: bearer, <token>`` — preferred,
+       no secret on the URL line.
+    2. ``Authorization: Bearer <token>`` — for non-browser clients
+       that can set headers on the upgrade request.
+    3. ``?token=<value>`` — legacy fallback, kept for the existing
+       CLI/script clients. Documented as deprecated.
+
+    The selected subprotocol must be echoed back when calling
+    ``ws.accept(subprotocol=...)``; otherwise a browser client drops
+    the connection with a protocol-mismatch error.
+    """
+    raw_proto = ws.headers.get("sec-websocket-protocol", "")
+    protocols = [p.strip() for p in raw_proto.split(",") if p.strip()]
+    if (
+        len(protocols) >= 2
+        and protocols[0].lower() == _BEARER_SUBPROTOCOL
+    ):
+        token = protocols[1]
+        return f"Bearer {token}", _BEARER_SUBPROTOCOL
+
+    auth = ws.headers.get("authorization", "")
+    if auth:
+        return auth, None
+
+    legacy_token = ws.query_params.get("token")
+    if legacy_token:
+        return f"Bearer {legacy_token}", None
+
+    return "", None
+
+
 @router.websocket("/ws")
 async def websocket_endpoint(
     ws: WebSocket,
@@ -26,8 +71,7 @@ async def websocket_endpoint(
         await ws.close(code=4400, reason="Missing 'oid' (or alias 'control') query parameter.")
         return
 
-    token = ws.query_params.get("token")
-    auth_header = f"Bearer {token}" if token else ws.headers.get("authorization", "")
+    auth_header, selected_subprotocol = _resolve_ws_auth(ws)
 
     try:
         check_oid_access(auth_header, resolved)
@@ -40,7 +84,7 @@ async def websocket_endpoint(
         await ws.close(code=4004, reason="No active session for this OID.")
         return
 
-    await WSHub.connect(ws, resolved)
+    await WSHub.connect(ws, resolved, subprotocol=selected_subprotocol)
     try:
         state_data = GameService.get_state(session).model_dump()
         await ws.send_json({"type": "state_update", "data": state_data})

--- a/app/api/ws_hub.py
+++ b/app/api/ws_hub.py
@@ -19,8 +19,21 @@ class WSHub:
     _connections: dict = {}
 
     @classmethod
-    async def connect(cls, ws: WebSocket, oid: str):
-        await ws.accept()
+    async def connect(cls, ws: WebSocket, oid: str, *,
+                      subprotocol: str | None = None):
+        """Accept *ws* and register it under *oid*.
+
+        ``subprotocol`` is echoed back to the client during the
+        WebSocket handshake. The Bearer-token-as-subprotocol pattern
+        (RFC 6455 §4.1) requires the server to confirm the chosen
+        subprotocol, otherwise the browser drops the connection
+        with a protocol-mismatch error. Callers that authenticated
+        via subprotocol must pass the same value here.
+        """
+        if subprotocol is not None:
+            await ws.accept(subprotocol=subprotocol)
+        else:
+            await ws.accept()
         cls._connections.setdefault(oid, set()).add(ws)
         logger.info(
             "WS client connected for OID=%s (total=%d)",

--- a/app/match_report.py
+++ b/app/match_report.py
@@ -75,19 +75,40 @@ def _public_delete_enabled() -> bool:
     return _is_env_enabled("MATCH_REPORT_PUBLIC_DELETE")
 
 
-def _check_access(authorization: Optional[str], token: Optional[str]) -> None:
+def _check_access(
+    authorization: Optional[str],
+    token: Optional[str],
+    *,
+    match_id: Optional[str] = None,
+    exp: Optional[str] = None,
+    sig: Optional[str] = None,
+) -> None:
     """Raise an ``HTTPException`` unless the caller is allowed to read.
 
     Order of precedence:
       1. ``MATCH_REPORT_PUBLIC=true`` — open access (matches the
          existing ``/overlay/{output_key}`` model);
-      2. otherwise, ``OVERLAY_MANAGER_PASSWORD`` must be set and
-         provided via Bearer header or ``?token=`` query;
-      3. when neither is configured, return 503 to make
-         misconfiguration loud rather than silently public.
+      2. a valid HMAC signature on ``(match_id, exp)`` (capability URL
+         minted by the admin endpoint, no password in the link);
+      3. otherwise, ``OVERLAY_MANAGER_PASSWORD`` must be set and
+         provided via Bearer header or ``?token=`` query (legacy);
+      4. when neither password nor signature works and no public-read
+         mode is enabled, return 503 to make misconfiguration loud
+         rather than silently public.
     """
     if _public_mode_enabled():
         return
+    # Capability URL — no need for the password to be on the wire.
+    # Signed URLs are minted by the admin endpoint and embed an
+    # ``exp`` that lets the operator share a short-lived link
+    # without leaking ``OVERLAY_MANAGER_PASSWORD``.
+    if match_id is not None and (exp or sig):
+        from app.match_report_signing import verify_signed_query
+        if verify_signed_query(match_id, exp, sig):
+            return
+        # Falling through is intentional: an invalid sig should not
+        # leak via a different error than an invalid token, so the
+        # require_admin_token call below produces the canonical 401/403.
     _require_admin_token(
         authorization, token,
         # Bandit B106 false positive: this is the error message shown
@@ -1376,9 +1397,15 @@ async def match_report(
     token: Optional[str] = Query(default=None,
                                  description="OVERLAY_MANAGER_PASSWORD; "
                                              "alternative to Bearer header."),
+    exp: Optional[str] = Query(default=None,
+                               description="Signed-URL expiry (unix seconds)."),
+    sig: Optional[str] = Query(default=None,
+                               description="Signed-URL HMAC-SHA256 hex digest."),
     accept_language: Optional[str] = Header(default=None),
 ):
-    _check_access(authorization, token)
+    _check_access(
+        authorization, token, match_id=match_id, exp=exp, sig=sig,
+    )
     payload = match_archive.load_match(match_id)
     if payload is None:
         raise HTTPException(status_code=404, detail="Match not found.")
@@ -1804,6 +1831,11 @@ async def matches_index(
                                  description="OVERLAY_MANAGER_PASSWORD; "
                                              "alternative to Bearer header."),
 ):
+    # Signed-URL auth deliberately not honoured on the index — a
+    # signature pins one specific match_id; the index would need a
+    # separate "list-all" capability that's a different feature
+    # (and intentionally not provided yet, since the index gives
+    # destructive access via per-row Delete).
     _check_access(authorization, token)
     summaries = match_archive.list_matches(oid=oid)
 

--- a/app/match_report_signing.py
+++ b/app/match_report_signing.py
@@ -44,11 +44,6 @@ from app.auth_utils import get_admin_password
 logger = logging.getLogger(__name__)
 
 
-# ``urlsafe_b64`` would shave a few bytes off the URL but operators
-# tend to copy-paste these into chat tools that mangle ``-`` / ``_`` in
-# unpredictable ways. Hex is uglier but bulletproof.
-_SIG_ENCODING = "hex"
-
 # Cap the TTL the admin endpoint will mint. Operators who want a
 # permanent share-link should set ``MATCH_REPORT_PUBLIC=true`` and
 # share the bare URL — that's the documented model. The cap stops

--- a/app/match_report_signing.py
+++ b/app/match_report_signing.py
@@ -1,0 +1,151 @@
+"""HMAC-signed URLs for ``/match/{match_id}/report``.
+
+The legacy access mechanism for the gated match-report is
+``?token=<OVERLAY_MANAGER_PASSWORD>``: the operator pastes the
+report URL into a chat tool and the URL contains the actual admin
+password. Any browser bookmark, server access log, or HTTP
+``Referer`` header that touches that URL leaks the credential.
+
+This module replaces that flow with capability-style signed URLs.
+The operator mints a per-match URL via the new admin endpoint
+``POST /api/v1/admin/match/{match_id}/sign-url``; the resulting URL
+carries an ``exp`` (expiry) and ``sig`` (HMAC-SHA256) parameter
+instead of the raw password. Anyone who holds the URL can read the
+report until ``exp`` passes; the admin password itself never leaves
+the server.
+
+The signing key is derived from ``OVERLAY_MANAGER_PASSWORD`` so the
+deployment story stays a single secret. Rotating the admin password
+invalidates every outstanding signed URL — that's the desired
+behaviour, since a rotation is usually motivated by a compromise.
+
+Format
+------
+
+* Query parameters: ``?exp=<unix_seconds>&sig=<hex>``.
+* Signature payload: ``f"{match_id}|{exp}".encode("utf-8")``.
+* Algorithm: HMAC-SHA256, lowercase hex digest.
+
+The verifier checks ``exp`` first (cheap reject for stale links)
+and only then computes the HMAC, using ``hmac.compare_digest`` to
+avoid a timing oracle.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import time
+from typing import Optional
+
+from app.auth_utils import get_admin_password
+
+logger = logging.getLogger(__name__)
+
+
+# ``urlsafe_b64`` would shave a few bytes off the URL but operators
+# tend to copy-paste these into chat tools that mangle ``-`` / ``_`` in
+# unpredictable ways. Hex is uglier but bulletproof.
+_SIG_ENCODING = "hex"
+
+# Cap the TTL the admin endpoint will mint. Operators who want a
+# permanent share-link should set ``MATCH_REPORT_PUBLIC=true`` and
+# share the bare URL — that's the documented model. The cap stops
+# someone from accidentally minting a year-long link in chat.
+DEFAULT_TTL_SECONDS = 24 * 60 * 60        # 1 day
+MAX_TTL_SECONDS = 30 * 24 * 60 * 60       # 30 days
+MIN_TTL_SECONDS = 60                      # 1 minute
+
+
+def _signing_key() -> Optional[bytes]:
+    """Return the HMAC key derived from ``OVERLAY_MANAGER_PASSWORD``.
+
+    Returns ``None`` when the password is unset — callers should fall
+    back to whatever auth mode is configured (typically a 503 in the
+    consuming endpoint).
+    """
+    pw = get_admin_password()
+    if pw is None:
+        return None
+    return pw.encode("utf-8")
+
+
+def _digest(match_id: str, exp_unix: int) -> Optional[str]:
+    key = _signing_key()
+    if key is None:
+        return None
+    msg = f"{match_id}|{exp_unix}".encode("utf-8")
+    return hmac.new(key, msg, hashlib.sha256).hexdigest()
+
+
+def clamp_ttl(ttl_seconds: Optional[int]) -> int:
+    """Bound *ttl_seconds* to ``[MIN_TTL_SECONDS, MAX_TTL_SECONDS]``.
+
+    ``None`` and non-positive values fall back to ``DEFAULT_TTL_SECONDS``.
+    """
+    if ttl_seconds is None:
+        return DEFAULT_TTL_SECONDS
+    try:
+        ttl = int(ttl_seconds)
+    except (TypeError, ValueError):
+        return DEFAULT_TTL_SECONDS
+    if ttl <= 0:
+        return DEFAULT_TTL_SECONDS
+    return max(MIN_TTL_SECONDS, min(MAX_TTL_SECONDS, ttl))
+
+
+def make_signed_query(
+    match_id: str,
+    ttl_seconds: Optional[int] = None,
+    *,
+    now: Optional[float] = None,
+) -> Optional[dict]:
+    """Return ``{exp, sig, expires_at}`` for the signed URL, or ``None``.
+
+    ``None`` means signing is unavailable because the admin password
+    is unset; callers translate that to a 503.
+
+    *now* is a test seam for deterministic expiry; production callers
+    should leave it as ``None``.
+    """
+    ttl = clamp_ttl(ttl_seconds)
+    base_now = time.time() if now is None else float(now)
+    exp = int(base_now) + ttl
+    sig = _digest(match_id, exp)
+    if sig is None:
+        return None
+    return {"exp": exp, "sig": sig, "expires_at": exp}
+
+
+def verify_signed_query(
+    match_id: str,
+    exp: object,
+    sig: object,
+    *,
+    now: Optional[float] = None,
+) -> bool:
+    """Return ``True`` iff ``(exp, sig)`` is a valid signature for *match_id*.
+
+    Both arguments come from raw query-string parsing so they may be
+    ``None`` or arbitrary strings — the function tolerates everything
+    and just returns ``False`` on malformed input.
+    """
+    if not isinstance(sig, str) or not sig:
+        return False
+    if isinstance(exp, str):
+        try:
+            exp_int = int(exp)
+        except ValueError:
+            return False
+    elif isinstance(exp, int):
+        exp_int = exp
+    else:
+        return False
+    base_now = time.time() if now is None else float(now)
+    if exp_int <= int(base_now):
+        return False
+    expected = _digest(match_id, exp_int)
+    if expected is None:
+        return False
+    return hmac.compare_digest(sig, expected)

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -427,6 +427,52 @@
         "title": "MatchPointInfo",
         "type": "object"
       },
+      "MatchSignUrlRequest": {
+        "properties": {
+          "ttl_seconds": {
+            "anyOf": [
+              {
+                "maximum": 2592000.0,
+                "minimum": 60.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "URL lifetime in seconds. Bounded to [60, 2592000]; defaults to 86400.",
+            "title": "Ttl Seconds"
+          }
+        },
+        "title": "MatchSignUrlRequest",
+        "type": "object"
+      },
+      "MatchSignUrlResponse": {
+        "properties": {
+          "expires_at": {
+            "description": "Unix-seconds expiry the URL was signed for.",
+            "title": "Expires At",
+            "type": "integer"
+          },
+          "expires_in": {
+            "description": "Seconds remaining until expiry, at mint time.",
+            "title": "Expires In",
+            "type": "integer"
+          },
+          "url": {
+            "description": "Absolute capability URL \u2014 anyone holding it can read the report until ``expires_at``.",
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "expires_at",
+          "expires_in"
+        ],
+        "title": "MatchSignUrlResponse",
+        "type": "object"
+      },
       "OverlayControlModel": {
         "additionalProperties": true,
         "properties": {
@@ -1519,6 +1565,68 @@
           }
         },
         "summary": "Admin Login",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/v1/admin/match/{match_id}/sign-url": {
+      "post": {
+        "description": "Return a capability URL the operator can paste into chat tools.\n\nThe legacy share flow (``/match/{id}/report?token=<password>``)\nembeds the actual ``OVERLAY_MANAGER_PASSWORD`` in the URL \u2014\nevery browser bookmark, server log, or HTTP ``Referer`` that\ntouches the link leaks the credential. This endpoint replaces\nthat flow with an HMAC-signed URL of the form\n``/match/{id}/report?exp=<ts>&sig=<hex>``: the password stays\non the server and the URL expires automatically.\n\nRotating the admin password invalidates every outstanding\nsigned URL \u2014 that's the desired behaviour, since rotations are\ntypically motivated by suspected leaks.\n\nThe endpoint deliberately does *not* check whether the\n``match_id`` exists: a 404 here would be a free oracle for\nenumerating archived matches by anyone holding the admin\npassword (who could already do far worse anyway). Signing a\nbogus match id just produces a URL that 404s on use.",
+        "operationId": "sign_match_report_url_api_v1_admin_match__match_id__sign_url_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "match_id",
+            "required": true,
+            "schema": {
+              "title": "Match Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MatchSignUrlRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MatchSignUrlResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mint a short-lived signed URL for a match report",
         "tags": [
           "Admin"
         ]
@@ -3820,6 +3928,42 @@
               ],
               "description": "OVERLAY_MANAGER_PASSWORD; alternative to Bearer header.",
               "title": "Token"
+            }
+          },
+          {
+            "description": "Signed-URL expiry (unix seconds).",
+            "in": "query",
+            "name": "exp",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Signed-URL expiry (unix seconds).",
+              "title": "Exp"
+            }
+          },
+          {
+            "description": "Signed-URL HMAC-SHA256 hex digest.",
+            "in": "query",
+            "name": "sig",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Signed-URL HMAC-SHA256 hex digest.",
+              "title": "Sig"
             }
           },
           {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -179,6 +179,44 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/match/{match_id}/sign-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Mint a short-lived signed URL for a match report
+         * @description Return a capability URL the operator can paste into chat tools.
+         *
+         *     The legacy share flow (``/match/{id}/report?token=<password>``)
+         *     embeds the actual ``OVERLAY_MANAGER_PASSWORD`` in the URL —
+         *     every browser bookmark, server log, or HTTP ``Referer`` that
+         *     touches the link leaks the credential. This endpoint replaces
+         *     that flow with an HMAC-signed URL of the form
+         *     ``/match/{id}/report?exp=<ts>&sig=<hex>``: the password stays
+         *     on the server and the URL expires automatically.
+         *
+         *     Rotating the admin password invalidates every outstanding
+         *     signed URL — that's the desired behaviour, since rotations are
+         *     typically motivated by suspected leaks.
+         *
+         *     The endpoint deliberately does *not* check whether the
+         *     ``match_id`` exists: a 404 here would be a free oracle for
+         *     enumerating archived matches by anyone holding the admin
+         *     password (who could already do far worse anyway). Signing a
+         *     bogus match id just produces a URL that 404s on use.
+         */
+        post: operations["sign_match_report_url_api_v1_admin_match__match_id__sign_url_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/status": {
         parameters: {
             query?: never;
@@ -1081,6 +1119,32 @@ export interface components {
             /** Team 2 Set Point */
             team_2_set_point: boolean;
         };
+        /** MatchSignUrlRequest */
+        MatchSignUrlRequest: {
+            /**
+             * Ttl Seconds
+             * @description URL lifetime in seconds. Bounded to [60, 2592000]; defaults to 86400.
+             */
+            ttl_seconds?: number | null;
+        };
+        /** MatchSignUrlResponse */
+        MatchSignUrlResponse: {
+            /**
+             * Expires At
+             * @description Unix-seconds expiry the URL was signed for.
+             */
+            expires_at: number;
+            /**
+             * Expires In
+             * @description Seconds remaining until expiry, at mint time.
+             */
+            expires_in: number;
+            /**
+             * Url
+             * @description Absolute capability URL — anyone holding it can read the report until ``expires_at``.
+             */
+            url: string;
+        };
         /** OverlayControlModel */
         OverlayControlModel: {
             /** Colors */
@@ -1625,6 +1689,43 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sign_match_report_url_api_v1_admin_match__match_id__sign_url_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string;
+            };
+            path: {
+                match_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MatchSignUrlRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MatchSignUrlResponse"];
                 };
             };
             /** @description Validation Error */
@@ -2881,6 +2982,10 @@ export interface operations {
             query?: {
                 /** @description OVERLAY_MANAGER_PASSWORD; alternative to Bearer header. */
                 token?: string | null;
+                /** @description Signed-URL expiry (unix seconds). */
+                exp?: string | null;
+                /** @description Signed-URL HMAC-SHA256 hex digest. */
+                sig?: string | null;
             };
             header?: {
                 authorization?: string | null;

--- a/tests/test_signed_urls_and_ws_subprotocol.py
+++ b/tests/test_signed_urls_and_ws_subprotocol.py
@@ -1,0 +1,411 @@
+"""Coverage for the H-4 query-string-secret hardening.
+
+Two surfaces are pinned:
+
+* :mod:`app.match_report_signing` — HMAC-signed match-report URLs
+  and the corresponding admin endpoint
+  ``POST /api/v1/admin/match/{match_id}/sign-url``. The admin
+  password no longer needs to be on the URL line.
+* :mod:`app.api.routes.websocket` — the ``/api/v1/ws`` route now
+  prefers the Bearer subprotocol (``Sec-WebSocket-Protocol:
+  bearer, <token>``) over the legacy ``?token=`` query param,
+  echoing the chosen subprotocol back to the client during
+  ``ws.accept`` so browser clients don't drop the connection.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app import match_report_signing
+from app.admin import admin_router
+from app.api.middleware import auth_rate_limit
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch):
+    monkeypatch.delenv("OVERLAY_MANAGER_PASSWORD", raising=False)
+    monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
+    auth_rate_limit._reset_for_tests()
+    yield
+    auth_rate_limit._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# match_report_signing module
+# ---------------------------------------------------------------------------
+
+
+def test_signing_returns_none_when_admin_password_unset():
+    assert match_report_signing.make_signed_query("m") is None
+
+
+def test_signing_returns_none_for_verify_when_admin_password_unset():
+    assert (
+        match_report_signing.verify_signed_query("m", "100", "deadbeef")
+        is False
+    )
+
+
+def test_signed_query_round_trips(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "k")
+    out = match_report_signing.make_signed_query("match-1", ttl_seconds=600)
+    assert out is not None
+    assert out["expires_at"] == out["exp"]
+    assert match_report_signing.verify_signed_query(
+        "match-1", out["exp"], out["sig"],
+    )
+
+
+def test_verify_rejects_expired(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "k")
+    out = match_report_signing.make_signed_query(
+        "match-1", ttl_seconds=match_report_signing.MIN_TTL_SECONDS,
+    )
+    assert out is not None
+    # Pretend we're far in the future.
+    future = out["exp"] + 1
+    assert (
+        match_report_signing.verify_signed_query(
+            "match-1", out["exp"], out["sig"], now=future,
+        )
+        is False
+    )
+
+
+def test_verify_rejects_tampered_match_id(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "k")
+    out = match_report_signing.make_signed_query("match-1", ttl_seconds=600)
+    assert out is not None
+    # Same exp + sig, different match_id → must fail.
+    assert (
+        match_report_signing.verify_signed_query(
+            "match-2", out["exp"], out["sig"],
+        )
+        is False
+    )
+
+
+def test_verify_rejects_tampered_sig(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "k")
+    out = match_report_signing.make_signed_query("match-1", ttl_seconds=600)
+    assert out is not None
+    bad_sig = "0" * len(out["sig"])
+    assert (
+        match_report_signing.verify_signed_query(
+            "match-1", out["exp"], bad_sig,
+        )
+        is False
+    )
+
+
+def test_verify_handles_malformed_inputs(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "k")
+    # Non-numeric exp.
+    assert (
+        match_report_signing.verify_signed_query("m", "not-a-number", "x")
+        is False
+    )
+    # Empty sig.
+    assert match_report_signing.verify_signed_query("m", 100, "") is False
+    # None sig.
+    assert match_report_signing.verify_signed_query("m", 100, None) is False
+    # None exp.
+    assert match_report_signing.verify_signed_query("m", None, "x") is False
+
+
+def test_password_rotation_invalidates_old_signatures(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "old")
+    out = match_report_signing.make_signed_query("match-1", ttl_seconds=600)
+    assert out is not None
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "new")
+    assert (
+        match_report_signing.verify_signed_query(
+            "match-1", out["exp"], out["sig"],
+        )
+        is False
+    )
+
+
+def test_clamp_ttl_bounds():
+    assert (
+        match_report_signing.clamp_ttl(-1)
+        == match_report_signing.DEFAULT_TTL_SECONDS
+    )
+    assert (
+        match_report_signing.clamp_ttl(0)
+        == match_report_signing.DEFAULT_TTL_SECONDS
+    )
+    # Below floor → snapped up to MIN.
+    assert (
+        match_report_signing.clamp_ttl(1)
+        == match_report_signing.MIN_TTL_SECONDS
+    )
+    # Above ceiling → snapped down to MAX.
+    assert (
+        match_report_signing.clamp_ttl(10**9)
+        == match_report_signing.MAX_TTL_SECONDS
+    )
+    # ``None`` and garbage fall back to the default.
+    assert (
+        match_report_signing.clamp_ttl(None)
+        == match_report_signing.DEFAULT_TTL_SECONDS
+    )
+    assert (
+        match_report_signing.clamp_ttl("not-a-number")
+        == match_report_signing.DEFAULT_TTL_SECONDS
+    )
+
+
+# ---------------------------------------------------------------------------
+# Admin sign-url endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def admin_client(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "admin-pw")
+    app = FastAPI()
+    app.include_router(admin_router)
+    return TestClient(app)
+
+
+def _admin_headers(pw: str = "admin-pw"):
+    return {"Authorization": f"Bearer {pw}"}
+
+
+def test_sign_url_requires_admin(admin_client):
+    res = admin_client.post(
+        "/api/v1/admin/match/m1/sign-url", json={},
+    )
+    assert res.status_code == 401
+
+
+def test_sign_url_returns_capability_url(admin_client):
+    res = admin_client.post(
+        "/api/v1/admin/match/match-abc/sign-url",
+        json={},
+        headers=_admin_headers(),
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["url"].endswith(
+        f"?exp={body['expires_at']}&sig=" + body["url"].rsplit("sig=", 1)[1],
+    )
+    # Crucial: the admin password must NOT appear in the URL.
+    assert "admin-pw" not in body["url"]
+    # And the URL is for the right match.
+    assert "/match/match-abc/report" in body["url"]
+
+
+def test_sign_url_respects_ttl(admin_client):
+    res = admin_client.post(
+        "/api/v1/admin/match/m1/sign-url",
+        json={"ttl_seconds": 60},
+        headers=_admin_headers(),
+    )
+    assert res.status_code == 200
+    body = res.json()
+    # Expires_in is bounded — we just minted it, should be near 60.
+    assert 50 <= body["expires_in"] <= 60
+
+
+def test_sign_url_rejects_out_of_range_ttl(admin_client):
+    # Above MAX_TTL_SECONDS → 422 from Pydantic Field bound.
+    res = admin_client.post(
+        "/api/v1/admin/match/m1/sign-url",
+        json={"ttl_seconds": 10**9},
+        headers=_admin_headers(),
+    )
+    assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /match/{match_id}/report — signed URL access path
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def gated_match(monkeypatch):
+    """Seed an archive entry that needs auth to read.
+
+    Returns ``(client, match_id)``.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from app.api import action_log, match_archive
+    from app.match_report import match_report_router
+
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "admin-pw")
+    monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
+
+    action_log.append(
+        "sig-oid", "add_point", {"team": 1, "undo": False},
+        {"team_1": {"score": 1}},
+    )
+    match_id = match_archive.archive_match(
+        oid="sig-oid",
+        final_state={
+            "current_set": 1,
+            "team_1": {"sets": 1, "timeouts": 0, "scores": {"set_1": 25}},
+            "team_2": {"sets": 0, "timeouts": 0, "scores": {"set_1": 20}},
+        },
+        customization={"Team 1 Name": "Home", "Team 2 Name": "Away"},
+        started_at=time.time() - 100,
+        winning_team=1,
+        points_limit=25,
+        points_limit_last_set=15,
+        sets_limit=3,
+    )
+    app = FastAPI()
+    app.include_router(match_report_router)
+    return TestClient(app), match_id
+
+
+def test_signed_url_grants_access_without_password(gated_match):
+    client, match_id = gated_match
+    out = match_report_signing.make_signed_query(match_id, ttl_seconds=600)
+    assert out is not None
+
+    res = client.get(
+        f"/match/{match_id}/report",
+        params={"exp": out["exp"], "sig": out["sig"]},
+    )
+    assert res.status_code == 200
+    assert "Home" in res.text
+
+
+def test_expired_signed_url_falls_back_to_password(gated_match):
+    client, match_id = gated_match
+    out = match_report_signing.make_signed_query(
+        match_id, ttl_seconds=match_report_signing.MIN_TTL_SECONDS,
+    )
+    assert out is not None
+    # Manually rewrite exp to the past.
+    res = client.get(
+        f"/match/{match_id}/report",
+        params={"exp": int(time.time()) - 60, "sig": out["sig"]},
+    )
+    # Falls through to the require-admin-token branch — without a
+    # Bearer header that's a 401.
+    assert res.status_code == 401
+
+
+def test_tampered_signature_is_rejected(gated_match):
+    client, match_id = gated_match
+    out = match_report_signing.make_signed_query(match_id, ttl_seconds=600)
+    assert out is not None
+    res = client.get(
+        f"/match/{match_id}/report",
+        params={"exp": out["exp"], "sig": "0" * len(out["sig"])},
+    )
+    assert res.status_code in (401, 403)
+
+
+def test_signed_url_for_other_match_does_not_grant_access(gated_match):
+    client, match_id = gated_match
+    other = match_report_signing.make_signed_query("other-match", 600)
+    assert other is not None
+    res = client.get(
+        f"/match/{match_id}/report",
+        params={"exp": other["exp"], "sig": other["sig"]},
+    )
+    # The signature is for ``other-match``, not this match_id; the
+    # signed-URL path must reject it and the request falls through to
+    # the password-required branch (no Bearer header → 401/403).
+    assert res.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket Bearer subprotocol auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ws_client(monkeypatch):
+    """SCOREBOARD_USERS-protected app with a single user."""
+    from fastapi import FastAPI
+
+    from app.api import api_router
+    from app.api.session_manager import SessionManager
+    from app.api.ws_hub import WSHub
+
+    SessionManager.clear()
+    WSHub.clear()
+    users = json.dumps({"alice": {"password": "alice-pw"}})
+    monkeypatch.setenv("SCOREBOARD_USERS", users)
+    app = FastAPI()
+    app.include_router(api_router)
+    client = TestClient(app)
+
+    # Initialise a session so the WS endpoint reaches the auth check
+    # before the SessionManager.get None branch.
+    res = client.post(
+        "/api/v1/session/init",
+        json={"oid": "test_overlay"},
+        headers={"Authorization": "Bearer alice-pw"},
+    )
+    assert res.status_code == 200, res.text
+
+    yield client
+    SessionManager.clear()
+    WSHub.clear()
+
+
+def test_ws_accepts_bearer_subprotocol(ws_client):
+    # TestClient.websocket_connect supports the ``subprotocols`` arg
+    # which becomes the ``Sec-WebSocket-Protocol`` header.
+    with ws_client.websocket_connect(
+        "/api/v1/ws?oid=test_overlay",
+        subprotocols=["bearer", "alice-pw"],
+    ) as ws:
+        # Server must echo back the chosen subprotocol so the browser
+        # accepts the connection.
+        assert ws.accepted_subprotocol == "bearer"
+        # Initial state_update should be delivered immediately.
+        msg = ws.receive_json()
+        assert msg["type"] == "state_update"
+
+
+def test_ws_rejects_invalid_bearer_subprotocol(ws_client):
+    from starlette.websockets import WebSocketDisconnect
+
+    with pytest.raises(WebSocketDisconnect):
+        with ws_client.websocket_connect(
+            "/api/v1/ws?oid=test_overlay",
+            subprotocols=["bearer", "wrong-password"],
+        ):
+            pass
+
+
+def test_ws_legacy_query_token_still_works(ws_client):
+    """Legacy ?token= path is preserved so older CLI clients keep working."""
+    with ws_client.websocket_connect(
+        "/api/v1/ws?oid=test_overlay&token=alice-pw",
+    ) as ws:
+        # No subprotocol negotiated — ``accepted_subprotocol`` is None.
+        assert ws.accepted_subprotocol is None
+        msg = ws.receive_json()
+        assert msg["type"] == "state_update"
+
+
+def test_ws_subprotocol_takes_precedence_over_query(ws_client):
+    """When both auth modes are present, the subprotocol wins.
+
+    Pinning this avoids a regression where a future refactor reorders
+    the resolution and silently downgrades a Bearer-subprotocol
+    client to query-token semantics (e.g. logging the legacy path).
+    """
+    with ws_client.websocket_connect(
+        "/api/v1/ws?oid=test_overlay&token=wrong-password",
+        subprotocols=["bearer", "alice-pw"],
+    ) as ws:
+        assert ws.accepted_subprotocol == "bearer"
+        msg = ws.receive_json()
+        assert msg["type"] == "state_update"


### PR DESCRIPTION
## Summary

PR 3 of the security plan (PRs 1+2 = #258, #259, both merged). Closes the H‑4 finding by taking credentials off the URL line on the two surfaces where they leaked: the match-report share flow and `/api/v1/ws` browser auth.

## What changes

### Match report — capability URLs replace `?token=<password>`

- New module `app/match_report_signing.py` — HMAC-SHA256 signer/verifier keyed off `OVERLAY_MANAGER_PASSWORD`. Format: `?exp=<unix>&sig=<hex>`. TTL clamped to `[60 s, 30 days]`, default `86 400 s`.
- New admin endpoint `POST /api/v1/admin/match/{match_id}/sign-url` (`require_admin`). Body: `{ttl_seconds?: int}`. Response: `{url, expires_at, expires_in}`. The URL embeds the signature, never the admin password.
- `_check_access` consults the signature first (capability mode), then falls through to the legacy `Authorization` / `?token=` paths. Public mode (`MATCH_REPORT_PUBLIC=true`) still wins ahead of everything.
- `?token=<password>` continues to work but is now documented as deprecated. Rotating `OVERLAY_MANAGER_PASSWORD` invalidates every outstanding signed URL — that's the desired behaviour after a suspected leak.

### `/api/v1/ws` — Bearer-subprotocol auth

- New helper `_resolve_ws_auth` in `app/api/routes/websocket.py`. Resolution order: `Sec-WebSocket-Protocol: bearer, <token>` → `Authorization: Bearer <token>` → `?token=…` (legacy).
- `WSHub.connect` grew an optional `subprotocol` kwarg so the negotiated value is echoed during `ws.accept()` (RFC 6455 §4.1) — without that browser clients drop the connection.
- Browser clients open with `new WebSocket(url, ['bearer', token])`; tokens never appear in URL access logs.

### Docs

- `AUTHENTICATION.md` §2 route inventory now lists the new admin endpoint and the new WS auth modes; new §7 documents both credential-transport patterns end-to-end.
- `README.md` reflects the new auth options on `/match/{id}/report`.
- `CHANGELOG.md` `[Unreleased] / Security` records both changes.
- `frontend/schema/openapi.json` + `frontend/src/api/schema.d.ts` regenerated for the new endpoint and query params.

## Test plan

- [x] `pytest tests/` — **763 passing** (was 742 + 21 new in `tests/test_signed_urls_and_ws_subprotocol.py`).
- [x] `ruff check app/ tests/` — clean.
- [x] `cd frontend && npm test` — **325/325**.
- [x] New cases cover: signing/verify round-trip, expired-rejection, tampered match-id rejection, tampered-sig rejection, malformed-input handling, password-rotation invalidation, TTL clamping; admin endpoint requires Bearer, returns capability URL with no password leak, respects TTL, rejects out-of-range TTL via Pydantic; report endpoint accepts signed URL without password, rejects expired/tampered/wrong-match signatures (falls through to 401/403); WS accepts Bearer subprotocol and echoes it back, rejects invalid subprotocol token, legacy `?token=` still works, subprotocol takes precedence when both present.
- [ ] Manual smoke: mint a signed URL via curl, paste into a browser, confirm report renders without supplying the admin password; confirm the URL expires.

## Out of scope (still queued for later PRs)

- H‑5 hashed credential storage at rest.
- M‑4 `TrustedHostMiddleware`, M‑5 CORS scaffolding.
- L‑4 CI security scanners (Bandit, pip‑audit, npm audit), `SECURITY.md`.

https://claude.ai/code/session_01BPyiEJ4eyUz9NHZy6zbRhy

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPyiEJ4eyUz9NHZy6zbRhy)_