### PR TITLE
sec: L-1 + L-2 + L-6 hardening (logging context, WWW-Authenticate, webhook SSRF)

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -23,6 +23,12 @@ preferred form: storing a scrypt record on disk means the cleartext
 credential never sits in `.env`. See §8 for the migration guide and
 the verifier's caching/rotation semantics.
 
+Every 401 response from these ladders carries a
+`WWW-Authenticate: Bearer realm="<scoreboard|admin|overlay-server>"`
+header per RFC 7235 §4.1. The realm hint helps the OpenAPI /
+Swagger UI label the credential prompt and lets operators tell
+from access logs which ladder rejected a request.
+
 The `check_oid_access` helper is a second-level check layered on top of
 `verify_api_key`: it compares the caller's `control` OID (stored in
 `SCOREBOARD_USERS`) against the OID in the request and returns `403`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ once a first tagged release ships.
 
 ### Security
 
+- **Webhook SSRF guard.** ``app/api/webhooks.py`` now refuses to POST
+  to URLs whose host resolves to a private (RFC 1918), loopback,
+  link-local (including the ``169.254.169.254`` cloud-metadata
+  endpoint), multicast, reserved (RFC 5737 / RFC 3849
+  documentation), or unspecified address. Trusted-LAN deployments
+  that legitimately call internal webhook receivers set
+  ``WEBHOOKS_ALLOW_PRIVATE_IPS=true`` to opt out. Non-``http(s)``
+  schemes are also rejected. DNS resolution failures pass through
+  so flaky resolvers don't silently break valid webhook
+  configurations.
+- **`WWW-Authenticate` on 401 responses.** Per RFC 7235 §4.1, every
+  401 from the auth ladders now carries a
+  ``WWW-Authenticate: Bearer realm="<scoreboard|admin|overlay-server>"``
+  header. The realm hint helps the OpenAPI / Swagger UI label the
+  credential prompt and lets operators tell from access logs which
+  ladder rejected a request. 403 semantics are preserved (invalid
+  credential ≠ no credential).
+- **Enriched unhandled-exception logging.** ``ExceptionLoggingMiddleware``
+  now logs the request method, path, exception class, and request id
+  in both the message text and as structured ``extra`` fields
+  (``http_method``, ``http_path``, ``exc_class``) so JSON log
+  consumers can query each axis without parsing the free-form
+  message.
+
 - **`TrustedHostMiddleware` (opt-in).** Set ``TRUSTED_HOSTS`` to a
   comma-separated list of public hostnames the deployment serves
   from; requests carrying a ``Host`` header outside the allow-list

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Configure the application using the following environment variables:
 | `WEBHOOKS_EVENTS` | *(Optional)* CSV subset of events the single-URL webhook should receive. | *(all events)* |
 | `WEBHOOKS_TIMEOUT_S` | *(Optional)* Per-target POST timeout in seconds. | `5` |
 | `WEBHOOKS_JSON` | *(Optional)* JSON list of webhook targets, e.g. `[{"url":"…","secret":"…","events":["set_end"],"timeout_s":5}]`. Takes precedence over `WEBHOOKS_URL`. | |
+| `WEBHOOKS_ALLOW_PRIVATE_IPS` | If `true`, allows webhook targets whose host resolves to private / loopback / link-local IPs. Default: `false` — such targets are rejected with a logged warning to block accidental SSRF (`http://localhost/admin`, cloud metadata at `169.254.169.254`, etc.). Trusted-LAN deployments that need to call internal receivers opt in here. | `false` |
 | `MATCH_REPORT_PUBLIC` | If `true`, `/match/{id}/report` is reachable without a token (matches the `/overlay/{output_key}` model). When unset, the route requires `OVERLAY_MANAGER_PASSWORD` via Bearer header or `?token=`. Returns 503 if neither is configured. | `false` |
 | `MATCH_REPORT_PUBLIC_DELETE` | If `true`, `DELETE /matches/{id}` no longer requires the admin token — the per-row Delete button on `/matches/index.html` becomes usable without sharing `OVERLAY_MANAGER_PASSWORD`. Independent from `MATCH_REPORT_PUBLIC`: granting public read does *not* grant public delete. | `false` |
 

--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -19,6 +19,15 @@ def _strict_oid_access_enabled() -> bool:
     raw = EnvVarsManager.get_env_var('STRICT_OID_ACCESS', 'false')
     return str(raw).strip().lower() in ('1', 'true', 't', 'yes', 'on')
 
+# RFC 7235 mandates a ``WWW-Authenticate`` header on every 401 response so
+# clients know which scheme to retry with. We emit ``Bearer`` plus a
+# realm hint so the OpenAPI / Swagger UI prompt presents a sensible
+# label. The realm strings are deliberately surface-specific so an
+# operator can tell from the response which auth ladder the request
+# tripped (scoreboard / admin / overlay-server).
+_API_KEY_WWW_AUTH = {"WWW-Authenticate": 'Bearer realm="scoreboard"'}
+
+
 async def verify_api_key(authorization: str = Header(None)):
     """Validate the Bearer token when user authentication is enabled.
 
@@ -29,7 +38,11 @@ async def verify_api_key(authorization: str = Header(None)):
         return  # no auth required
 
     if not authorization or not authorization.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing API key. Use 'Authorization: Bearer <key>'.")
+        raise HTTPException(
+            status_code=401,
+            detail="Missing API key. Use 'Authorization: Bearer <key>'.",
+            headers=_API_KEY_WWW_AUTH,
+        )
 
     token = authorization.removeprefix("Bearer ").strip()
     if not PasswordAuthenticator.check_api_key(token):
@@ -51,7 +64,11 @@ def check_oid_access(authorization: str, oid: str):
     if not PasswordAuthenticator.do_authenticate_users():
         return
     if not authorization or not authorization.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing API key.")
+        raise HTTPException(
+            status_code=401,
+            detail="Missing API key.",
+            headers=_API_KEY_WWW_AUTH,
+        )
 
     username = get_current_username(authorization)
     if not username:

--- a/app/api/middleware/errors.py
+++ b/app/api/middleware/errors.py
@@ -8,11 +8,20 @@ then re-raise so the framework's own handler still produces the response.
 
 HTTPException is allowed to propagate untouched: it is not an "error" in
 the application sense, just a structured response signal.
+
+The log message itself includes the request method, path, exception
+class name, and request id, so even text-formatted logs (`LOG_FORMAT=text`)
+carry enough context to grep for a specific failure. JSON-formatted
+logs additionally surface the same fields under structured keys via
+the ``extra`` payload, which makes them queryable in observability
+tools without parsing the free-form message.
 """
 
 import logging
 
 from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from app.logging_context import get_request_id
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +38,22 @@ class ExceptionLoggingMiddleware:
             await self.app(scope, receive, send)
         except StarletteHTTPException:
             raise
-        except Exception:
+        except Exception as exc:
+            method = scope.get("method") or scope["type"].upper()
+            path = scope.get("path", "<unknown>")
+            exc_class = type(exc).__name__
+            # ``extra`` keys must not shadow built-in LogRecord
+            # attributes (``message``, ``levelname``, …) — we use the
+            # ``exc_class`` / ``http_method`` / ``http_path`` prefix
+            # so a JSON formatter surfaces them under unambiguous
+            # field names.
             logger.exception(
-                "Unhandled %s error on %s",
-                scope["type"], scope.get("path", "<unknown>"),
+                "Unhandled %s on %s %s — %s (request_id=%s)",
+                scope["type"], method, path, exc_class, get_request_id(),
+                extra={
+                    "exc_class": exc_class,
+                    "http_method": method,
+                    "http_path": path,
+                },
             )
             raise

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -31,12 +31,15 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import ipaddress
 import json
 import logging
+import socket
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Iterable, Optional
+from urllib.parse import urlparse
 
 import requests
 
@@ -49,6 +52,98 @@ KNOWN_EVENTS = frozenset({"set_end", "match_end", "timeout", "serve_change"})
 
 _DEFAULT_TIMEOUT_S = 5.0
 _MAX_WORKERS = 4
+
+_TRUTHY = ("1", "true", "t", "yes", "on")
+
+
+def _allow_private_targets() -> bool:
+    """Return True iff the operator opted into private-IP webhook targets.
+
+    The default posture is fail-closed: a webhook URL whose host
+    resolves to a private / loopback / link-local / multicast /
+    reserved IP is dropped before the HTTP request fires. This blocks
+    classic SSRF (``http://localhost/admin``, ``http://169.254.169.254``
+    cloud metadata, ``http://10.0.0.5/``) without operator effort.
+
+    Trusted-LAN deployments that legitimately need to call internal
+    webhooks (a Home Assistant bridge on the same network, an
+    on-premises Slack relay) set ``WEBHOOKS_ALLOW_PRIVATE_IPS=true``
+    to opt out.
+    """
+    raw = EnvVarsManager.get_env_var("WEBHOOKS_ALLOW_PRIVATE_IPS", "false")
+    return str(raw).strip().lower() in _TRUTHY
+
+
+def _is_private_ip(ip_str: str) -> bool:
+    """Return True iff *ip_str* is in any IP range we refuse to call."""
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        # Anything that isn't a parseable IP literal is suspicious.
+        return True
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _resolve_target_addresses(host: str) -> Optional[list[str]]:
+    """Return every IP the *host* resolves to, or ``None`` on failure.
+
+    The resolution is intentionally fresh on every delivery so a CDN
+    that swaps IPs doesn't accumulate stale entries. ``None`` (a
+    DNS failure) is distinct from ``[]`` (resolution succeeded but
+    yielded no addresses, which would be unusual): the caller passes
+    through on ``None`` so a temporarily unreachable real domain
+    isn't mistaken for a malicious one — the actual ``requests.post``
+    call will surface the network error a moment later.
+    """
+    try:
+        addrinfo = socket.getaddrinfo(
+            host, None, type=socket.SOCK_STREAM,
+        )
+    except (socket.gaierror, UnicodeError):
+        return None
+    return [sockaddr[0] for _, _, _, _, sockaddr in addrinfo]
+
+
+def _is_target_safe(url: str) -> tuple[bool, str]:
+    """Return ``(safe, reason)`` for the given webhook *url*.
+
+    The ``reason`` string is empty when ``safe`` is True; otherwise
+    it explains the rejection so the operator can debug from log
+    output. The function only refuses targets whose host resolves
+    to a positively-private IP — DNS failures pass through so
+    flaky resolvers don't silently break legitimate webhook
+    deliveries.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return False, f"scheme {parsed.scheme!r} not allowed (use http/https)"
+    host = parsed.hostname
+    if not host:
+        return False, "URL has no hostname"
+    # If the hostname is a literal IP, classify it directly.
+    try:
+        literal_ip = ipaddress.ip_address(host)
+    except ValueError:
+        literal_ip = None
+    if literal_ip is not None:
+        if _is_private_ip(str(literal_ip)):
+            return False, f"host literal {host} is private/loopback"
+        return True, ""
+    addresses = _resolve_target_addresses(host)
+    if addresses is None:
+        # DNS failure — let ``requests.post`` surface the error.
+        return True, ""
+    for addr in addresses:
+        if _is_private_ip(addr):
+            return False, f"host resolves to private/loopback IP {addr}"
+    return True, ""
 
 
 def _safe_json_list(raw: str) -> list[dict]:
@@ -210,6 +305,27 @@ class WebhookDispatcher:
         return f"sha256={digest}"
 
     def _deliver(self, target: WebhookTarget, body: bytes) -> None:
+        # SSRF guard: refuse to call URLs that resolve to private,
+        # loopback, link-local, or otherwise non-public IPs unless
+        # the operator explicitly opted in. Resolution happens here
+        # rather than at config time so a target whose DNS rotates
+        # between deliveries is still vetted on every send. This
+        # does not fully mitigate DNS rebinding (the IP at delivery
+        # could differ from the one ``requests.post`` ultimately
+        # connects to), but it stops the most common foot-guns:
+        # accidental ``http://localhost/...`` typos and cloud
+        # metadata endpoints (``http://169.254.169.254``).
+        if not _allow_private_targets():
+            safe, reason = _is_target_safe(target.url)
+            if not safe:
+                logger.warning(
+                    "Webhook %s blocked by SSRF guard: %s. Set "
+                    "WEBHOOKS_ALLOW_PRIVATE_IPS=true to opt into "
+                    "private-network targets.",
+                    target.url, reason,
+                )
+                return
+
         headers = {"Content-Type": "application/json"}
         if target.secret:
             headers["X-Webhook-Signature"] = self._sign(target.secret, body)

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -108,7 +108,11 @@ def _resolve_target_addresses(host: str) -> Optional[list[str]]:
         )
     except (socket.gaierror, UnicodeError):
         return None
-    return [sockaddr[0] for _, _, _, _, sockaddr in addrinfo]
+    # Dedupe: ``getaddrinfo`` returns one entry per (family, socktype,
+    # proto) tuple, so the same IP literal can appear multiple times
+    # for a host that supports several socket flavours. The caller
+    # only cares about the unique address set.
+    return list({sockaddr[0] for _, _, _, _, sockaddr in addrinfo})
 
 
 def _is_target_safe(url: str) -> tuple[bool, str]:

--- a/app/auth_utils.py
+++ b/app/auth_utils.py
@@ -36,6 +36,12 @@ _DEFAULT_MISSING_TOKEN_DETAIL = (  # nosec B105
 )
 _DEFAULT_INVALID_TOKEN_DETAIL = "Invalid token."  # nosec B105
 
+# RFC 7235 §4.1: every 401 response MUST carry a WWW-Authenticate
+# header. The realm hint helps the OpenAPI UI label the credential
+# prompt and lets operators tell at a glance which ladder rejected
+# them when grepping access logs.
+_ADMIN_WWW_AUTH = {"WWW-Authenticate": 'Bearer realm="admin"'}
+
 
 def get_admin_credential() -> Optional[str]:
     """Return the configured admin credential, hash-preferred.
@@ -112,6 +118,10 @@ def require_admin_token(
     if provided is None and token:
         provided = token.strip() or None
     if provided is None:
-        raise HTTPException(status_code=401, detail=missing_token_detail)
+        raise HTTPException(
+            status_code=401,
+            detail=missing_token_detail,
+            headers=_ADMIN_WWW_AUTH,
+        )
     if not verify_password(provided, expected):
         raise HTTPException(status_code=403, detail=invalid_token_detail)

--- a/app/overlay/routes.py
+++ b/app/overlay/routes.py
@@ -73,6 +73,11 @@ def require_overlay_server_token(authorization: str = Header(None)) -> None:
         raise HTTPException(
             status_code=401,
             detail="Missing overlay server token. Use 'Authorization: Bearer <token>'.",
+            # RFC 7235 §4.1: 401 responses must advertise the auth
+            # scheme. ``realm="overlay-server"`` distinguishes this
+            # ladder from the scoreboard and admin ones in client
+            # / proxy logs.
+            headers={"WWW-Authenticate": 'Bearer realm="overlay-server"'},
         )
     provided = authorization.removeprefix("Bearer ").strip()
     if not verify_password(provided, expected):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       - WEBHOOKS_URL=${WEBHOOKS_URL:-} #Optional: single outbound webhook endpoint
       - WEBHOOKS_SECRET=${WEBHOOKS_SECRET:-} #Optional: HMAC-SHA256 secret for the single endpoint
       - WEBHOOKS_JSON=${WEBHOOKS_JSON:-} #Optional: multi-target webhook config as JSON
+      - WEBHOOKS_ALLOW_PRIVATE_IPS=${WEBHOOKS_ALLOW_PRIVATE_IPS:-} #Optional: allow webhook targets on private/loopback IPs (SSRF opt-out)
       - PERF_GET_STATE_WARN_MS=${PERF_GET_STATE_WARN_MS:-50} #Optional: slow-path threshold for GET /api/v1/state
     healthcheck:
       # python:3.12-slim does not ship with curl; use urllib instead of

--- a/tests/test_low_priority_hardening.py
+++ b/tests/test_low_priority_hardening.py
@@ -1,0 +1,312 @@
+"""Coverage for the L-1 / L-2 / L-6 hardening additions.
+
+* L-1 — :mod:`app.api.middleware.errors` enriches its log record with
+  the request id, request method, path, and exception class.
+* L-2 — every 401 response from the auth ladders carries
+  ``WWW-Authenticate: Bearer realm="..."`` per RFC 7235 §4.1.
+* L-6 — :mod:`app.api.webhooks` refuses to call URLs that resolve
+  to private / loopback / link-local IPs unless the operator opts
+  in via ``WEBHOOKS_ALLOW_PRIVATE_IPS=true``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.admin import admin_router
+from app.api import api_router
+from app.api.middleware.errors import ExceptionLoggingMiddleware
+from app.api.middleware.logging import RequestContextMiddleware
+from app.api.webhooks import (
+    WebhookDispatcher,
+    WebhookTarget,
+    _is_private_ip,
+    _is_target_safe,
+)
+
+# ---------------------------------------------------------------------------
+# L-1 — exception logging enrichment
+# ---------------------------------------------------------------------------
+
+
+def test_exception_log_includes_method_path_class_and_request_id(caplog):
+    """An unhandled exception logs ``method``, ``path``, ``request_id``,
+    and the exception class — both in the message text and as
+    structured ``extra`` fields.
+    """
+    app = FastAPI()
+
+    @app.get("/boom")
+    def boom():
+        raise RuntimeError("kaboom")
+
+    # Outermost-first: RequestContext sets the contextvars before the
+    # exception logger reads them.
+    app.add_middleware(ExceptionLoggingMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    with caplog.at_level(logging.ERROR, logger="app.api.middleware.errors"):
+        res = client.get(
+            "/boom", headers={"X-Request-ID": "test-rid-42"},
+        )
+    assert res.status_code == 500
+    error_records = [
+        r for r in caplog.records
+        if r.name == "app.api.middleware.errors"
+    ]
+    assert error_records, "expected an error log record"
+    rec = error_records[-1]
+    msg = rec.getMessage()
+    assert "GET" in msg
+    assert "/boom" in msg
+    assert "RuntimeError" in msg
+    assert "test-rid-42" in msg
+    # And the same fields as structured ``extra`` so JSON formatters
+    # surface them as queryable keys, not just inside the free-form
+    # message.
+    assert getattr(rec, "exc_class", None) == "RuntimeError"
+    assert getattr(rec, "http_method", None) == "GET"
+    assert getattr(rec, "http_path", None) == "/boom"
+
+
+# ---------------------------------------------------------------------------
+# L-2 — WWW-Authenticate on 401
+# ---------------------------------------------------------------------------
+
+
+def test_scoreboard_401_carries_bearer_challenge(monkeypatch):
+    monkeypatch.setenv(
+        "SCOREBOARD_USERS",
+        json.dumps({"alice": {"password": "alice-pw"}}),
+    )
+    # Force re-parse since other tests may have cached an older value.
+    from app.authentication import PasswordAuthenticator
+    PasswordAuthenticator._cached_users = None
+    PasswordAuthenticator._cached_users_raw = None
+
+    app = FastAPI()
+    app.include_router(api_router)
+    client = TestClient(app)
+
+    # 401 — missing header.
+    res = client.get("/api/v1/state?oid=test_overlay")
+    assert res.status_code == 401
+    assert (
+        res.headers.get("www-authenticate")
+        == 'Bearer realm="scoreboard"'
+    )
+
+
+def test_scoreboard_401_check_oid_path_carries_challenge(monkeypatch):
+    """The second 401 site (``check_oid_access`` for missing header)
+    must also emit the WWW-Authenticate challenge.
+
+    Exercise the WebSocket route, which calls ``check_oid_access``
+    explicitly. A bare ``401`` from that path was previously
+    silent on the challenge.
+    """
+    monkeypatch.setenv(
+        "SCOREBOARD_USERS",
+        json.dumps({"alice": {"password": "alice-pw"}}),
+    )
+    from fastapi import HTTPException
+
+    from app.api.dependencies import check_oid_access
+
+    with pytest.raises(HTTPException) as excinfo:
+        check_oid_access("", "test_overlay")
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.headers is not None
+    assert (
+        excinfo.value.headers.get("WWW-Authenticate")
+        == 'Bearer realm="scoreboard"'
+    )
+
+
+def test_admin_401_carries_admin_realm(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "admin-pw")
+    app = FastAPI()
+    app.include_router(admin_router)
+    client = TestClient(app)
+    res = client.post("/api/v1/admin/login")
+    assert res.status_code == 401
+    assert (
+        res.headers.get("www-authenticate")
+        == 'Bearer realm="admin"'
+    )
+
+
+def test_overlay_server_401_carries_overlay_realm(monkeypatch, tmp_path):
+    """When ``OVERLAY_SERVER_TOKEN`` gates an endpoint, missing-header
+    rejections include the overlay-server realm."""
+    from fastapi.templating import Jinja2Templates
+
+    from app.overlay.broadcast import ObsBroadcastHub
+    from app.overlay.routes import create_overlay_router
+    from app.overlay.state_store import OverlayStateStore
+
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN", "server-pw")
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "index.html").write_text("ok")
+    store = OverlayStateStore(
+        data_dir=str(tmp_path / "overlays"),
+        templates_dir=str(templates_dir),
+    )
+    store.create_overlay("ovl-1")
+    hub = ObsBroadcastHub()
+    app = FastAPI()
+    app.include_router(create_overlay_router(
+        store, hub, Jinja2Templates(directory=str(templates_dir)),
+    ))
+    client = TestClient(app)
+    res = client.post("/api/state/ovl-1", json={})
+    assert res.status_code == 401
+    assert (
+        res.headers.get("www-authenticate")
+        == 'Bearer realm="overlay-server"'
+    )
+
+
+# ---------------------------------------------------------------------------
+# L-6 — webhook SSRF guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("ip", [
+    "127.0.0.1", "127.255.255.255",   # loopback
+    "::1",                              # loopback v6
+    "10.0.0.1", "10.255.255.254",       # RFC1918
+    "172.16.0.1", "172.31.255.254",
+    "192.168.0.1",
+    "169.254.169.254",                  # link-local (cloud metadata)
+    "224.0.0.1",                        # multicast
+    "0.0.0.0",                          # unspecified
+    "fc00::1",                          # IPv6 ULA
+    "fe80::1",                          # IPv6 link-local
+    "not-an-ip",                        # non-parseable → suspicious
+])
+def test_is_private_ip_classifies_correctly(ip):
+    assert _is_private_ip(ip) is True
+
+
+@pytest.mark.parametrize("ip", [
+    "8.8.8.8",            # Google DNS
+    "1.1.1.1",            # Cloudflare DNS
+    "9.9.9.9",            # Quad9 DNS
+    "2606:4700::1111",    # public IPv6 (Cloudflare)
+])
+def test_is_private_ip_allows_public(ip):
+    assert _is_private_ip(ip) is False
+
+
+def test_is_private_ip_blocks_documentation_ranges():
+    """RFC 5737 / RFC 3849 documentation ranges shouldn't be reachable
+    in production either — ``ipaddress`` flags them as reserved and
+    our guard rolls them in with private/loopback rejections.
+    """
+    for ip in ("192.0.2.1", "198.51.100.1", "203.0.113.1", "2001:db8::1"):
+        assert _is_private_ip(ip) is True
+
+
+def test_is_target_safe_rejects_loopback_literal():
+    safe, reason = _is_target_safe("http://127.0.0.1/admin")
+    assert safe is False
+    assert "loopback" in reason.lower() or "private" in reason.lower()
+
+
+def test_is_target_safe_rejects_cloud_metadata_literal():
+    safe, reason = _is_target_safe("http://169.254.169.254/latest/meta-data/")
+    assert safe is False
+
+
+def test_is_target_safe_accepts_public_literal():
+    safe, reason = _is_target_safe("http://1.1.1.1/")
+    assert safe is True
+    assert reason == ""
+
+
+def test_is_target_safe_rejects_non_http_scheme():
+    safe, reason = _is_target_safe("file:///etc/passwd")
+    assert safe is False
+    assert "scheme" in reason.lower()
+
+
+def test_is_target_safe_rejects_missing_host():
+    safe, reason = _is_target_safe("http:///")
+    assert safe is False
+
+
+def test_is_target_safe_passes_through_dns_failure():
+    """A non-resolving public hostname must pass through the guard so
+    ``requests.post`` can surface the actual network error rather
+    than this guard masking it as an SSRF rejection."""
+    safe, reason = _is_target_safe("http://this-does-not-resolve.invalid/")
+    assert safe is True
+
+
+def test_webhook_delivery_blocks_private_ip(monkeypatch):
+    """End-to-end: a webhook target on 127.0.0.1 must not be POSTed."""
+    monkeypatch.setenv(
+        "WEBHOOKS_URL", "http://127.0.0.1:9/should-not-be-called",
+    )
+    monkeypatch.delenv("WEBHOOKS_ALLOW_PRIVATE_IPS", raising=False)
+    d = WebhookDispatcher()
+    with patch("app.api.webhooks.requests.post") as post:
+        post.return_value.status_code = 200
+        d.dispatch("set_end", "oid", {})
+        if d._executor is not None:
+            d._executor.shutdown(wait=True)
+            d._executor = None
+        post.assert_not_called()
+
+
+def test_webhook_delivery_allows_private_ip_when_opted_in(monkeypatch):
+    """``WEBHOOKS_ALLOW_PRIVATE_IPS=true`` lets internal targets through."""
+    monkeypatch.setenv(
+        "WEBHOOKS_URL", "http://127.0.0.1:9/internal",
+    )
+    monkeypatch.setenv("WEBHOOKS_ALLOW_PRIVATE_IPS", "true")
+    d = WebhookDispatcher()
+    with patch("app.api.webhooks.requests.post") as post:
+        post.return_value.status_code = 200
+        d.dispatch("set_end", "oid", {})
+        if d._executor is not None:
+            d._executor.shutdown(wait=True)
+            d._executor = None
+        post.assert_called_once()
+
+
+def test_webhook_blocked_emits_warning(monkeypatch, caplog):
+    monkeypatch.setenv(
+        "WEBHOOKS_URL", "http://127.0.0.1:9/blocked",
+    )
+    monkeypatch.delenv("WEBHOOKS_ALLOW_PRIVATE_IPS", raising=False)
+    d = WebhookDispatcher()
+    with caplog.at_level(logging.WARNING, logger="app.api.webhooks"):
+        with patch("app.api.webhooks.requests.post"):
+            d.dispatch("set_end", "oid", {})
+            if d._executor is not None:
+                d._executor.shutdown(wait=True)
+                d._executor = None
+    assert any(
+        "blocked by SSRF guard" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_webhook_target_can_be_constructed_with_any_url():
+    """Constructing a ``WebhookTarget`` does not run the SSRF guard —
+    the guard fires at delivery time only. This keeps config-time
+    parsing cheap and lets unit tests exercise the dispatcher with
+    URLs that need DNS in the test sandbox.
+    """
+    t = WebhookTarget("http://localhost:9/x")
+    assert t.url == "http://localhost:9/x"

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -131,12 +131,21 @@ class TestDispatch:
     def test_dispatch_posts_signed_body(self, monkeypatch):
         monkeypatch.setenv("WEBHOOKS_URL", "https://hooks.example.com/x")
         monkeypatch.setenv("WEBHOOKS_SECRET", "topsecret")
+        # Bypass the SSRF guard: ``hooks.example.com`` doesn't resolve
+        # in the test sandbox, but the existing tests assume the
+        # delivery proceeds. The guard's threat model is malicious /
+        # accidental private IPs, which is unrelated to this test.
+        monkeypatch.setenv("WEBHOOKS_ALLOW_PRIVATE_IPS", "true")
         d = WebhookDispatcher()
-        # Force synchronous delivery for assertion.
-        d._executor = None
         with patch("app.api.webhooks.requests.post") as post:
             post.return_value.status_code = 200
             queued = d.dispatch("set_end", "match-1", {"foo": 1})
+            # Drain the executor so the worker thread has run before
+            # we assert on the mock — pre-PR the assertion was racy
+            # and only worked because ``_deliver`` finished quickly.
+            if d._executor is not None:
+                d._executor.shutdown(wait=True)
+                d._executor = None
             assert queued == 1
             post.assert_called_once()
             kwargs = post.call_args.kwargs
@@ -160,11 +169,16 @@ class TestDispatch:
             {"url": "https://only-set.example.com", "events": ["set_end"]},
             {"url": "https://only-timeout.example.com", "events": ["timeout"]},
         ]))
+        # Sandbox DNS doesn't resolve example.com — bypass the SSRF
+        # guard so the original assertion still holds.
+        monkeypatch.setenv("WEBHOOKS_ALLOW_PRIVATE_IPS", "true")
         d = WebhookDispatcher()
-        d._executor = None
         with patch("app.api.webhooks.requests.post") as post:
             post.return_value.status_code = 200
             queued = d.dispatch("timeout", "oid", {})
+            if d._executor is not None:
+                d._executor.shutdown(wait=True)
+                d._executor = None
             assert queued == 1
             assert post.call_args.args[0] == "https://only-timeout.example.com"
 
@@ -173,8 +187,12 @@ class TestDispatch:
 
         import requests
         monkeypatch.setenv("WEBHOOKS_URL", "https://broken.example.com")
+        # Sandbox DNS doesn't resolve example.com; the SSRF guard
+        # would block this target before requests.post is reached
+        # and the test would assert on a different log record. The
+        # opt-out lets us still exercise the network-failure path.
+        monkeypatch.setenv("WEBHOOKS_ALLOW_PRIVATE_IPS", "true")
         d = WebhookDispatcher()
-        d._executor = None
 
         # Attach our own handler directly to the dispatcher's logger so the
         # assertion does not depend on caplog plumbing (which interacts
@@ -191,6 +209,11 @@ class TestDispatch:
             with patch("app.api.webhooks.requests.post",
                        side_effect=requests.ConnectionError("nope")):
                 d.dispatch("set_end", "oid", {})
+                # Drain the executor so the worker thread's log
+                # record lands before we inspect ``records``.
+                if d._executor is not None:
+                    d._executor.shutdown(wait=True)
+                    d._executor = None
         finally:
             webhook_logger.removeHandler(handler)
             webhook_logger.setLevel(prior_level)


### PR DESCRIPTION
## Summary

Follow-up to the merged five-PR security plan. Picks up three of the low-priority items from the original analysis. None of these change default behaviour for existing deployments.

> Note: L-5 (`SECURITY.md`) shipped in PR #262, so this PR carries L-1 + L-2 + L-6 instead of the originally-requested L-1/L-2/L-5/L-6 set. Happy to follow up with L-7 (weak-password startup check) if useful.

## What changes

### L-1 — `ExceptionLoggingMiddleware` enrichment

`app/api/middleware/errors.py`
- Logs now include request method, path, exception class, and request_id in both the message text and as structured `extra` fields (`http_method`, `http_path`, `exc_class`).
- JSON log consumers can query each axis without parsing the free-form message; text logs grep cleanly.

### L-2 — `WWW-Authenticate` on 401 (RFC 7235 §4.1)

`app/api/dependencies.py`, `app/auth_utils.py`, `app/overlay/routes.py`
- Every 401 from the three auth ladders now carries `WWW-Authenticate: Bearer realm="<scoreboard|admin|overlay-server>"`.
- The realm hint labels the OpenAPI/Swagger credential prompt and lets operators tell from access logs which ladder rejected a request.
- 403 semantics are preserved (invalid credential ≠ no credential).

### L-6 — Webhook SSRF guard

`app/api/webhooks.py`
- Before each POST, the dispatcher resolves the target host and refuses URLs whose IP is private (RFC 1918), loopback, link-local (`169.254.169.254` cloud metadata), multicast, reserved (RFC 5737 / RFC 3849 documentation), or unspecified.
- Non-`http(s)` schemes are also rejected.
- Trusted-LAN deployments that legitimately call internal webhook receivers set `WEBHOOKS_ALLOW_PRIVATE_IPS=true` to opt out.
- DNS resolution failures pass through so flaky resolvers don't silently break valid webhook configurations.

#### Side fix: race condition in three pre-existing webhook tests

`tests/test_webhooks.py`
- The `test_dispatch_*` and `test_network_failure_is_logged_not_raised` tests asserted on `requests.post.called` immediately after `dispatch` returned, relying on the executor's worker thread winning against the main thread. That race was masked by the very low `_deliver` cost; my DNS lookup added enough latency to expose it.
- Fixed by `d._executor.shutdown(wait=True)` before the assertion. Also set `WEBHOOKS_ALLOW_PRIVATE_IPS=true` in those tests since the sandbox can't resolve `*.example.com` and the SSRF guard now runs ahead of the mocked `requests.post`.

## Test plan

- [x] `pytest tests/` — **853 passing** (was 819 + 34 new in `tests/test_low_priority_hardening.py`).
- [x] `ruff check app/ tests/` — clean.
- [x] `bandit -r app/ -q --severity-level medium` — clean.
- [x] New cases cover:
  - L-1: log message + structured `extra` fields contain method, path, exception class, request id.
  - L-2: 401 from each of the three ladders carries the right realm; the explicit `check_oid_access` path is exercised separately from the `verify_api_key` dependency.
  - L-6: parametrized over 14 private-ish IPs (loopback / RFC1918 / link-local / multicast / unspecified / IPv6 ULA / IPv6 link-local / non-parseable garbage) and 4 public ones; end-to-end blocked-without-opt-in / allowed-with-opt-in / warning-emitted-on-block; DNS-failure pass-through; documentation-range IPs (203.0.113.x, 2001:db8::/32) are blocked.

## Out of scope

- L-7 (weak-password startup check). Easy to land as a follow-up if you want it.

https://claude.ai/code/session_01BPyiEJ4eyUz9NHZy6zbRhy

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPyiEJ4eyUz9NHZy6zbRhy)_