### PR TITLE
sec: hygiene — TrustedHost, CORS scaffolding, CI scanners, SECURITY.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,69 @@ jobs:
         name: frontend-coverage
         path: frontend/coverage/lcov.info
         if-no-files-found: ignore
+
+  security-scan:
+    # Surfaces dependency CVEs and risky-pattern findings on every PR.
+    # The scanners are configured to FAIL on issues in the codebase /
+    # the pinned lockfiles so a regression is caught before merge.
+    # ``continue-on-error`` is intentionally NOT set: an operator
+    # adding a vulnerable pin should see a red check and have to either
+    # bump the dep or document the suppression in pyproject.toml /
+    # ``# nosec`` comments.
+    name: Security scanners (bandit, pip-audit, npm audit)
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.11"
+        cache: 'pip'
+
+    - name: Install scanners
+      run: |
+        python -m pip install --upgrade pip
+        # Pin Bandit and pip-audit to known-good majors so the scan
+        # output is stable across CI runs. Bumping them is a
+        # deliberate operator decision that should land in its own
+        # PR with the diff of new findings reviewed.
+        pip install "bandit[toml]==1.7.*" "pip-audit==2.*"
+
+    - name: Bandit static analysis
+      # ``-r`` walks the package; ``-q`` suppresses progress output.
+      # ``--severity-level medium`` filters out the LOW noise Bandit
+      # emits for things like ``random`` usage in non-security paths;
+      # we still want HIGH/MEDIUM findings to fail the job.
+      # The repo already uses targeted ``# nosec`` comments where a
+      # pattern is intentional (see app/auth_utils.py, app/match_report.py).
+      run: |
+        bandit -r app/ -q --severity-level medium
+
+    - name: pip-audit (runtime lockfile)
+      # Runs against the runtime lockfile so a CVE in a transitive
+      # dep surfaces here. The dev lockfile is scanned in the next
+      # step to catch issues in tooling without conflating the two.
+      run: |
+        pip-audit -r requirements.lock --strict
+
+    - name: pip-audit (dev lockfile)
+      run: |
+        pip-audit -r requirements-dev.lock --strict
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: "20"
+        cache: "npm"
+        cache-dependency-path: frontend/package-lock.json
+
+    - name: npm audit (runtime + transitive)
+      working-directory: frontend
+      # ``--omit=dev`` skips the toolchain (Vite, Vitest, etc.) so a
+      # known-low CVE in a build-only dep doesn't block production
+      # changes. ``--audit-level=high`` matches the Bandit threshold:
+      # we want HIGH+ findings to fail, not every advisory.
+      run: |
+        npm audit --omit=dev --audit-level=high

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -282,7 +282,50 @@ State is process-local. Multi-replica deployments should still front
 the app with a layer-7 limiter (Cloudflare, Nginx, etc.) — this
 middleware is the single-replica self-hosted backstop.
 
-### 6.2 `SecurityHeadersMiddleware` — HTTP response hardening
+### 6.2 `TrustedHostMiddleware` — Host-header poisoning defence (opt-in)
+
+Wired in `app/bootstrap.py:_maybe_register_trusted_hosts`. When
+`TRUSTED_HOSTS` is unset the middleware is not installed (default,
+backwards compatible). When set to a comma-separated list of
+hostnames, Starlette's `TrustedHostMiddleware` rejects requests
+whose `Host` header doesn't match any entry with HTTP 400 before
+any handler reads `request.base_url` (used by `/links`,
+`/api/config/{id}`, the signed-URL minter, etc.). Wildcard
+subdomains are honoured (`*.example.com` matches any subdomain).
+
+| Env var | Default | Meaning |
+| :--- | :--- | :--- |
+| `TRUSTED_HOSTS` | unset | Comma-separated allow-list. Whitespace around entries is stripped. |
+
+Operators behind a reverse proxy must also configure uvicorn with
+`--proxy-headers` so the ASGI scope reflects the real `Host`. The
+overlay routes (`/overlay/{id}`) remain reachable from any host
+because the `Host` check happens before the route is dispatched —
+see `_maybe_register_trusted_hosts` if you need to relax that for
+OBS browser sources on a different domain.
+
+### 6.3 `CORSMiddleware` — cross-origin SPA scaffolding (opt-in)
+
+Wired in `app/bootstrap.py:_maybe_register_cors`. When
+`CORS_ALLOWED_ORIGINS` is unset the middleware is not installed
+(default, backwards compatible — the bundled SPA is served by
+FastAPI itself, no cross-origin requests). When set to a
+comma-separated list of origins, browser preflight responses get
+explicit allow-list semantics:
+
+* `Access-Control-Allow-Origin` is echoed only for listed origins.
+* `Access-Control-Allow-Credentials: true` so the React UI can
+  forward `Authorization` headers.
+* `Access-Control-Allow-Headers` includes `Authorization`,
+  `Content-Type`, `X-Request-ID`, and `Sec-WebSocket-Protocol`
+  — the headers the existing auth flows and the WS subprotocol
+  handshake actually use.
+
+| Env var | Default | Meaning |
+| :--- | :--- | :--- |
+| `CORS_ALLOWED_ORIGINS` | unset | Comma-separated allow-list of origins. `*` is **rejected** to prevent a copy-paste footgun on a credentialed API; an `ERROR` is logged and CORS stays disabled. |
+
+### 6.4 `SecurityHeadersMiddleware` — HTTP response hardening
 
 Located in `app/api/middleware/security_headers.py`. Adds:
 

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -298,11 +298,13 @@ subdomains are honoured (`*.example.com` matches any subdomain).
 | `TRUSTED_HOSTS` | unset | Comma-separated allow-list. Whitespace around entries is stripped. |
 
 Operators behind a reverse proxy must also configure uvicorn with
-`--proxy-headers` so the ASGI scope reflects the real `Host`. The
-overlay routes (`/overlay/{id}`) remain reachable from any host
-because the `Host` check happens before the route is dispatched —
-see `_maybe_register_trusted_hosts` if you need to relax that for
-OBS browser sources on a different domain.
+`--proxy-headers` so the ASGI scope reflects the real `Host`.
+Enforcement is global — the overlay routes (`/overlay/{id}`,
+`/ws/{id}`) are subject to the same allow-list because the `Host`
+check fires before route dispatch. If OBS browser sources on a
+different domain need to load an overlay, add that domain (or a
+wildcard parent) to `TRUSTED_HOSTS`; do not try to special-case the
+overlay router downstream of the middleware.
 
 ### 6.3 `CORSMiddleware` — cross-origin SPA scaffolding (opt-in)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ once a first tagged release ships.
 
 ### Security
 
+- **`TrustedHostMiddleware` (opt-in).** Set ``TRUSTED_HOSTS`` to a
+  comma-separated list of public hostnames the deployment serves
+  from; requests carrying a ``Host`` header outside the allow-list
+  are rejected with HTTP 400 before any handler reads
+  ``request.base_url``. Wildcard subdomains are honoured. Default:
+  unset → no enforcement (backwards compatible).
+- **CORS scaffolding (opt-in).** Set ``CORS_ALLOWED_ORIGINS`` to a
+  comma-separated list of origins permitted to call the API
+  cross-origin. ``*`` is deliberately rejected on this credentialed
+  API; explicit origins only. ``Authorization``,
+  ``Content-Type``, ``X-Request-ID``, and
+  ``Sec-WebSocket-Protocol`` are forwarded so the existing auth
+  flows and the new Bearer-subprotocol WebSocket handshake all keep
+  working. Default: unset → same-origin only (backwards compatible).
+- **CI security scanners.** New ``security-scan`` job in
+  ``.github/workflows/ci.yml`` runs Bandit (MEDIUM+ severity) over
+  ``app/``, ``pip-audit --strict`` against both
+  ``requirements.lock`` and ``requirements-dev.lock``, and
+  ``npm audit --omit=dev --audit-level=high`` against the frontend.
+  Findings fail the job; suppression requires either a documented
+  ``# nosec`` comment or an explicit advisory ignore.
+- **`SECURITY.md`** — formal vulnerability-disclosure policy.
+  Points reporters at GitHub's private vulnerability reporting,
+  documents in-scope/out-of-scope surfaces, and links to the
+  hardening reference (``AUTHENTICATION.md``).
+
 - **Hashed credentials at rest.** New module ``app/password_hash.py``
   uses ``hashlib.scrypt`` (no new dependency) to mint salted hash
   records of the form ``scrypt$n=16384,r=8,p=1$<salt>$<hash>``. Three

--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ Configure the application using the following environment variables:
 | `OVERLAY_SERVER_TOKEN_HASH` | scrypt-hashed alternative to `OVERLAY_SERVER_TOKEN`. When set, the bootstrap skips auto-generating the persisted plaintext file — a hash-only deployment keeps zero cleartext on this server (the peer keeps the cleartext). | |
 | `OVERLAY_SERVER_TOKEN_DISABLED` | If `true`, opts back into legacy unauthenticated overlay-server endpoints. The bootstrap logs a `CRITICAL` startup warning when active. Only safe on a trusted LAN. | `false` |
 | `SCOREBOARD_USERS_DISABLED` | If `true`, silences the startup warning emitted when `SCOREBOARD_USERS` is unset. The API still allows unauthenticated requests; this flag only acknowledges the choice. | `false` |
+| `TRUSTED_HOSTS` | Comma-separated allow-list of hostnames the app accepts in the `Host` header. Wildcard subdomains (`*.example.com`) supported. Requests outside the list are rejected with HTTP 400 before any handler reads `request.base_url`. See [AUTHENTICATION.md](AUTHENTICATION.md) §6.2. | *(unset → no enforcement)* |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated allow-list of origins permitted to call the API cross-origin. `*` is rejected (credentialed API; explicit origins only). Default: same-origin only. See [AUTHENTICATION.md](AUTHENTICATION.md) §6.3. | *(unset → no CORS)* |
 | `APP_THEMES` | JSON with a list of customization themes. | |
 | `REMOTE_CONFIG_URL` | URL to a remote JSON file with the configuration. | |
 | `SINGLE_OVERLAY_MODE` | If `true`, restricts the app to a single active overlay at a time. | `true` |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,94 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes target the latest tagged release on `main` and the
+`dev` branch. Earlier releases are not patched — operators running an
+older build are expected to upgrade to receive fixes.
+
+## Reporting a vulnerability
+
+If you believe you have found a security issue in
+`volley-overlay-control`, please **do not** open a public GitHub issue
+or pull request describing the vulnerability. Instead:
+
+1. Use GitHub's [private vulnerability reporting](https://github.com/JacoboSanchez/volley-overlay-control/security/advisories/new)
+   to file a confidential advisory.
+2. Or, if the GitHub flow is not available to you, open a **public**
+   GitHub issue with the single sentence "I have a security issue to
+   report; please send me a contact channel" — a maintainer will
+   reach out off-band.
+
+When you report, please include:
+
+- The version (commit SHA or release tag) you're running.
+- Steps to reproduce, including any required configuration.
+- The impact you observed and what you think the worst-case impact
+  could be.
+- Optional: a suggested mitigation or patch.
+
+We aim to acknowledge reports within five business days and to ship a
+fix or coordinated disclosure within 90 days. Reports that turn out to
+be configuration questions or low-impact hardening suggestions are
+welcome too — we'll just route them to a regular issue / PR with your
+permission.
+
+## Scope
+
+In-scope:
+
+- The FastAPI backend (`app/`).
+- The React control UI (`frontend/`).
+- The bundled overlay templates (`overlay_templates/`,
+  `overlay_static/`).
+- The Docker image and `docker-compose.yml`.
+- Any documented integration surface (REST, WebSocket, webhooks).
+
+Out of scope:
+
+- Vulnerabilities that require an attacker who already has shell
+  access to the host (the application runs as a non-root user inside
+  the container; container-escape findings should go to the upstream
+  base images: `python:3.13-slim`, `node:25-alpine`).
+- Issues that depend on a misconfiguration explicitly called out as
+  insecure in [`AUTHENTICATION.md`](AUTHENTICATION.md) — e.g.
+  `OVERLAY_SERVER_TOKEN_DISABLED=true` on a public deployment, or
+  `MATCH_REPORT_PUBLIC=true` with a guessable `match_id` (the IDs are
+  hash-prefixed and intentionally hard to guess, but the model is
+  capability-URL).
+- Vulnerabilities in third-party services this app integrates with
+  (overlays.uno, OBS itself, the operator's reverse proxy).
+
+## Hardening reference
+
+The auth ladder, the credential-transport patterns, the
+defence-in-depth middlewares, and the hash-at-rest options are
+documented in [`AUTHENTICATION.md`](AUTHENTICATION.md). New operators
+should at least:
+
+1. Set `SCOREBOARD_USERS` (with `password_hash` per user) so the API
+   is not open to the network.
+2. Set `OVERLAY_MANAGER_PASSWORD_HASH` so `/manage` and the admin
+   endpoints are gated.
+3. Set `OVERLAY_SERVER_TOKEN` (or let the bootstrap auto-generate it)
+   so overlay-server mutation endpoints reject anonymous writes.
+4. Configure `TRUSTED_HOSTS` to the public hostname(s) the app serves
+   from when running behind a reverse proxy.
+5. If serving the React UI from a different origin, set
+   `CORS_ALLOWED_ORIGINS` explicitly — wildcards are rejected.
+
+## CI scanning
+
+Every PR runs three security scanners as part of the CI matrix
+(`.github/workflows/ci.yml`, job `security-scan`):
+
+- **Bandit** — static analysis of `app/` at MEDIUM+ severity.
+- **pip-audit** — CVE scan of both `requirements.lock` and
+  `requirements-dev.lock`.
+- **npm audit** — CVE scan of `frontend/` runtime dependencies at
+  HIGH+ severity (dev tooling is omitted to keep the signal-to-noise
+  ratio high).
+
+A PR cannot merge with red scanners; suppressing a finding requires
+either a documented `# nosec` comment with a rationale, or an
+explicit advisory ignore in the corresponding tool's config.

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -16,7 +16,9 @@ from functools import lru_cache
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
+from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -370,6 +372,72 @@ def _register_spa(application: FastAPI) -> None:
     )
 
 
+def _split_csv_env(name: str) -> list[str]:
+    """Parse a comma-separated env var into a stripped, non-empty list."""
+    raw = os.environ.get(name, "")
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _maybe_register_trusted_hosts(application: FastAPI) -> None:
+    """Wire ``TrustedHostMiddleware`` when ``TRUSTED_HOSTS`` is configured.
+
+    Without this middleware, ``request.base_url`` and any link composed
+    from ``Host`` (``/links``, ``/api/config/{id}``) can be poisoned by
+    a caller setting an arbitrary ``Host`` header. Operators behind a
+    reverse proxy should set ``TRUSTED_HOSTS`` to the comma-separated
+    list of hostnames they actually serve from. Wildcards are honoured
+    by Starlette (``*.example.com`` matches any subdomain).
+
+    Default: unset → no host enforcement, backwards compatible.
+    """
+    hosts = _split_csv_env("TRUSTED_HOSTS")
+    if not hosts:
+        return
+    application.add_middleware(TrustedHostMiddleware, allowed_hosts=hosts)
+    logger.info(
+        "TrustedHostMiddleware enabled (allowed_hosts=%s)",
+        ",".join(hosts),
+    )
+
+
+def _maybe_register_cors(application: FastAPI) -> None:
+    """Wire ``CORSMiddleware`` when ``CORS_ALLOWED_ORIGINS`` is configured.
+
+    Default: unset → no CORS, same-origin only (backwards compatible —
+    the bundled SPA is served by FastAPI itself, no cross-origin
+    requests). Operators running the React UI from a separate origin
+    (a CDN, a dev server, a custom domain) populate the env var with
+    a comma-separated allow-list. ``*`` is **not** accepted to prevent
+    a copy-paste footgun on credentialed APIs; explicit hosts only.
+    """
+    origins = _split_csv_env("CORS_ALLOWED_ORIGINS")
+    if not origins:
+        return
+    if any(o == "*" for o in origins):
+        logger.error(
+            "CORS_ALLOWED_ORIGINS=* is not accepted on a credentialed "
+            "API — refusing to enable CORS. Use explicit origins."
+        )
+        return
+    application.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
+        # Authorization is the credential the browser must be allowed
+        # to forward; the rest of the list mirrors the headers the
+        # control UI sends so preflight does not strip them.
+        allow_headers=[
+            "Authorization", "Content-Type", "X-Request-ID",
+            "Sec-WebSocket-Protocol",
+        ],
+    )
+    logger.info(
+        "CORSMiddleware enabled (origins=%s)",
+        ",".join(origins),
+    )
+
+
 def create_app() -> FastAPI:
     """Build and return the FastAPI application.
 
@@ -391,14 +459,21 @@ def create_app() -> FastAPI:
     _register_spa(application)
     # Middleware ordering — Starlette wraps in reverse registration order, so
     # the LAST add_middleware ends up outermost. We want:
-    #   AuthRateLimit  (outermost — reject brute-force IPs before any work)
-    #     SecurityHeaders  (annotates every outgoing response)
-    #       GZip           (compresses after headers are decided)
-    #         RequestContext (populates contextvars for logging)
-    #           ExceptionLogging (innermost — sees raw handler exceptions)
+    #   TrustedHost     (outermost — reject Host-header attacks before
+    #                    anything else inspects request.base_url)
+    #     CORS          (browser preflight short-circuits before auth)
+    #       AuthRateLimit  (reject brute-force IPs before any work)
+    #         SecurityHeaders  (annotates every outgoing response)
+    #           GZip           (compresses after headers are decided)
+    #             RequestContext (populates contextvars for logging)
+    #               ExceptionLogging (innermost — sees raw handler exceptions)
     application.add_middleware(ExceptionLoggingMiddleware)
     application.add_middleware(RequestContextMiddleware)
     application.add_middleware(GZipMiddleware, minimum_size=1024)
     application.add_middleware(SecurityHeadersMiddleware)
     application.add_middleware(AuthRateLimitMiddleware)
+    # CORS and TrustedHost are opt-in; the helpers no-op when the env
+    # vars are unset so existing deployments are unaffected.
+    _maybe_register_cors(application)
+    _maybe_register_trusted_hosts(application)
     return application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - OVERLAY_SERVER_TOKEN_HASH=${OVERLAY_SERVER_TOKEN_HASH:-} #Optional: scrypt-hashed alternative
       - OVERLAY_SERVER_TOKEN_DISABLED=${OVERLAY_SERVER_TOKEN_DISABLED:-} #Optional: opt out of overlay-server auth
       - SCOREBOARD_USERS_DISABLED=${SCOREBOARD_USERS_DISABLED:-} #Optional: silence the open-API startup warning
+      - TRUSTED_HOSTS=${TRUSTED_HOSTS:-} #Optional: comma-separated allow-list of Host header values (wildcards OK)
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-} #Optional: comma-separated allow-list of cross-origin SPA hosts (no wildcards)
       - MATCH_REPORT_PUBLIC=${MATCH_REPORT_PUBLIC:-false} #Optional: open match-report routes to anonymous reads
       - SCOREBOARD_USERS=${SCOREBOARD_USERS:-}
       - REST_USER_AGENT=${REST_USER_AGENT:-}

--- a/tests/test_trusted_hosts_and_cors.py
+++ b/tests/test_trusted_hosts_and_cors.py
@@ -1,0 +1,201 @@
+"""Coverage for the opt-in middlewares wired in PR 5 of the security plan.
+
+Both ``TrustedHostMiddleware`` and ``CORSMiddleware`` are off by
+default — operators that are happy with the bundled same-origin
+deployment see no behavior change. When they're configured via env
+vars, the helpers in :mod:`app.bootstrap` install them with a few
+defensive defaults (no wildcard CORS on a credentialed API, etc.)
+that are pinned here.
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib import reload
+from typing import Iterable
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _build_app(monkeypatch, *, trusted_hosts: Iterable[str] | None = None,
+               cors_origins: Iterable[str] | None = None) -> FastAPI:
+    """Re-create a FastAPI app with the given env-var configuration.
+
+    ``app.bootstrap._maybe_register_*`` reads from ``os.environ`` at
+    call time, so the test sets the env var, calls ``create_app``,
+    and gets a fresh wiring per case. Other env vars are deliberately
+    left to ``conftest`` defaults to keep the harness minimal.
+    """
+    monkeypatch.delenv("TRUSTED_HOSTS", raising=False)
+    monkeypatch.delenv("CORS_ALLOWED_ORIGINS", raising=False)
+    if trusted_hosts is not None:
+        monkeypatch.setenv("TRUSTED_HOSTS", ",".join(trusted_hosts))
+    if cors_origins is not None:
+        monkeypatch.setenv("CORS_ALLOWED_ORIGINS", ",".join(cors_origins))
+
+    # Reload bootstrap so any cached env-var reads are dropped — the
+    # helper functions read ``os.environ`` directly so this is mainly
+    # cosmetic, but it documents the intent.
+    from app import bootstrap as bootstrap_module
+    reload(bootstrap_module)
+    return bootstrap_module.create_app()
+
+
+# ---------------------------------------------------------------------------
+# TrustedHostMiddleware
+# ---------------------------------------------------------------------------
+
+
+def test_trusted_hosts_unset_does_not_enforce(monkeypatch):
+    app = _build_app(monkeypatch)
+    client = TestClient(app)
+    # Any Host header passes when the middleware isn't installed.
+    res = client.get("/health", headers={"Host": "evil.example.com"})
+    assert res.status_code == 200
+
+
+def test_trusted_hosts_rejects_unlisted_host(monkeypatch):
+    app = _build_app(monkeypatch, trusted_hosts=["scoreboard.example.com"])
+    client = TestClient(app)
+    res = client.get(
+        "/health",
+        headers={"Host": "evil.example.com"},
+    )
+    # Starlette returns 400 with body "Invalid host header".
+    assert res.status_code == 400
+    assert "host" in res.text.lower()
+
+
+def test_trusted_hosts_accepts_listed_host(monkeypatch):
+    app = _build_app(monkeypatch, trusted_hosts=["scoreboard.example.com"])
+    client = TestClient(app)
+    res = client.get(
+        "/health",
+        headers={"Host": "scoreboard.example.com"},
+    )
+    assert res.status_code == 200
+
+
+def test_trusted_hosts_supports_wildcard_subdomain(monkeypatch):
+    """Starlette's wildcard pattern is the cheapest way to allow many
+    subdomains; pin the syntax so a future swap doesn't silently
+    weaken host matching.
+    """
+    app = _build_app(monkeypatch, trusted_hosts=["*.example.com"])
+    client = TestClient(app)
+    ok = client.get("/health", headers={"Host": "a.example.com"})
+    assert ok.status_code == 200
+    rejected = client.get("/health", headers={"Host": "example.org"})
+    assert rejected.status_code == 400
+
+
+def test_trusted_hosts_csv_with_whitespace_is_split(monkeypatch):
+    app = _build_app(
+        monkeypatch,
+        trusted_hosts=["a.example.com", " b.example.com "],
+    )
+    client = TestClient(app)
+    assert client.get("/health", headers={"Host": "a.example.com"}).status_code == 200
+    # Whitespace must be stripped — ``b.example.com `` (trailing space)
+    # would never have matched a real Host header.
+    assert client.get("/health", headers={"Host": "b.example.com"}).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# CORSMiddleware
+# ---------------------------------------------------------------------------
+
+
+def test_cors_unset_does_not_install_middleware(monkeypatch):
+    app = _build_app(monkeypatch)
+    client = TestClient(app)
+    res = client.get(
+        "/health",
+        headers={"Origin": "https://control.example.com"},
+    )
+    assert res.status_code == 200
+    # Without CORS the response carries no ``Access-Control-Allow-Origin``.
+    assert "access-control-allow-origin" not in res.headers
+
+
+def test_cors_explicit_origin_is_echoed(monkeypatch):
+    app = _build_app(
+        monkeypatch, cors_origins=["https://control.example.com"],
+    )
+    client = TestClient(app)
+    res = client.get(
+        "/health",
+        headers={"Origin": "https://control.example.com"},
+    )
+    assert res.status_code == 200
+    assert (
+        res.headers.get("access-control-allow-origin")
+        == "https://control.example.com"
+    )
+
+
+def test_cors_unlisted_origin_does_not_get_header(monkeypatch):
+    app = _build_app(
+        monkeypatch, cors_origins=["https://control.example.com"],
+    )
+    client = TestClient(app)
+    res = client.get(
+        "/health",
+        headers={"Origin": "https://evil.example.com"},
+    )
+    assert res.status_code == 200
+    # Unlisted origin: no CORS header echoed → browser blocks the
+    # response client-side.
+    assert "access-control-allow-origin" not in res.headers
+
+
+def test_cors_wildcard_is_rejected(monkeypatch, caplog):
+    """A bare ``*`` must be refused — it would defeat the
+    credentialed-API stance (Authorization header forwarding requires
+    an explicit allow-list)."""
+    with caplog.at_level(logging.ERROR, logger="app.bootstrap"):
+        app = _build_app(monkeypatch, cors_origins=["*"])
+    client = TestClient(app)
+    res = client.get(
+        "/health", headers={"Origin": "https://anything.example.com"},
+    )
+    # No CORS header — middleware was never installed.
+    assert res.status_code == 200
+    assert "access-control-allow-origin" not in res.headers
+    assert any("CORS_ALLOWED_ORIGINS=*" in rec.message for rec in caplog.records)
+
+
+def test_cors_preflight_passes_through(monkeypatch):
+    """Preflight requests must short-circuit without consulting auth."""
+    app = _build_app(
+        monkeypatch, cors_origins=["https://control.example.com"],
+    )
+    client = TestClient(app)
+    res = client.options(
+        "/api/v1/state",
+        headers={
+            "Origin": "https://control.example.com",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "Authorization",
+        },
+    )
+    # 200 from the CORS middleware — the route's auth dependency is
+    # never consulted on preflight.
+    assert res.status_code == 200
+    assert res.headers["access-control-allow-origin"] == "https://control.example.com"
+    assert "authorization" in res.headers.get(
+        "access-control-allow-headers", "",
+    ).lower()
+
+
+@pytest.fixture(autouse=True)
+def _restore_bootstrap():
+    """Reload bootstrap once at teardown so other test modules see a
+    clean module state (the fixture above reloads it per call but we
+    don't want a half-mutated module surviving the test class).
+    """
+    yield
+    from app import bootstrap as bootstrap_module
+    reload(bootstrap_module)


### PR DESCRIPTION
## Summary

Final PR of the security plan (PRs 1‑4 = #258, #259, #260, #261, all merged). Closes the remaining M‑4, M‑5, and L‑4 hygiene items. Every change is opt-in or additive — existing deployments see no behaviour change.

## What changes

### `TrustedHostMiddleware` — Host-header poisoning defence (M‑4, opt-in)

- Wired in `app/bootstrap.py:_maybe_register_trusted_hosts`.
- `TRUSTED_HOSTS` (comma-separated) lists the allowed `Host` header values.
- Requests outside the list → HTTP 400 before any handler reads `request.base_url` (used by `/links`, `/api/config/{id}`, the signed-URL minter from PR #260).
- Wildcard subdomains supported (`*.example.com`).
- Default: unset → no enforcement (backwards compatible).

### CORS scaffolding (M‑5, opt-in)

- Wired in `app/bootstrap.py:_maybe_register_cors`.
- `CORS_ALLOWED_ORIGINS` (comma-separated) lists explicit origins; **`*` is deliberately rejected** on this credentialed API and an `ERROR` is logged. Forces operators to enumerate origins.
- Forwards `Authorization`, `Content-Type`, `X-Request-ID`, and `Sec-WebSocket-Protocol` so existing auth flows and the WS Bearer-subprotocol handshake (PR #260) keep working.
- Default: unset → same-origin only (backwards compatible — bundled SPA is served by FastAPI itself).

### CI security scanners (L‑4)

New `security-scan` job in `.github/workflows/ci.yml`:
- **Bandit** at MEDIUM+ severity over `app/`.
- **pip-audit --strict** against both `requirements.lock` and `requirements-dev.lock`.
- **npm audit --omit=dev --audit-level=high** against the frontend.

Findings fail the job. All three scanners are clean as of this commit (verified locally).

### `SECURITY.md`

Formal disclosure policy pointing reporters at GitHub's private vulnerability reporting. Documents in-/out-of-scope surfaces, the supported-versions matrix, and links to the hardening reference (`AUTHENTICATION.md`).

### Middleware stack ordering

Documented inline in `bootstrap.create_app`:
```
TrustedHost (outermost — reject Host attacks before anything else)
  CORS         (browser preflight short-circuits before auth)
    AuthRateLimit
      SecurityHeaders
        GZip
          RequestContext
            ExceptionLogging (innermost)
```

## Test plan

- [x] `pytest tests/` — **819 passing** (was 809 + 10 new in `tests/test_trusted_hosts_and_cors.py`).
- [x] `ruff check app/ tests/` — clean.
- [x] `bandit -r app/ -q --severity-level medium` — clean.
- [x] `pip-audit --strict -r requirements.lock` — no known vulnerabilities.
- [x] `pip-audit --strict -r requirements-dev.lock` — no known vulnerabilities.
- [x] `cd frontend && npm audit --omit=dev --audit-level=high` — 0 vulnerabilities.
- [x] New tests cover: `TRUSTED_HOSTS` unset → no enforcement, listed/unlisted Host rejection, wildcard subdomain matching, CSV-with-whitespace splitting; `CORS_ALLOWED_ORIGINS` unset → no middleware, explicit origin echoed, unlisted origin gets no header, `*` rejected with logged `ERROR`, preflight passes through with the right headers.

## Operator action

| Setting | Recommended value |
|---|---|
| `TRUSTED_HOSTS` | Your public hostname(s) — e.g. `scoreboard.example.com` or `*.example.com` |
| `CORS_ALLOWED_ORIGINS` | Empty unless serving the SPA from a different origin; then explicit origins only |

## Plan complete

This wraps the five-PR security plan. All twelve original findings (H‑1 … H‑5, M‑1 … M‑5, L‑3, L‑4) have shipped. The remaining L‑1, L‑2, L‑5, L‑6, L‑7 items in the original analysis are nice-to-have polish that didn't justify a dedicated PR.

https://claude.ai/code/session_01BPyiEJ4eyUz9NHZy6zbRhy

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPyiEJ4eyUz9NHZy6zbRhy)_