### PR TITLE
sec: roll up six-PR security hardening release (dev → main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,69 @@ jobs:
         name: frontend-coverage
         path: frontend/coverage/lcov.info
         if-no-files-found: ignore
+
+  security-scan:
+    # Surfaces dependency CVEs and risky-pattern findings on every PR.
+    # The scanners are configured to FAIL on issues in the codebase /
+    # the pinned lockfiles so a regression is caught before merge.
+    # ``continue-on-error`` is intentionally NOT set: an operator
+    # adding a vulnerable pin should see a red check and have to either
+    # bump the dep or document the suppression in pyproject.toml /
+    # ``# nosec`` comments.
+    name: Security scanners (bandit, pip-audit, npm audit)
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.11"
+        cache: 'pip'
+
+    - name: Install scanners
+      run: |
+        python -m pip install --upgrade pip
+        # Pin Bandit and pip-audit to known-good majors so the scan
+        # output is stable across CI runs. Bumping them is a
+        # deliberate operator decision that should land in its own
+        # PR with the diff of new findings reviewed.
+        pip install "bandit[toml]==1.7.*" "pip-audit==2.*"
+
+    - name: Bandit static analysis
+      # ``-r`` walks the package; ``-q`` suppresses progress output.
+      # ``--severity-level medium`` filters out the LOW noise Bandit
+      # emits for things like ``random`` usage in non-security paths;
+      # we still want HIGH/MEDIUM findings to fail the job.
+      # The repo already uses targeted ``# nosec`` comments where a
+      # pattern is intentional (see app/auth_utils.py, app/match_report.py).
+      run: |
+        bandit -r app/ -q --severity-level medium
+
+    - name: pip-audit (runtime lockfile)
+      # Runs against the runtime lockfile so a CVE in a transitive
+      # dep surfaces here. The dev lockfile is scanned in the next
+      # step to catch issues in tooling without conflating the two.
+      run: |
+        pip-audit -r requirements.lock --strict
+
+    - name: pip-audit (dev lockfile)
+      run: |
+        pip-audit -r requirements-dev.lock --strict
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: "20"
+        cache: "npm"
+        cache-dependency-path: frontend/package-lock.json
+
+    - name: npm audit (runtime + transitive)
+      working-directory: frontend
+      # ``--omit=dev`` skips the toolchain (Vite, Vitest, etc.) so a
+      # known-low CVE in a build-only dep doesn't block production
+      # changes. ``--audit-level=high`` matches the Bandit threshold:
+      # we want HIGH+ findings to fail, not every advisory.
+      run: |
+        npm audit --omit=dev --audit-level=high

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ volley-overlay-control/
 │   └── public/                # Static assets (icons, fonts)
 │
 ├── app/                       # Backend source code
+│   ├── bootstrap.py           # FastAPI factory — wires routers, middleware stack, SPA mount
 │   ├── state.py               # Data model — match state dictionary
 │   ├── game_manager.py        # Business logic — volleyball rules & score mutations
 │   ├── backend.py             # Coordinator — delegates to overlay backend strategies
@@ -55,7 +56,11 @@ volley-overlay-control/
 │   ├── ws_client.py           # Persistent WebSocket client for external overlay servers (optional)
 │   ├── customization.py       # Team names, colors, logos, layout geometry
 │   ├── conf.py                # Configuration object — wraps env vars
-│   ├── authentication.py      # PasswordAuthenticator (API-key validation)
+│   ├── authentication.py      # PasswordAuthenticator (API-key validation; verify cache for hashed creds)
+│   ├── auth_utils.py          # Shared admin-token verifier (Bearer + ?token=, hash or plaintext)
+│   ├── password_hash.py       # scrypt-based credential hashing (CLI: `python -m app.password_hash`)
+│   ├── security_bootstrap.py  # Startup credential resolution (auto-mints OVERLAY_SERVER_TOKEN, warns on open SCOREBOARD_USERS)
+│   ├── match_report_signing.py # HMAC-signed capability URLs for /match/{id}/report
 │   ├── app_storage.py         # In-memory key-value storage
 │   ├── oid_utils.py           # OID parsing utilities (extract_oid, compose_output)
 │   ├── env_vars_manager.py    # Centralized env var access with remote config caching
@@ -65,7 +70,8 @@ volley-overlay-control/
 │   │
 │   ├── api/                   # REST API + WebSocket layer for frontends
 │   │   ├── __init__.py        # Exports api_router
-│   │   ├── routes.py          # FastAPI endpoints under /api/v1/
+│   │   ├── routes/            # Domain-split FastAPI endpoints under /api/v1/ (game, session, customization, …)
+│   │   ├── middleware/        # ASGI middlewares — errors, logging, auth_rate_limit, security_headers
 │   │   ├── schemas.py         # Pydantic request/response models
 │   │   ├── game_service.py    # Service layer — single entry point for all game actions
 │   │   ├── session_manager.py # Thread-safe game session management by OID
@@ -73,7 +79,7 @@ volley-overlay-control/
 │   │   ├── action_log.py      # Append-only per-OID audit log (data/audit_<hash>.jsonl)
 │   │   ├── match_archive.py   # Per-match snapshot writer (data/matches/match_<hash>_<UTC>.json)
 │   │   ├── match_rules.py     # Indoor/beach presets + beach side-switch helpers
-│   │   ├── webhooks.py        # Outbound HTTP webhooks fired on game events (set_end, match_end, timeout, serve_change)
+│   │   ├── webhooks.py        # Outbound HTTP webhooks fired on game events (set_end, match_end, timeout, serve_change); SSRF-guarded by default
 │   │   ├── ws_hub.py          # WebSocket notification hub for real-time state push
 │   │   └── dependencies.py    # Auth + session FastAPI dependencies
 │   │
@@ -94,7 +100,7 @@ volley-overlay-control/
 │
 ├── overlay_templates/         # Jinja2 HTML templates for overlay styles (16 templates)
 ├── overlay_static/            # Static assets for overlays (JS, CSS, images)
-├── data/                      # Persisted custom overlay state (overlay_state_{id}.json)
+├── data/                      # Persisted runtime state — overlay_state_{id}.json, audit_<hash>.jsonl, matches/, .overlay_server_token (auto-generated, mode 0o600)
 │
 ├── tests/                     # Pytest suite (181 tests)
 │   ├── conftest.py            # Shared fixtures: load_test_env
@@ -222,6 +228,7 @@ Full list in [README.md](README.md).
 | `/manage` | Custom overlay manager page (password-protected via `OVERLAY_MANAGER_PASSWORD`) |
 | `/api/v1/*` | REST API (see [FRONTEND_DEVELOPMENT.md](FRONTEND_DEVELOPMENT.md)) |
 | `/api/v1/admin/custom-overlays` | List / create (optionally clone) / delete custom overlays (`Authorization: Bearer $OVERLAY_MANAGER_PASSWORD`) |
+| `/api/v1/admin/match/{match_id}/sign-url` | `POST` — mint an HMAC-signed capability URL for `/match/{id}/report` (admin Bearer required; replaces the legacy `?token=<password>` share flow) |
 | `/api/v1/admin/login`, `/api/v1/admin/status` | Admin auth check + feature-enabled probe |
 | `/api/v1/session/rules?oid=X` | `POST` — update match rules (mode, points, sets) for the session. |
 | `/api/v1/audit?oid=X[&limit=N]` | Most-recent records from the per-OID action audit log |
@@ -290,6 +297,8 @@ Use `app/oid_utils.py` for `extract_oid()` and `compose_output()` — do not imp
 - **Do not block the event loop** — long-running I/O must use the `ThreadPoolExecutor` in `Backend`.
 - **Do not skip `GameManager.save()`** — after any mutation, save must be called.
 - **Custom overlay detection:** `Backend.is_custom_overlay()` calls `resolve_overlay_kind()` (in `app/overlay_backends/utils.py`), which returns `OverlayKind.CUSTOM` only if the local overlay store has a file for that id. The legacy `C-` prefix is still accepted (and stripped) but never auto-creates a missing overlay.
+- **Do not bypass `run_security_bootstrap`.** `bootstrap.create_app` calls it before any router is registered so `OVERLAY_SERVER_TOKEN` is auto-generated / loaded and `os.environ` is populated before the auth dependencies read it. Tests that build a real app via `create_app()` rely on the autouse `isolate_security_bootstrap` fixture in `tests/conftest.py` to redirect the token-persistence path to a per-test temp dir; do not call `ensure_overlay_server_token` directly without that isolation.
+- **Credentials never compare with `==`.** All three auth surfaces (`PasswordAuthenticator`, `auth_utils.require_admin_token`, `overlay/routes.require_overlay_server_token`) go through `app.password_hash.verify_password`, which accepts either a scrypt hash record or the legacy plaintext value with a constant-time compare. The hash form (`password_hash` per user, `OVERLAY_MANAGER_PASSWORD_HASH`, `OVERLAY_SERVER_TOKEN_HASH`) wins when both are set — see `AUTHENTICATION.md` §8.
 - **Undo is a per-call flag, not a stack** — `add_game`, `add_set`, and `add_timeout` reverse only the most recent action of that type. `add_game(undo=True)` additionally falls back to `current_set - 1` when the current set has no score for the requested team, so a set-winning point can be undone after the session has advanced. The bundled React UI tracks its own short history of forward actions in `App.tsx` to drive the bottom-bar undo button — that stack is client-side only and does not survive page reloads or other clients.
 
 ---
@@ -317,6 +326,8 @@ The SPA mount uses a custom `SPAStaticFiles` class that falls back to `index.htm
 | `FRONTEND_DEVELOPMENT.md` | REST API reference + guide for building JS frontends |
 | `CUSTOM_OVERLAY.md` | Guide for building a custom overlay server |
 | `CUSTOM_OVERLAY_API.yaml` | OpenAPI 3.0 spec for the custom overlay REST contract |
+| `AUTHENTICATION.md` | Auth coverage audit — per-route inventory, defence-in-depth middleware, hashed-credential migration |
+| `SECURITY.md` | Vulnerability disclosure policy and supported-versions matrix |
 | `CHANGELOG.md` | User-facing change log (Keep a Changelog format) |
 | `AGENTS.md` | This file — AI agent guide |
 

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -23,6 +23,12 @@ preferred form: storing a scrypt record on disk means the cleartext
 credential never sits in `.env`. See §8 for the migration guide and
 the verifier's caching/rotation semantics.
 
+Every 401 response from these ladders carries a
+`WWW-Authenticate: Bearer realm="<scoreboard|admin|overlay-server>"`
+header per RFC 7235 §4.1. The realm hint helps the OpenAPI /
+Swagger UI label the credential prompt and lets operators tell
+from access logs which ladder rejected a request.
+
 The `check_oid_access` helper is a second-level check layered on top of
 `verify_api_key`: it compares the caller's `control` OID (stored in
 `SCOREBOARD_USERS`) against the OID in the request and returns `403`

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -218,13 +218,25 @@ When adding a new route, add a matching entry in this test file.
 
 ## 5. Release notes
 
-One deployment-visible change operators should be aware of:
+Two deployment-visible changes operators should be aware of:
 
-1. **`OVERLAY_SERVER_TOKEN` is recommended** — set it on any deployment
-   that exposes overlay routes (the default in-process overlay server
-   setup). Control apps pointed at an external overlay server via
-   `APP_CUSTOM_OVERLAY_URL` must also set it to the same value. Leaving
-   it unset is backward-compatible but triggers a startup warning.
+1. **`OVERLAY_SERVER_TOKEN` is now auto-generated.** When the env var
+   is unset on first start, the bootstrap mints a random token,
+   persists it to `data/.overlay_server_token` (mode `0o600`), and
+   exposes it via `os.environ` so the rest of the app picks it up
+   transparently. Subsequent restarts read the same file, so the
+   token stays stable. Operators pairing this app with an external
+   overlay server (`APP_CUSTOM_OVERLAY_URL`) must either set
+   `OVERLAY_SERVER_TOKEN` explicitly on both sides, or read the
+   generated value from the persisted file. Set
+   `OVERLAY_SERVER_TOKEN_DISABLED=true` to opt back into the legacy
+   unauthenticated behaviour (only safe on a trusted LAN); the
+   bootstrap logs a `CRITICAL` warning when this opt-out is active.
+2. **`SCOREBOARD_USERS` unset now triggers a startup warning.** The
+   API still works without auth — backwards compatible — but the
+   open-API posture is now visible in the startup tail. Set
+   `SCOREBOARD_USERS_DISABLED=true` to silence the warning for
+   trusted-LAN deployments.
 
 ## 6. Defence-in-depth middleware
 

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -282,7 +282,50 @@ State is process-local. Multi-replica deployments should still front
 the app with a layer-7 limiter (Cloudflare, Nginx, etc.) — this
 middleware is the single-replica self-hosted backstop.
 
-### 6.2 `SecurityHeadersMiddleware` — HTTP response hardening
+### 6.2 `TrustedHostMiddleware` — Host-header poisoning defence (opt-in)
+
+Wired in `app/bootstrap.py:_maybe_register_trusted_hosts`. When
+`TRUSTED_HOSTS` is unset the middleware is not installed (default,
+backwards compatible). When set to a comma-separated list of
+hostnames, Starlette's `TrustedHostMiddleware` rejects requests
+whose `Host` header doesn't match any entry with HTTP 400 before
+any handler reads `request.base_url` (used by `/links`,
+`/api/config/{id}`, the signed-URL minter, etc.). Wildcard
+subdomains are honoured (`*.example.com` matches any subdomain).
+
+| Env var | Default | Meaning |
+| :--- | :--- | :--- |
+| `TRUSTED_HOSTS` | unset | Comma-separated allow-list. Whitespace around entries is stripped. |
+
+Operators behind a reverse proxy must also configure uvicorn with
+`--proxy-headers` so the ASGI scope reflects the real `Host`. The
+overlay routes (`/overlay/{id}`) remain reachable from any host
+because the `Host` check happens before the route is dispatched —
+see `_maybe_register_trusted_hosts` if you need to relax that for
+OBS browser sources on a different domain.
+
+### 6.3 `CORSMiddleware` — cross-origin SPA scaffolding (opt-in)
+
+Wired in `app/bootstrap.py:_maybe_register_cors`. When
+`CORS_ALLOWED_ORIGINS` is unset the middleware is not installed
+(default, backwards compatible — the bundled SPA is served by
+FastAPI itself, no cross-origin requests). When set to a
+comma-separated list of origins, browser preflight responses get
+explicit allow-list semantics:
+
+* `Access-Control-Allow-Origin` is echoed only for listed origins.
+* `Access-Control-Allow-Credentials: true` so the React UI can
+  forward `Authorization` headers.
+* `Access-Control-Allow-Headers` includes `Authorization`,
+  `Content-Type`, `X-Request-ID`, and `Sec-WebSocket-Protocol`
+  — the headers the existing auth flows and the WS subprotocol
+  handshake actually use.
+
+| Env var | Default | Meaning |
+| :--- | :--- | :--- |
+| `CORS_ALLOWED_ORIGINS` | unset | Comma-separated allow-list of origins. `*` is **rejected** to prevent a copy-paste footgun on a credentialed API; an `ERROR` is logged and CORS stays disabled. |
+
+### 6.4 `SecurityHeadersMiddleware` — HTTP response hardening
 
 Located in `app/api/middleware/security_headers.py`. Adds:
 

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -225,3 +225,55 @@ One deployment-visible change operators should be aware of:
    setup). Control apps pointed at an external overlay server via
    `APP_CUSTOM_OVERLAY_URL` must also set it to the same value. Leaving
    it unset is backward-compatible but triggers a startup warning.
+
+## 6. Defence-in-depth middleware
+
+Two middlewares wrap every request and complement the per-route auth
+ladder above. Both are wired in `app/bootstrap.py:create_app` so
+operators don't need to opt in.
+
+### 6.1 `AuthRateLimitMiddleware` — brute-force backstop
+
+Located in `app/api/middleware/auth_rate_limit.py`. Watches the
+`/api/v1/` and `/manage` path prefixes; when a response carries a
+401 or 403 status, the caller's IP (sourced from `X-Forwarded-For`
+when present, otherwise the raw socket peer) is recorded in a
+sliding-window counter. Once the bucket exceeds the configured
+threshold the next request from that IP is short-circuited with
+`429 Too Many Requests` and a `Retry-After` header before reaching
+the handler. Any non-401/403 response clears the bucket immediately
+so a legitimate operator who mistyped once isn't penalised.
+
+| Env var | Default | Meaning |
+| :--- | :--- | :--- |
+| `AUTH_RATE_LIMIT_MAX_FAILURES` | `10` | 401/403 responses per window before blocking |
+| `AUTH_RATE_LIMIT_WINDOW_SECONDS` | `60` | sliding-window length |
+| `AUTH_RATE_LIMIT_BLOCK_SECONDS` | `60` | how long the IP stays blocked once the threshold trips |
+
+State is process-local. Multi-replica deployments should still front
+the app with a layer-7 limiter (Cloudflare, Nginx, etc.) — this
+middleware is the single-replica self-hosted backstop.
+
+### 6.2 `SecurityHeadersMiddleware` — HTTP response hardening
+
+Located in `app/api/middleware/security_headers.py`. Adds:
+
+* `X-Content-Type-Options: nosniff` and `Referrer-Policy:
+  strict-origin-when-cross-origin` and a `Permissions-Policy` that
+  denies geolocation/microphone/camera/payment/usb on every response.
+* `Content-Security-Policy` (locked to `'self'` plus
+  `'unsafe-inline'`/`'unsafe-eval'` to keep the existing inline
+  match-report and SPA scripts working) and `X-Frame-Options:
+  SAMEORIGIN` on HTML responses. The `/overlay/*` routes get
+  `frame-ancestors *` instead so OBS browser sources can still embed
+  them off-origin.
+* `Cache-Control: no-store` on `/api/v1/` responses that don't
+  already set a `Cache-Control` header — keeps authenticated JSON
+  out of intermediary caches.
+
+Operators can override individual headers via env vars:
+`SECURITY_CSP`, `SECURITY_REFERRER_POLICY`,
+`SECURITY_PERMISSIONS_POLICY`, and `SECURITY_HSTS_SECONDS`
+(opt-in HSTS, off by default so non-HTTPS deployments are not
+locked out). Existing handler-level `Cache-Control` headers are
+always preserved.

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -14,9 +14,14 @@ different environment variable:
 
 | Layer | Env var | How it's enforced | Where |
 | :--- | :--- | :--- | :--- |
-| `verify_api_key` dependency | `SCOREBOARD_USERS` | Per-route `Depends(verify_api_key)`. Returns `401` when the header is missing, `403` when the Bearer token does not match any configured user. | `app/api/dependencies.py` |
-| `require_admin` dependency | `OVERLAY_MANAGER_PASSWORD` | Per-route `Depends(require_admin)`. Returns `503` when the password env var is unset, `401` when the header is missing, `403` when the Bearer token does not match. | `app/admin/routes.py` |
-| `require_overlay_server_token` dependency | `OVERLAY_SERVER_TOKEN` | Per-route `Depends(require_overlay_server_token)`. **No-op when the env var is unset** (logs a startup warning). When set: `401` without header, `403` with a mismatched Bearer token. | `app/overlay/routes.py` |
+| `verify_api_key` dependency | `SCOREBOARD_USERS` (per-user `password` or `password_hash`) | Per-route `Depends(verify_api_key)`. Returns `401` when the header is missing, `403` when the Bearer token does not match any configured user. | `app/api/dependencies.py` |
+| `require_admin` dependency | `OVERLAY_MANAGER_PASSWORD` or `OVERLAY_MANAGER_PASSWORD_HASH` | Per-route `Depends(require_admin)`. Returns `503` when neither env var is set, `401` when the header is missing, `403` when the Bearer token does not match. | `app/admin/routes.py` |
+| `require_overlay_server_token` dependency | `OVERLAY_SERVER_TOKEN` or `OVERLAY_SERVER_TOKEN_HASH` | Per-route `Depends(require_overlay_server_token)`. Auto-populated by the security bootstrap when neither is set (unless `OVERLAY_SERVER_TOKEN_DISABLED=true`). When set: `401` without header, `403` with a mismatched Bearer token. | `app/overlay/routes.py` |
+
+Each row's `_HASH` env var (or `password_hash` user field) is the
+preferred form: storing a scrypt record on disk means the cleartext
+credential never sits in `.env`. See §8 for the migration guide and
+the verifier's caching/rotation semantics.
 
 The `check_oid_access` helper is a second-level check layered on top of
 `verify_api_key`: it compares the caller's `control` OID (stored in
@@ -355,3 +360,68 @@ The route now resolves auth in this order:
 
 The token never appears in the request line for browser clients
 that adopt path 1.
+
+## 8. Hashed credentials at rest
+
+The three credential env vars all started life as plaintext values
+read directly from `.env` / compose. `secrets.compare_digest` /
+`hmac.compare_digest` made the *comparison* constant-time, but the
+source value sat in cleartext on disk where any operator with shell
+access could read it. PR 4 of the security plan added an opt-in
+hashed alternative without introducing a new dependency.
+
+### 8.1 Hash format
+
+Hashes are produced by `app/password_hash.py` using
+`hashlib.scrypt`. The wire format is::
+
+    scrypt$n=16384,r=8,p=1$<salt-hex>$<hash-hex>
+
+* `n`, `r`, `p` are the standard scrypt parameters; the verifier
+  reads them from the record so existing hashes keep working when
+  the defaults change.
+* `salt` is 16 random bytes, lowercase hex (32 chars).
+* `hash` is the 32-byte derived key, lowercase hex (64 chars).
+
+Mint a hash via the CLI helper::
+
+    python -m app.password_hash                    # interactive (no echo)
+    echo -n 'mypw' | python -m app.password_hash --stdin
+    python -m app.password_hash --stdin --n 32768  # heavier hash
+
+### 8.2 Per-surface configuration
+
+| Credential | Plaintext env var | Hash env var | Field name |
+| :--- | :--- | :--- | :--- |
+| Scoreboard user | inside `SCOREBOARD_USERS` JSON: `password` | inside `SCOREBOARD_USERS` JSON: `password_hash` | (per-user) |
+| Admin (`/manage`, `/api/v1/admin/*`) | `OVERLAY_MANAGER_PASSWORD` | `OVERLAY_MANAGER_PASSWORD_HASH` | env var |
+| Overlay server | `OVERLAY_SERVER_TOKEN` | `OVERLAY_SERVER_TOKEN_HASH` | env var |
+
+When both forms are configured, the hash wins. This matters for the
+migration path: an operator who has minted a hash but hasn't yet
+deleted the plaintext should already be authenticating against the
+new value, otherwise the old password keeps working until both are
+rotated.
+
+### 8.3 Verification cache
+
+`hashlib.scrypt` at the default parameters costs ~50 ms per check.
+Routes protected by `verify_api_key` are called many times per
+second from the React UI, so unhashed verification is essentially
+free but hashed verification would add real latency. The
+`PasswordAuthenticator._verify_cache` keeps a 60-second per-process
+TTL cache keyed on `sha256(provided_token)`; cached lookups skip
+the scrypt call entirely. The cache is invalidated automatically
+on `SCOREBOARD_USERS` rotation, so a removed user cannot remain
+authenticated past the env-var change.
+
+### 8.4 Auto-generation interaction
+
+`security_bootstrap.ensure_overlay_server_token` (PR 2) auto-generates
+`OVERLAY_SERVER_TOKEN` and persists it to `data/.overlay_server_token`
+on first start. When `OVERLAY_SERVER_TOKEN_HASH` is set, the
+bootstrap skips that step — a hash-only deployment intentionally
+keeps zero cleartext on the server side. The peer
+(`CustomOverlayBackend`) still reads the cleartext token from its
+own configuration, so the hash-only model splits trust cleanly:
+this server stores only a hash, the peer stores only the cleartext.

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -298,11 +298,13 @@ subdomains are honoured (`*.example.com` matches any subdomain).
 | `TRUSTED_HOSTS` | unset | Comma-separated allow-list. Whitespace around entries is stripped. |
 
 Operators behind a reverse proxy must also configure uvicorn with
-`--proxy-headers` so the ASGI scope reflects the real `Host`. The
-overlay routes (`/overlay/{id}`) remain reachable from any host
-because the `Host` check happens before the route is dispatched —
-see `_maybe_register_trusted_hosts` if you need to relax that for
-OBS browser sources on a different domain.
+`--proxy-headers` so the ASGI scope reflects the real `Host`.
+Enforcement is global — the overlay routes (`/overlay/{id}`,
+`/ws/{id}`) are subject to the same allow-list because the `Host`
+check fires before route dispatch. If OBS browser sources on a
+different domain need to load an overlay, add that domain (or a
+wildcard parent) to `TRUSTED_HOSTS`; do not try to special-case the
+overlay router downstream of the middleware.
 
 ### 6.3 `CORSMiddleware` — cross-origin SPA scaffolding (opt-in)
 

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -62,7 +62,7 @@ via `get_session` (or explicitly inside the handler).
 | `GET` | `/themes` | Y | |
 | `GET` | `/links` | Y + OID | |
 | `GET` | `/styles` | Y + OID | |
-| `WS` | `/ws` | Y + OID | Explicit `check_oid_access`; accepts token via `?token=…` query param |
+| `WS` | `/ws` | Y + OID | Explicit `check_oid_access`; accepts token via `Sec-WebSocket-Protocol: bearer, <token>` (preferred) or `?token=…` query param (deprecated, kept for legacy clients) |
 
 ### 2.2 Admin — `admin_router` + `admin_page_router` (`app/admin/routes.py`)
 
@@ -71,6 +71,7 @@ via `get_session` (or explicitly inside the handler).
 | `GET` | `/manage` | — | Static HTML page; JS prompts for password client-side and keeps it in a closure variable only. |
 | `GET` | `/api/v1/admin/status` | — | Returns `{"enabled": bool}` only — does not leak the password itself. |
 | `POST` | `/api/v1/admin/login` | `require_admin` | Used by the management page to validate the password. |
+| `POST` | `/api/v1/admin/match/{match_id}/sign-url` | `require_admin` | Mints an HMAC-signed capability URL for the gated match report. Body: `{"ttl_seconds": int}`. Response: `{"url", "expires_at", "expires_in"}`. The URL embeds `?exp=&sig=` — never the admin password. |
 | `GET` | `/api/v1/admin/custom-overlays` | `require_admin` | Lists custom overlays managed by the in-process engine. |
 | `POST` | `/api/v1/admin/custom-overlays` | `require_admin` | Creates a custom overlay (optional `copy_from` to clone). |
 | `DELETE` | `/api/v1/admin/custom-overlays/{id}` | `require_admin` | Deletes a custom overlay and its persisted state. |
@@ -299,3 +300,58 @@ Operators can override individual headers via env vars:
 (opt-in HSTS, off by default so non-HTTPS deployments are not
 locked out). Existing handler-level `Cache-Control` headers are
 always preserved.
+
+## 7. Credential transport patterns
+
+This section documents how each credential travels on the wire, and
+the H-4 hardening that flipped two of them away from the URL line.
+
+### 7.1 Match report: signed capability URLs
+
+The legacy share flow for the gated match report was
+``/match/{id}/report?token=$OVERLAY_MANAGER_PASSWORD``. Pasting
+the URL into chat tools, browser bookmarks, or anywhere a
+``Referer`` header could be sent leaked the actual admin password.
+
+Operators should now mint a capability URL via
+``POST /api/v1/admin/match/{match_id}/sign-url`` (admin Bearer
+required). The response carries a URL of the form
+``/match/{id}/report?exp=<unix_seconds>&sig=<hmac_hex>``. The
+signing key is derived from ``OVERLAY_MANAGER_PASSWORD``, so:
+
+* Anyone who holds the URL can read the report until ``exp``
+  passes.
+* The admin password itself never leaves the server.
+* Rotating ``OVERLAY_MANAGER_PASSWORD`` invalidates every
+  outstanding signed URL — the desired behaviour after a suspected
+  leak.
+* TTL is bounded to ``[60 s, 30 days]``; the default is one day.
+
+The legacy ``?token=`` flow is preserved for backwards
+compatibility but should be considered deprecated. The matches
+index (``/matches/index.html``) deliberately does *not* honour
+signed URLs — it would need a separate list-all capability that
+also unlocks per-row deletion, and that feature is intentionally
+not provided yet.
+
+### 7.2 `/api/v1/ws`: Bearer subprotocol auth
+
+WebSocket connections from JavaScript clients cannot set custom
+headers. The legacy workaround was a ``?token=<value>`` query
+parameter, which leaks via every reverse-proxy access log.
+
+The route now resolves auth in this order:
+
+1. ``Sec-WebSocket-Protocol: bearer, <token>`` — preferred.
+   Browser clients open the socket with
+   ``new WebSocket(url, ["bearer", token])``. The server
+   selects the ``bearer`` subprotocol and echoes it back during
+   the handshake (RFC 6455 §4.1).
+2. ``Authorization: Bearer <token>`` header — for non-browser
+   clients that can set headers on the upgrade request.
+3. ``?token=<value>`` query parameter — legacy fallback. Kept
+   so existing CLI / script clients keep working; documented as
+   deprecated in the OpenAPI schema.
+
+The token never appears in the request line for browser clients
+that adopt path 1.

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -236,13 +236,23 @@ operators don't need to opt in.
 
 Located in `app/api/middleware/auth_rate_limit.py`. Watches the
 `/api/v1/` and `/manage` path prefixes; when a response carries a
-401 or 403 status, the caller's IP (sourced from `X-Forwarded-For`
-when present, otherwise the raw socket peer) is recorded in a
-sliding-window counter. Once the bucket exceeds the configured
-threshold the next request from that IP is short-circuited with
-`429 Too Many Requests` and a `Retry-After` header before reaching
-the handler. Any non-401/403 response clears the bucket immediately
-so a legitimate operator who mistyped once isn't penalised.
+401 or 403 status, the caller's IP is recorded in a sliding-window
+counter. Once the bucket exceeds the configured threshold the next
+request from that IP is short-circuited with `429 Too Many
+Requests` and a `Retry-After` header before reaching the handler.
+The bucket is reset only by the sliding window — non-failure
+responses are intentionally ignored so an attacker cannot launder
+failures by interleaving login attempts with hits to a public
+endpoint under the same prefix (e.g. `/api/v1/admin/status`).
+
+The caller IP is sourced exclusively from `scope["client"]` —
+client-supplied `X-Forwarded-For` headers are ignored to defeat
+spoofing. **Operators behind a reverse proxy must configure
+uvicorn with `--proxy-headers` and `--forwarded-allow-ips=<proxy
+IP>`** so the ASGI scope reflects the real remote IP rather than
+the proxy hop. Without that, every caller behind the proxy
+collapses into a single bucket and a single attacker can lock out
+all legitimate users.
 
 | Env var | Default | Meaning |
 | :--- | :--- | :--- |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ once a first tagged release ships.
 
 ### Security
 
+- **`TrustedHostMiddleware` (opt-in).** Set ``TRUSTED_HOSTS`` to a
+  comma-separated list of public hostnames the deployment serves
+  from; requests carrying a ``Host`` header outside the allow-list
+  are rejected with HTTP 400 before any handler reads
+  ``request.base_url``. Wildcard subdomains are honoured. Default:
+  unset → no enforcement (backwards compatible).
+- **CORS scaffolding (opt-in).** Set ``CORS_ALLOWED_ORIGINS`` to a
+  comma-separated list of origins permitted to call the API
+  cross-origin. ``*`` is deliberately rejected on this credentialed
+  API; explicit origins only. ``Authorization``,
+  ``Content-Type``, ``X-Request-ID``, and
+  ``Sec-WebSocket-Protocol`` are forwarded so the existing auth
+  flows and the new Bearer-subprotocol WebSocket handshake all keep
+  working. Default: unset → same-origin only (backwards compatible).
+- **CI security scanners.** New ``security-scan`` job in
+  ``.github/workflows/ci.yml`` runs Bandit (MEDIUM+ severity) over
+  ``app/``, ``pip-audit --strict`` against both
+  ``requirements.lock`` and ``requirements-dev.lock``, and
+  ``npm audit --omit=dev --audit-level=high`` against the frontend.
+  Findings fail the job; suppression requires either a documented
+  ``# nosec`` comment or an explicit advisory ignore.
+- **`SECURITY.md`** — formal vulnerability-disclosure policy.
+  Points reporters at GitHub's private vulnerability reporting,
+  documents in-scope/out-of-scope surfaces, and links to the
+  hardening reference (``AUTHENTICATION.md``).
+
 - **Hashed credentials at rest.** New module ``app/password_hash.py``
   uses ``hashlib.scrypt`` (no new dependency) to mint salted hash
   records of the form ``scrypt$n=16384,r=8,p=1$<salt>$<hash>``. Three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Security
+
+- New ``SecurityHeadersMiddleware`` adds baseline response headers on
+  every request: ``X-Content-Type-Options: nosniff``,
+  ``Referrer-Policy: strict-origin-when-cross-origin``, and a
+  ``Permissions-Policy`` that denies geolocation/microphone/camera by
+  default. HTML responses additionally carry a ``Content-Security-Policy``
+  (locked to ``'self'`` + inline scripts/styles to keep the existing
+  match report rendering) and ``X-Frame-Options: SAMEORIGIN``. The
+  ``/overlay/*`` routes get a relaxed ``frame-ancestors *`` so OBS
+  browser sources can still embed them. Operators can override the
+  CSP / referrer / permissions strings via ``SECURITY_CSP``,
+  ``SECURITY_REFERRER_POLICY``, ``SECURITY_PERMISSIONS_POLICY`` and
+  opt into HSTS by setting ``SECURITY_HSTS_SECONDS`` (off by default
+  to avoid locking out non-HTTPS deployments).
+- New ``AuthRateLimitMiddleware`` watches ``/api/v1/`` and ``/manage``
+  for repeated 401/403 responses and blocks further requests from
+  the same IP with HTTP 429 once a per-IP threshold is reached. This
+  is a defence-in-depth backstop for brute-force attempts against
+  ``/api/v1/admin/login`` and the ``verify_api_key`` /
+  ``require_admin`` dependencies. Tunables:
+  ``AUTH_RATE_LIMIT_MAX_FAILURES`` (default 10),
+  ``AUTH_RATE_LIMIT_WINDOW_SECONDS`` (default 60),
+  ``AUTH_RATE_LIMIT_BLOCK_SECONDS`` (default 60). A successful
+  response clears the bucket immediately.
+- ``/api/v1/`` JSON responses now carry ``Cache-Control: no-store``
+  unless the handler explicitly sets a different policy, so
+  intermediaries cannot cache authenticated payloads.
+- ``PUT /api/v1/customization`` now caps payload size and validates
+  every value:
+  - At most 64 top-level keys per request.
+  - String values capped at 256 characters (8 KiB for logo URLs to
+    accommodate base64 ``data:image/...`` payloads).
+  - Logo URLs must use ``http(s)://`` or ``data:image/...`` schemes.
+    ``javascript:``, ``vbscript:``, ``data:text/html``, ``file://``,
+    etc. are rejected before persistence and broadcast.
+
 ## [5.1.2] - 2026-05-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ once a first tagged release ships.
 
 ### Security
 
+- **Hashed credentials at rest.** New module ``app/password_hash.py``
+  uses ``hashlib.scrypt`` (no new dependency) to mint salted hash
+  records of the form ``scrypt$n=16384,r=8,p=1$<salt>$<hash>``. Three
+  auth surfaces gained an opt-in hashed alternative — operators
+  migrate without a flag day, since each surface accepts either the
+  legacy plaintext or the new hash:
+  - ``SCOREBOARD_USERS`` user entries may carry ``password_hash``
+    instead of ``password``. When both are present, the hash wins
+    so the migration doesn't leave both credentials valid.
+  - ``OVERLAY_MANAGER_PASSWORD_HASH`` is honoured alongside the
+    legacy ``OVERLAY_MANAGER_PASSWORD``. The match-report URL
+    signing key follows whichever credential is configured, so
+    rotating either one still invalidates outstanding signed URLs.
+  - ``OVERLAY_SERVER_TOKEN_HASH`` is honoured alongside
+    ``OVERLAY_SERVER_TOKEN``. When the hash is set, the security
+    bootstrap skips auto-generation of the persisted plaintext
+    file — a hash-only deployment keeps zero cleartext on the
+    server side; the peer keeps the cleartext token.
+
+  Mint a hash via ``python -m app.password_hash`` (interactive
+  prompt) or ``echo -n 'pw' | python -m app.password_hash --stdin``.
+
+  Hash verification with the default scrypt parameters costs ~50 ms
+  per check, which would noticeably slow the React control UI's
+  per-action API calls. ``PasswordAuthenticator`` now keeps a
+  60-second per-process verify cache keyed on
+  ``sha256(provided_token)`` so the hot path stays fast; the cache
+  is automatically invalidated whenever ``SCOREBOARD_USERS`` is
+  rotated.
+
 - **Capability-style signed URLs for the gated match report.** New
   endpoint ``POST /api/v1/admin/match/{match_id}/sign-url`` (admin
   Bearer auth) returns a short-lived URL of the form

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,14 +31,26 @@ once a first tagged release ships.
   ``require_admin`` dependencies. Tunables:
   ``AUTH_RATE_LIMIT_MAX_FAILURES`` (default 10),
   ``AUTH_RATE_LIMIT_WINDOW_SECONDS`` (default 60),
-  ``AUTH_RATE_LIMIT_BLOCK_SECONDS`` (default 60). A successful
-  response clears the bucket immediately.
+  ``AUTH_RATE_LIMIT_BLOCK_SECONDS`` (default 60). The bucket is
+  reset only by the sliding window — successful responses to public
+  endpoints under the same prefix (``/api/v1/admin/status``,
+  ``/manage`` itself) do not clear failures, so an attacker cannot
+  launder login attempts by interleaving status requests. The
+  client identifier is sourced from ``scope["client"]`` only;
+  client-supplied ``X-Forwarded-For`` headers are ignored to defeat
+  spoofing. Operators behind a reverse proxy must configure uvicorn
+  with ``--proxy-headers`` / ``--forwarded-allow-ips`` so the ASGI
+  scope reflects the real remote IP.
 - ``/api/v1/`` JSON responses now carry ``Cache-Control: no-store``
   unless the handler explicitly sets a different policy, so
   intermediaries cannot cache authenticated payloads.
 - ``PUT /api/v1/customization`` now caps payload size and validates
   every value:
   - At most 64 top-level keys per request.
+  - Only scalar JSON types (string, boolean, number, null) are
+    accepted — arrays and nested objects are rejected so the
+    deep-merge into the broadcast state cannot be used to inflate
+    the WebSocket payload.
   - String values capped at 256 characters (8 KiB for logo URLs to
     accommodate base64 ``data:image/...`` payloads).
   - Logo URLs must use ``http(s)://`` or ``data:image/...`` schemes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ once a first tagged release ships.
 
 ### Security
 
+- **Capability-style signed URLs for the gated match report.** New
+  endpoint ``POST /api/v1/admin/match/{match_id}/sign-url`` (admin
+  Bearer auth) returns a short-lived URL of the form
+  ``/match/{id}/report?exp=<unix>&sig=<hmac>``. The legacy
+  ``?token=<OVERLAY_MANAGER_PASSWORD>`` flow is preserved for
+  backwards compatibility but operators should switch over: signed
+  URLs do not embed the admin password, expire automatically (TTL
+  bounded to ``[60, 30 days]``, default ``86 400 s``), and rotating
+  the password invalidates every outstanding signature.
+- **Bearer subprotocol auth on ``/api/v1/ws``.** The WebSocket route
+  now prefers ``Sec-WebSocket-Protocol: bearer, <token>`` over the
+  legacy ``?token=`` query parameter. The handshake echoes the
+  selected subprotocol so browser clients accept the connection.
+  Resolution order: subprotocol → ``Authorization`` header → legacy
+  ``?token=`` query (deprecated). Tokens no longer need to appear
+  in URL access logs or HTTP ``Referer`` headers for browser clients.
+
 - ``OVERLAY_SERVER_TOKEN`` is now **auto-generated and persisted on
   first start** instead of leaving the seven overlay-server mutation
   endpoints (``POST /api/state/{id}``, ``/create/overlay/{id}``,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ once a first tagged release ships.
 
 ### Security
 
+- **Webhook SSRF guard.** ``app/api/webhooks.py`` now refuses to POST
+  to URLs whose host resolves to a private (RFC 1918), loopback,
+  link-local (including the ``169.254.169.254`` cloud-metadata
+  endpoint), multicast, reserved (RFC 5737 / RFC 3849
+  documentation), or unspecified address. Trusted-LAN deployments
+  that legitimately call internal webhook receivers set
+  ``WEBHOOKS_ALLOW_PRIVATE_IPS=true`` to opt out. Non-``http(s)``
+  schemes are also rejected. DNS resolution failures pass through
+  so flaky resolvers don't silently break valid webhook
+  configurations.
+- **`WWW-Authenticate` on 401 responses.** Per RFC 7235 §4.1, every
+  401 from the auth ladders now carries a
+  ``WWW-Authenticate: Bearer realm="<scoreboard|admin|overlay-server>"``
+  header. The realm hint helps the OpenAPI / Swagger UI label the
+  credential prompt and lets operators tell from access logs which
+  ladder rejected a request. 403 semantics are preserved (invalid
+  credential ≠ no credential).
+- **Enriched unhandled-exception logging.** ``ExceptionLoggingMiddleware``
+  now logs the request method, path, exception class, and request id
+  in both the message text and as structured ``extra`` fields
+  (``http_method``, ``http_path``, ``exc_class``) so JSON log
+  consumers can query each axis without parsing the free-form
+  message.
+
 - **`TrustedHostMiddleware` (opt-in).** Set ``TRUSTED_HOSTS`` to a
   comma-separated list of public hostnames the deployment serves
   from; requests carrying a ``Host`` header outside the allow-list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ once a first tagged release ships.
 
 ### Security
 
+- ``OVERLAY_SERVER_TOKEN`` is now **auto-generated and persisted on
+  first start** instead of leaving the seven overlay-server mutation
+  endpoints (``POST /api/state/{id}``, ``/create/overlay/{id}``,
+  ``/delete/overlay/{id}``, ``/api/raw_config/{id}``,
+  ``/api/theme/{id}/{name}``) unauthenticated by default. Resolution
+  order at startup:
+  1. ``OVERLAY_SERVER_TOKEN_DISABLED=true`` keeps the legacy
+     fail-open behaviour and logs a ``CRITICAL`` startup warning.
+  2. ``OVERLAY_SERVER_TOKEN=<value>`` already set wins.
+  3. Otherwise the bootstrap reads / mints a token at
+     ``data/.overlay_server_token`` (mode ``0o600``) and injects it
+     into ``os.environ`` so the rest of the app picks it up
+     transparently. The same value is reused across restarts so an
+     external ``CustomOverlayBackend`` peer does not need to be
+     re-configured.
+
+  **Operator action:** when an external overlay server points at this
+  app via ``APP_CUSTOM_OVERLAY_URL``, both sides must use the same
+  ``OVERLAY_SERVER_TOKEN``. Either set it explicitly on both, or read
+  the auto-generated value from ``data/.overlay_server_token`` after
+  the first start. To restore the previous unauthenticated behaviour
+  on a trusted LAN, set ``OVERLAY_SERVER_TOKEN_DISABLED=true``.
+- ``SCOREBOARD_USERS`` left unset now emits a startup ``WARNING``
+  (previously silent) so the open-API posture is visible in the
+  startup tail. ``SCOREBOARD_USERS_DISABLED=true`` silences the
+  warning for trusted-LAN deployments.
 - New ``SecurityHeadersMiddleware`` adds baseline response headers on
   every request: ``X-Content-Type-Options: nosniff``,
   ``Referrer-Policy: strict-origin-when-cross-origin``, and a

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Configure the application using the following environment variables:
 | `WEBHOOKS_EVENTS` | *(Optional)* CSV subset of events the single-URL webhook should receive. | *(all events)* |
 | `WEBHOOKS_TIMEOUT_S` | *(Optional)* Per-target POST timeout in seconds. | `5` |
 | `WEBHOOKS_JSON` | *(Optional)* JSON list of webhook targets, e.g. `[{"url":"…","secret":"…","events":["set_end"],"timeout_s":5}]`. Takes precedence over `WEBHOOKS_URL`. | |
+| `WEBHOOKS_ALLOW_PRIVATE_IPS` | If `true`, allows webhook targets whose host resolves to private / loopback / link-local IPs. Default: `false` — such targets are rejected with a logged warning to block accidental SSRF (`http://localhost/admin`, cloud metadata at `169.254.169.254`, etc.). Trusted-LAN deployments that need to call internal receivers opt in here. | `false` |
 | `MATCH_REPORT_PUBLIC` | If `true`, `/match/{id}/report` is reachable without a token (matches the `/overlay/{output_key}` model). When unset, the route requires `OVERLAY_MANAGER_PASSWORD` via Bearer header or `?token=`. Returns 503 if neither is configured. | `false` |
 | `MATCH_REPORT_PUBLIC_DELETE` | If `true`, `DELETE /matches/{id}` no longer requires the admin token — the per-row Delete button on `/matches/index.html` becomes usable without sharing `OVERLAY_MANAGER_PASSWORD`. Independent from `MATCH_REPORT_PUBLIC`: granting public read does *not* grant public delete. | `false` |
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ Configure the application using the following environment variables:
 | `OVERLAY_SERVER_TOKEN_HASH` | scrypt-hashed alternative to `OVERLAY_SERVER_TOKEN`. When set, the bootstrap skips auto-generating the persisted plaintext file — a hash-only deployment keeps zero cleartext on this server (the peer keeps the cleartext). | |
 | `OVERLAY_SERVER_TOKEN_DISABLED` | If `true`, opts back into legacy unauthenticated overlay-server endpoints. The bootstrap logs a `CRITICAL` startup warning when active. Only safe on a trusted LAN. | `false` |
 | `SCOREBOARD_USERS_DISABLED` | If `true`, silences the startup warning emitted when `SCOREBOARD_USERS` is unset. The API still allows unauthenticated requests; this flag only acknowledges the choice. | `false` |
+| `TRUSTED_HOSTS` | Comma-separated allow-list of hostnames the app accepts in the `Host` header. Wildcard subdomains (`*.example.com`) supported. Requests outside the list are rejected with HTTP 400 before any handler reads `request.base_url`. See [AUTHENTICATION.md](AUTHENTICATION.md) §6.2. | *(unset → no enforcement)* |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated allow-list of origins permitted to call the API cross-origin. `*` is rejected (credentialed API; explicit origins only). Default: same-origin only. See [AUTHENTICATION.md](AUTHENTICATION.md) §6.3. | *(unset → no CORS)* |
 | `APP_THEMES` | JSON with a list of customization themes. | |
 | `REMOTE_CONFIG_URL` | URL to a remote JSON file with the configuration. | |
 | `SINGLE_OVERLAY_MODE` | If `true`, restricts the app to a single active overlay at a time. | `true` |

--- a/README.md
+++ b/README.md
@@ -191,11 +191,13 @@ Configure the application using the following environment variables:
 | `LOG_REDACT` | If `true`, PII fields (OIDs, URLs) are redacted in log output and error reports from the SPA. | `true` |
 | `REST_USER_AGENT` | User-Agent to avoid Cloudflare bot detection. | `curl/8.15.0` |
 | `APP_TEAMS` | JSON with the list of predefined teams. | |
-| `SCOREBOARD_USERS` | JSON with the list of users and passwords (also used as API keys). | |
+| `SCOREBOARD_USERS` | JSON map of users. Each entry carries either `password` (legacy plaintext) or `password_hash` (a scrypt record minted via `python -m app.password_hash`). When both are present, the hash wins. See [AUTHENTICATION.md](AUTHENTICATION.md) §8. | |
 | `PREDEFINED_OVERLAYS` | JSON with a list of preconfigured overlays. | |
 | `HIDE_CUSTOM_OVERLAY_WHEN_PREDEFINED` | If `true`, hides the option to manually enter an overlay. | `false` |
-| `OVERLAY_MANAGER_PASSWORD` | Password that unlocks the custom overlay manager page at `/manage` (also required to read `/list/overlay`). Leave empty to disable the page. | |
+| `OVERLAY_MANAGER_PASSWORD` | Password that unlocks the custom overlay manager page at `/manage` (also required to read `/list/overlay`). Leave empty to disable the page, or use `OVERLAY_MANAGER_PASSWORD_HASH` instead to keep no cleartext on disk. | |
+| `OVERLAY_MANAGER_PASSWORD_HASH` | scrypt-hashed alternative to `OVERLAY_MANAGER_PASSWORD`. Mint via `python -m app.password_hash`. When both are set, the hash wins. See [AUTHENTICATION.md](AUTHENTICATION.md) §8. | |
 | `OVERLAY_SERVER_TOKEN` | Bearer token required by the built-in overlay server's mutation and config endpoints (`/api/state/{id}`, `/api/raw_config/{id}`, `/api/config/{id}`, `/create/overlay/{id}`, `/delete/overlay/{id}`, `/api/theme/{id}/{name}`). **Auto-generated and persisted to `data/.overlay_server_token` on first start when unset.** Set explicitly here to override (e.g. when an external `CustomOverlayBackend` peer must use the same value). See [AUTHENTICATION.md](AUTHENTICATION.md) §5. | *(auto)* |
+| `OVERLAY_SERVER_TOKEN_HASH` | scrypt-hashed alternative to `OVERLAY_SERVER_TOKEN`. When set, the bootstrap skips auto-generating the persisted plaintext file — a hash-only deployment keeps zero cleartext on this server (the peer keeps the cleartext). | |
 | `OVERLAY_SERVER_TOKEN_DISABLED` | If `true`, opts back into legacy unauthenticated overlay-server endpoints. The bootstrap logs a `CRITICAL` startup warning when active. Only safe on a trusted LAN. | `false` |
 | `SCOREBOARD_USERS_DISABLED` | If `true`, silences the startup warning emitted when `SCOREBOARD_USERS` is unset. The API still allows unauthenticated requests; this flag only acknowledges the choice. | `false` |
 | `APP_THEMES` | JSON with a list of customization themes. | |

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Import configuration from an external resource via `REMOTE_CONFIG_URL`. The appl
 | `/api/v1/matches[?oid=X]` | `GET` — list summaries of archived matches, newest first (optional OID filter). |
 | `/api/v1/matches/{match_id}` | `GET` — full archived match snapshot (final state, customization, audit log, config). |
 | `/api/v1/game/undo` | `POST` — pop the last forward `add_point`/`add_set`/`add_timeout` from the audit log and reverse it. Returns 200 with `success=false` and `message="Nothing to undo."` when the log is empty. |
-| `/match/{match_id}/report` | `GET` — print-friendly HTML match report. Gated by `OVERLAY_MANAGER_PASSWORD` (Bearer header or `?token=`) unless `MATCH_REPORT_PUBLIC=true`. Returns 503 when neither is configured. |
+| `/match/{match_id}/report` | `GET` — print-friendly HTML match report. Gated by `OVERLAY_MANAGER_PASSWORD` unless `MATCH_REPORT_PUBLIC=true`. Auth modes: `Authorization: Bearer <password>` header, `?exp=&sig=` signed URL minted via `POST /api/v1/admin/match/{id}/sign-url` (preferred), or legacy `?token=<password>` query (deprecated — leaks the admin password into URL access logs). Returns 503 when neither password nor public mode is configured. |
 | `/matches/index.html?oid=X` | `GET` — browseable HTML list of every archived match for the OID (date, sets, duration, link to each report). Same auth gate as `/match/{id}/report`; the `?token=` query is propagated to the per-match report links. |
 | `/matches/{match_id}` | `DELETE` — remove a single archived snapshot. Gated by `OVERLAY_MANAGER_PASSWORD` unless `MATCH_REPORT_PUBLIC_DELETE=true`. |
 | `/overlay/{id}` | Overlay HTML for OBS browser sources (built-in engine). `?style=mosaic` renders a preview grid of every selectable style. |

--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ Configure the application using the following environment variables:
 | `PREDEFINED_OVERLAYS` | JSON with a list of preconfigured overlays. | |
 | `HIDE_CUSTOM_OVERLAY_WHEN_PREDEFINED` | If `true`, hides the option to manually enter an overlay. | `false` |
 | `OVERLAY_MANAGER_PASSWORD` | Password that unlocks the custom overlay manager page at `/manage` (also required to read `/list/overlay`). Leave empty to disable the page. | |
-| `OVERLAY_SERVER_TOKEN` | *(Recommended)* Bearer token required by the built-in overlay server's mutation and config endpoints (`/api/state/{id}`, `/api/raw_config/{id}`, `/api/config/{id}`, `/create/overlay/{id}`, `/delete/overlay/{id}`, `/api/theme/{id}/{name}`). When unset the endpoints stay open and a warning is logged at startup. If you also run the control app against an **external** overlay server via `APP_CUSTOM_OVERLAY_URL`, set the same value on both sides. See [AUTHENTICATION.md](AUTHENTICATION.md) (F-3, F-5). | |
+| `OVERLAY_SERVER_TOKEN` | Bearer token required by the built-in overlay server's mutation and config endpoints (`/api/state/{id}`, `/api/raw_config/{id}`, `/api/config/{id}`, `/create/overlay/{id}`, `/delete/overlay/{id}`, `/api/theme/{id}/{name}`). **Auto-generated and persisted to `data/.overlay_server_token` on first start when unset.** Set explicitly here to override (e.g. when an external `CustomOverlayBackend` peer must use the same value). See [AUTHENTICATION.md](AUTHENTICATION.md) §5. | *(auto)* |
+| `OVERLAY_SERVER_TOKEN_DISABLED` | If `true`, opts back into legacy unauthenticated overlay-server endpoints. The bootstrap logs a `CRITICAL` startup warning when active. Only safe on a trusted LAN. | `false` |
+| `SCOREBOARD_USERS_DISABLED` | If `true`, silences the startup warning emitted when `SCOREBOARD_USERS` is unset. The API still allows unauthenticated requests; this flag only acknowledges the choice. | `false` |
 | `APP_THEMES` | JSON with a list of customization themes. | |
 | `REMOTE_CONFIG_URL` | URL to a remote JSON file with the configuration. | |
 | `SINGLE_OVERLAY_MODE` | If `true`, restricts the app to a single active overlay at a time. | `true` |
@@ -311,9 +313,8 @@ OVERLAY_MANAGER_PASSWORD=change-me
 ### Overlay server token (`OVERLAY_SERVER_TOKEN`)
 
 When the built-in overlay server is mounted (i.e. the `overlay_templates/`
-directory is present), its mutation and config endpoints can be gated behind
-a Bearer token. Set `OVERLAY_SERVER_TOKEN` to any non-empty value and every
-request to the following routes must include
+directory is present), its mutation and config endpoints are gated behind
+a Bearer token. Every request to the following routes must include
 `Authorization: Bearer <token>`:
 
 - `POST /api/state/{id}`
@@ -323,13 +324,18 @@ request to the following routes must include
 - `GET /api/config/{id}`
 - `POST /api/theme/{id}/{name}`
 
-When the variable is unset the routes stay open and a warning is logged at
-startup — existing deployments keep working unchanged.
+The token is **auto-generated and persisted to `data/.overlay_server_token`
+on first start**. Subsequent restarts reuse the same value, so an external
+`CustomOverlayBackend` peer pointed at this app via
+`APP_CUSTOM_OVERLAY_URL` only needs to be configured once: read the value
+from the persisted file or set `OVERLAY_SERVER_TOKEN` explicitly on both
+sides.
 
-If the control app is pointed at an **external** overlay server via
-`APP_CUSTOM_OVERLAY_URL`, set `OVERLAY_SERVER_TOKEN` to the same value on
-both sides. The control app's `CustomOverlayBackend` forwards the token in
-every request it makes to the overlay server.
+To opt back into the legacy unauthenticated behaviour (e.g. for a
+trusted-LAN install or local debugging), set
+`OVERLAY_SERVER_TOKEN_DISABLED=true`. A `CRITICAL` startup warning is
+logged whenever this opt-out is active so the choice is visible in the
+startup tail.
 
 The OBS capability URLs (`/overlay/{output_key}` and `/ws/{output_key}`) are
 intentionally **not** gated by this token — they are the public-by-design

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,94 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes target the latest tagged release on `main` and the
+`dev` branch. Earlier releases are not patched — operators running an
+older build are expected to upgrade to receive fixes.
+
+## Reporting a vulnerability
+
+If you believe you have found a security issue in
+`volley-overlay-control`, please **do not** open a public GitHub issue
+or pull request describing the vulnerability. Instead:
+
+1. Use GitHub's [private vulnerability reporting](https://github.com/JacoboSanchez/volley-overlay-control/security/advisories/new)
+   to file a confidential advisory.
+2. Or, if the GitHub flow is not available to you, open a **public**
+   GitHub issue with the single sentence "I have a security issue to
+   report; please send me a contact channel" — a maintainer will
+   reach out off-band.
+
+When you report, please include:
+
+- The version (commit SHA or release tag) you're running.
+- Steps to reproduce, including any required configuration.
+- The impact you observed and what you think the worst-case impact
+  could be.
+- Optional: a suggested mitigation or patch.
+
+We aim to acknowledge reports within five business days and to ship a
+fix or coordinated disclosure within 90 days. Reports that turn out to
+be configuration questions or low-impact hardening suggestions are
+welcome too — we'll just route them to a regular issue / PR with your
+permission.
+
+## Scope
+
+In-scope:
+
+- The FastAPI backend (`app/`).
+- The React control UI (`frontend/`).
+- The bundled overlay templates (`overlay_templates/`,
+  `overlay_static/`).
+- The Docker image and `docker-compose.yml`.
+- Any documented integration surface (REST, WebSocket, webhooks).
+
+Out of scope:
+
+- Vulnerabilities that require an attacker who already has shell
+  access to the host (the application runs as a non-root user inside
+  the container; container-escape findings should go to the upstream
+  base images: `python:3.13-slim`, `node:25-alpine`).
+- Issues that depend on a misconfiguration explicitly called out as
+  insecure in [`AUTHENTICATION.md`](AUTHENTICATION.md) — e.g.
+  `OVERLAY_SERVER_TOKEN_DISABLED=true` on a public deployment, or
+  `MATCH_REPORT_PUBLIC=true` with a guessable `match_id` (the IDs are
+  hash-prefixed and intentionally hard to guess, but the model is
+  capability-URL).
+- Vulnerabilities in third-party services this app integrates with
+  (overlays.uno, OBS itself, the operator's reverse proxy).
+
+## Hardening reference
+
+The auth ladder, the credential-transport patterns, the
+defence-in-depth middlewares, and the hash-at-rest options are
+documented in [`AUTHENTICATION.md`](AUTHENTICATION.md). New operators
+should at least:
+
+1. Set `SCOREBOARD_USERS` (with `password_hash` per user) so the API
+   is not open to the network.
+2. Set `OVERLAY_MANAGER_PASSWORD_HASH` so `/manage` and the admin
+   endpoints are gated.
+3. Set `OVERLAY_SERVER_TOKEN` (or let the bootstrap auto-generate it)
+   so overlay-server mutation endpoints reject anonymous writes.
+4. Configure `TRUSTED_HOSTS` to the public hostname(s) the app serves
+   from when running behind a reverse proxy.
+5. If serving the React UI from a different origin, set
+   `CORS_ALLOWED_ORIGINS` explicitly — wildcards are rejected.
+
+## CI scanning
+
+Every PR runs three security scanners as part of the CI matrix
+(`.github/workflows/ci.yml`, job `security-scan`):
+
+- **Bandit** — static analysis of `app/` at MEDIUM+ severity.
+- **pip-audit** — CVE scan of both `requirements.lock` and
+  `requirements-dev.lock`.
+- **npm audit** — CVE scan of `frontend/` runtime dependencies at
+  HIGH+ severity (dev tooling is omitted to keep the signal-to-noise
+  ratio high).
+
+A PR cannot merge with red scanners; suppressing a finding requires
+either a documented `# nosec` comment with a rationale, or an
+explicit advisory ignore in the corresponding tool's config.

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -20,6 +20,7 @@ variable to be set and the request to include a matching
 import logging
 import os
 import re
+import time
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
@@ -259,11 +260,10 @@ def sign_match_report_url(
         f"{base_url}/match/{match_id}/report"
         f"?exp={signed['exp']}&sig={signed['sig']}"
     )
-    import time as _time
     return MatchSignUrlResponse(
         url=url,
         expires_at=signed["expires_at"],
-        expires_in=max(0, signed["expires_at"] - int(_time.time())),
+        expires_in=max(0, signed["expires_at"] - int(time.time())),
     )
 
 

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -22,12 +22,18 @@ import os
 import re
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 from starlette.concurrency import run_in_threadpool
 
 from app.auth_utils import get_admin_password, require_admin_token
+from app.match_report_signing import (
+    DEFAULT_TTL_SECONDS,
+    MAX_TTL_SECONDS,
+    MIN_TTL_SECONDS,
+    make_signed_query,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +55,35 @@ class CustomOverlayCreate(BaseModel):
     copy_from: Optional[str] = Field(
         None,
         description="Optional existing overlay id to clone configuration from",
+    )
+
+
+class MatchSignUrlRequest(BaseModel):
+    ttl_seconds: Optional[int] = Field(
+        default=None,
+        ge=MIN_TTL_SECONDS,
+        le=MAX_TTL_SECONDS,
+        description=(
+            "URL lifetime in seconds. Bounded to "
+            f"[{MIN_TTL_SECONDS}, {MAX_TTL_SECONDS}]; defaults to "
+            f"{DEFAULT_TTL_SECONDS}."
+        ),
+    )
+
+
+class MatchSignUrlResponse(BaseModel):
+    url: str = Field(
+        ...,
+        description=(
+            "Absolute capability URL — anyone holding it can read "
+            "the report until ``expires_at``."
+        ),
+    )
+    expires_at: int = Field(
+        ..., description="Unix-seconds expiry the URL was signed for.",
+    )
+    expires_in: int = Field(
+        ..., description="Seconds remaining until expiry, at mint time.",
     )
 
 
@@ -177,6 +212,59 @@ def create_custom_overlay(payload: CustomOverlayCreate):
         "oid": name,
         "output_key": store.get_output_key(name),
     }
+
+
+@admin_router.post(
+    "/match/{match_id}/sign-url",
+    response_model=MatchSignUrlResponse,
+    dependencies=[Depends(require_admin)],
+    summary="Mint a short-lived signed URL for a match report",
+)
+def sign_match_report_url(
+    match_id: str,
+    payload: MatchSignUrlRequest,
+    request: Request,
+):
+    """Return a capability URL the operator can paste into chat tools.
+
+    The legacy share flow (``/match/{id}/report?token=<password>``)
+    embeds the actual ``OVERLAY_MANAGER_PASSWORD`` in the URL —
+    every browser bookmark, server log, or HTTP ``Referer`` that
+    touches the link leaks the credential. This endpoint replaces
+    that flow with an HMAC-signed URL of the form
+    ``/match/{id}/report?exp=<ts>&sig=<hex>``: the password stays
+    on the server and the URL expires automatically.
+
+    Rotating the admin password invalidates every outstanding
+    signed URL — that's the desired behaviour, since rotations are
+    typically motivated by suspected leaks.
+
+    The endpoint deliberately does *not* check whether the
+    ``match_id`` exists: a 404 here would be a free oracle for
+    enumerating archived matches by anyone holding the admin
+    password (who could already do far worse anyway). Signing a
+    bogus match id just produces a URL that 404s on use.
+    """
+    signed = make_signed_query(match_id, payload.ttl_seconds)
+    if signed is None:
+        # Should be unreachable — require_admin already 503's when
+        # the password is unset — but guard anyway in case a future
+        # refactor decouples the two.
+        raise HTTPException(
+            status_code=503,
+            detail="Match-report signing requires OVERLAY_MANAGER_PASSWORD.",
+        )
+    base_url = str(request.base_url).rstrip("/")
+    url = (
+        f"{base_url}/match/{match_id}/report"
+        f"?exp={signed['exp']}&sig={signed['sig']}"
+    )
+    import time as _time
+    return MatchSignUrlResponse(
+        url=url,
+        expires_at=signed["expires_at"],
+        expires_in=max(0, signed["expires_at"] - int(_time.time())),
+    )
 
 
 @admin_router.delete("/custom-overlays/{name}", dependencies=[Depends(require_admin)])

--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -19,6 +19,15 @@ def _strict_oid_access_enabled() -> bool:
     raw = EnvVarsManager.get_env_var('STRICT_OID_ACCESS', 'false')
     return str(raw).strip().lower() in ('1', 'true', 't', 'yes', 'on')
 
+# RFC 7235 mandates a ``WWW-Authenticate`` header on every 401 response so
+# clients know which scheme to retry with. We emit ``Bearer`` plus a
+# realm hint so the OpenAPI / Swagger UI prompt presents a sensible
+# label. The realm strings are deliberately surface-specific so an
+# operator can tell from the response which auth ladder the request
+# tripped (scoreboard / admin / overlay-server).
+_API_KEY_WWW_AUTH = {"WWW-Authenticate": 'Bearer realm="scoreboard"'}
+
+
 async def verify_api_key(authorization: str = Header(None)):
     """Validate the Bearer token when user authentication is enabled.
 
@@ -29,7 +38,11 @@ async def verify_api_key(authorization: str = Header(None)):
         return  # no auth required
 
     if not authorization or not authorization.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing API key. Use 'Authorization: Bearer <key>'.")
+        raise HTTPException(
+            status_code=401,
+            detail="Missing API key. Use 'Authorization: Bearer <key>'.",
+            headers=_API_KEY_WWW_AUTH,
+        )
 
     token = authorization.removeprefix("Bearer ").strip()
     if not PasswordAuthenticator.check_api_key(token):
@@ -51,7 +64,11 @@ def check_oid_access(authorization: str, oid: str):
     if not PasswordAuthenticator.do_authenticate_users():
         return
     if not authorization or not authorization.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing API key.")
+        raise HTTPException(
+            status_code=401,
+            detail="Missing API key.",
+            headers=_API_KEY_WWW_AUTH,
+        )
 
     username = get_current_username(authorization)
     if not username:

--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -58,8 +58,12 @@ def check_oid_access(authorization: str, oid: str):
         raise HTTPException(status_code=403, detail="Invalid API key.")
 
     users = PasswordAuthenticator._get_users()
-    userconf = users.get(username)
-    if userconf:
+    # ``_get_users`` already guarantees a dict-or-None at the top
+    # level, but a per-user entry may still be a non-dict shape
+    # (e.g. ``{"alice": "string"}``); skip the OID check rather
+    # than crash on ``userconf.get(...)``.
+    userconf = users.get(username) if isinstance(users, dict) else None
+    if isinstance(userconf, dict):
         allowed_oid = userconf.get("control")
         if allowed_oid and allowed_oid != oid:
             raise HTTPException(status_code=403, detail="Not authorized for this OID.")

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -628,10 +628,12 @@ class GameService:
                 message="No valid customization keys provided.",
             )
 
-        # Per-value validation: cap string lengths and require logo URLs
-        # to use a safe scheme. Non-string values (booleans, floats) are
-        # passed through unchanged; the existing model treats them as
-        # opaque blobs and broadcasts them verbatim.
+        # Per-value validation: only scalar JSON types are allowed
+        # (str / bool / int / float / None). Lists and nested objects
+        # are rejected outright — the customization model is a flat
+        # map of UI knobs, so an array or dict would either be ignored
+        # downstream or balloon the broadcast payload via deep merge.
+        # Strings are length-capped and logo URLs are scheme-checked.
         for key, value in filtered.items():
             if key in LOGO_KEYS:
                 if value in (None, ""):
@@ -645,13 +647,26 @@ class GameService:
                             f"data:image scheme."
                         ),
                     )
-            elif isinstance(value, str) and len(value) > MAX_STRING_VALUE_LENGTH:
+            elif isinstance(value, str):
+                if len(value) > MAX_STRING_VALUE_LENGTH:
+                    return ActionResponse(
+                        success=False,
+                        state=GameService.get_state(session),
+                        message=(
+                            f"Value for '{key}' exceeds "
+                            f"{MAX_STRING_VALUE_LENGTH} characters."
+                        ),
+                    )
+            elif not isinstance(value, (bool, int, float, type(None))):
+                # ``bool`` is a subclass of ``int`` so it would have
+                # been accepted by the numeric branch anyway, but
+                # listing it explicitly documents intent.
                 return ActionResponse(
                     success=False,
                     state=GameService.get_state(session),
                     message=(
-                        f"Value for '{key}' exceeds "
-                        f"{MAX_STRING_VALUE_LENGTH} characters."
+                        f"Value for '{key}' must be a string, "
+                        f"boolean, number, or null."
                     ),
                 )
         # Merge into existing model to preserve keys not in the allowed set

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -11,11 +11,15 @@ from app.api.match_rules import (
 )
 from app.api.schemas import (
     ALLOWED_CUSTOMIZATION_KEYS,
+    LOGO_KEYS,
+    MAX_CUSTOMIZATION_KEYS,
+    MAX_STRING_VALUE_LENGTH,
     ActionResponse,
     BeachSideSwitch,
     GameStateResponse,
     MatchPointInfo,
     TeamState,
+    is_safe_logo_url,
 )
 from app.api.webhooks import webhook_dispatcher
 from app.api.ws_hub import WSHub
@@ -595,6 +599,26 @@ class GameService:
 
     @staticmethod
     def update_customization(session, data: dict) -> ActionResponse:
+        # Reject obviously malformed payloads before doing any work. The
+        # cap on top-level keys keeps a malicious client from streaming
+        # tens of thousands of unknown keys (the filter below drops them,
+        # but allocating the dict iteration is still wasted work).
+        if not isinstance(data, dict):
+            return ActionResponse(
+                success=False,
+                state=GameService.get_state(session),
+                message="Customization payload must be a JSON object.",
+            )
+        if len(data) > MAX_CUSTOMIZATION_KEYS:
+            return ActionResponse(
+                success=False,
+                state=GameService.get_state(session),
+                message=(
+                    f"Customization payload exceeds {MAX_CUSTOMIZATION_KEYS} "
+                    f"keys."
+                ),
+            )
+
         # Filter to allowed keys only
         filtered = {k: v for k, v in data.items() if k in ALLOWED_CUSTOMIZATION_KEYS}
         if not filtered:
@@ -603,6 +627,33 @@ class GameService:
                 state=GameService.get_state(session),
                 message="No valid customization keys provided.",
             )
+
+        # Per-value validation: cap string lengths and require logo URLs
+        # to use a safe scheme. Non-string values (booleans, floats) are
+        # passed through unchanged; the existing model treats them as
+        # opaque blobs and broadcasts them verbatim.
+        for key, value in filtered.items():
+            if key in LOGO_KEYS:
+                if value in (None, ""):
+                    continue
+                if not is_safe_logo_url(value):
+                    return ActionResponse(
+                        success=False,
+                        state=GameService.get_state(session),
+                        message=(
+                            f"Logo URL for '{key}' must use http(s) or "
+                            f"data:image scheme."
+                        ),
+                    )
+            elif isinstance(value, str) and len(value) > MAX_STRING_VALUE_LENGTH:
+                return ActionResponse(
+                    success=False,
+                    state=GameService.get_state(session),
+                    message=(
+                        f"Value for '{key}' exceeds "
+                        f"{MAX_STRING_VALUE_LENGTH} characters."
+                    ),
+                )
         # Merge into existing model to preserve keys not in the allowed set
         # (e.g. Team 1 Logo Fit, Color 3, Text Color 3)
         current = session.customization.get_model()

--- a/app/api/middleware/auth_rate_limit.py
+++ b/app/api/middleware/auth_rate_limit.py
@@ -13,8 +13,12 @@ This guards the four credential-bearing surfaces against brute force:
 * every ``/api/v1/`` route protected by ``verify_api_key``.
 * ``/manage`` (admin password used by the static page).
 
-A successful response (anything outside 401/403) clears the bucket
-so a legitimate operator who mistyped once isn't penalised.
+A successful response is intentionally ignored — the bucket is reset
+only by the sliding window expiring old failures. This prevents an
+attacker from laundering failed login attempts by interleaving them
+with hits to a public endpoint under the same prefix (e.g.
+``/api/v1/admin/status``). See ``_record_outcome`` for the full
+rationale.
 
 All state is process-local — clusters with multiple replicas should
 front the app with a layer-7 limiter (Cloudflare, Nginx, etc.) that

--- a/app/api/middleware/auth_rate_limit.py
+++ b/app/api/middleware/auth_rate_limit.py
@@ -1,0 +1,206 @@
+"""Per-IP rate limiter for authenticated and admin endpoints.
+
+Watches every request whose path matches one of the configured
+prefixes; a 401 or 403 response increments the per-IP failure
+counter, and once a bucket exceeds ``_MAX_FAILURES`` within
+``_WINDOW_SECONDS`` the next request from that IP is short-circuited
+with ``429 Too Many Requests`` before reaching the handler.
+
+This guards the four credential-bearing surfaces against brute force:
+
+* ``POST /api/v1/admin/login`` — admin password check.
+* ``GET /api/v1/admin/*`` and the rest of the admin CRUD.
+* every ``/api/v1/`` route protected by ``verify_api_key``.
+* ``/manage`` (admin password used by the static page).
+
+A successful response (anything outside 401/403) clears the bucket
+so a legitimate operator who mistyped once isn't penalised.
+
+All state is process-local — clusters with multiple replicas should
+front the app with a layer-7 limiter (Cloudflare, Nginx, etc.) that
+shares state. The in-process limiter is a defence-in-depth backstop
+for self-hosted single-replica deployments.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from collections import OrderedDict, deque
+from typing import Iterable
+
+# Tunables — kept generous so legitimate operator workflows
+# (e.g. opening /manage in three tabs) never trip the limit, but
+# tight enough that an unattended attacker is throttled within
+# seconds. Override via env vars if needed.
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return default
+
+
+_MAX_FAILURES = _env_int("AUTH_RATE_LIMIT_MAX_FAILURES", 10)
+_WINDOW_SECONDS = float(_env_int("AUTH_RATE_LIMIT_WINDOW_SECONDS", 60))
+_BLOCK_SECONDS = float(_env_int("AUTH_RATE_LIMIT_BLOCK_SECONDS", 60))
+_MAX_CLIENTS = 4096
+
+# Path prefixes that this limiter watches. Listed explicitly so a future
+# unauthenticated route that happens to live under /api/v1/ does not
+# silently pull failures from elsewhere into its bucket.
+_WATCHED_PREFIXES: tuple[str, ...] = (
+    "/api/v1/",
+    "/manage",
+)
+
+
+class _Bucket:
+    __slots__ = ("failures", "blocked_until")
+
+    def __init__(self) -> None:
+        self.failures: deque[float] = deque()
+        self.blocked_until: float = 0.0
+
+
+_buckets: "OrderedDict[str, _Bucket]" = OrderedDict()
+_lock = asyncio.Lock()
+
+
+def _client_ip(scope) -> str:
+    """Best-effort peer identifier from the ASGI scope.
+
+    Honours ``X-Forwarded-For`` so the limiter does not collapse every
+    caller behind a reverse proxy into one bucket; falls back to the
+    raw socket address. Production deployments should also configure
+    uvicorn with ``--proxy-headers``.
+    """
+    for k, v in scope.get("headers") or ():
+        if k == b"x-forwarded-for":
+            try:
+                first = v.decode("latin-1").split(",", 1)[0].strip()
+            except Exception:
+                first = ""
+            if first:
+                return first
+    client = scope.get("client") or ()
+    if isinstance(client, (list, tuple)) and client:
+        return str(client[0])
+    return "unknown"
+
+
+def _path_is_watched(path: str, watched: Iterable[str]) -> bool:
+    return any(path == p or path.startswith(p) for p in watched)
+
+
+def _trim_failures_locked(bucket: _Bucket, now: float) -> None:
+    cutoff = now - _WINDOW_SECONDS
+    while bucket.failures and bucket.failures[0] < cutoff:
+        bucket.failures.popleft()
+
+
+async def _is_blocked(ip: str) -> bool:
+    """Return True if the bucket for *ip* is currently blocked."""
+    now = time.monotonic()
+    async with _lock:
+        bucket = _buckets.get(ip)
+        if bucket is None:
+            return False
+        _buckets.move_to_end(ip)
+        if bucket.blocked_until > now:
+            return True
+        return False
+
+
+async def _record_outcome(ip: str, status_code: int) -> None:
+    """Update the bucket for *ip* based on the response *status_code*.
+
+    A 401/403 records a failure (and may flip the bucket into the
+    blocked state); any other status drops the bucket entirely so a
+    successful login resets the counter.
+    """
+    now = time.monotonic()
+    async with _lock:
+        if status_code in (401, 403):
+            bucket = _buckets.get(ip)
+            if bucket is None:
+                bucket = _Bucket()
+                _buckets[ip] = bucket
+                if len(_buckets) > _MAX_CLIENTS:
+                    _buckets.popitem(last=False)
+            else:
+                _buckets.move_to_end(ip)
+            _trim_failures_locked(bucket, now)
+            bucket.failures.append(now)
+            if len(bucket.failures) >= _MAX_FAILURES:
+                bucket.blocked_until = now + _BLOCK_SECONDS
+        else:
+            # Any non-auth-failure outcome (200, 422, 404, 500, …)
+            # clears the bucket. We only care about repeated 401/403.
+            _buckets.pop(ip, None)
+
+
+def _reset_for_tests() -> None:
+    """Test hook to clear all buckets between cases."""
+    _buckets.clear()
+
+
+class AuthRateLimitMiddleware:
+    """Pure-ASGI middleware enforcing the per-IP failure limit."""
+
+    def __init__(self, app) -> None:
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "") or ""
+        if not _path_is_watched(path, _WATCHED_PREFIXES):
+            await self.app(scope, receive, send)
+            return
+
+        ip = _client_ip(scope)
+
+        if await _is_blocked(ip):
+            await _send_429(send)
+            return
+
+        status_holder = {"code": 0}
+
+        async def send_wrapper(message):
+            if message.get("type") == "http.response.start":
+                status_holder["code"] = int(message.get("status") or 0)
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+        if status_holder["code"]:
+            await _record_outcome(ip, status_holder["code"])
+
+
+async def _send_429(send) -> None:
+    body = (
+        b'{"detail":"Too many authentication failures. '
+        b'Please retry later."}'
+    )
+    await send({
+        "type": "http.response.start",
+        "status": 429,
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(body)).encode("latin-1")),
+            (b"retry-after", str(int(_BLOCK_SECONDS)).encode("latin-1")),
+            (b"cache-control", b"no-store"),
+        ],
+    })
+    await send({
+        "type": "http.response.body",
+        "body": body,
+        "more_body": False,
+    })

--- a/app/api/middleware/auth_rate_limit.py
+++ b/app/api/middleware/auth_rate_limit.py
@@ -75,19 +75,20 @@ _lock = asyncio.Lock()
 def _client_ip(scope) -> str:
     """Best-effort peer identifier from the ASGI scope.
 
-    Honours ``X-Forwarded-For`` so the limiter does not collapse every
-    caller behind a reverse proxy into one bucket; falls back to the
-    raw socket address. Production deployments should also configure
-    uvicorn with ``--proxy-headers``.
+    Reads ``scope["client"]`` only — uvicorn populates this from the
+    socket peer by default, and from a trusted proxy hop when the
+    server is started with ``--proxy-headers`` /
+    ``--forwarded-allow-ips``. Trusting ``X-Forwarded-For`` directly
+    here would be spoofable: any request can supply that header and
+    pin the leftmost value to an arbitrary IP, defeating the
+    per-IP bucket. The ASGI server is the single trust boundary that
+    decides whether the proxy chain is honoured.
+
+    Operators behind a reverse proxy must configure uvicorn /
+    gunicorn with the appropriate proxy-header flags so
+    ``scope["client"]`` reflects the real remote IP — see
+    `AUTHENTICATION.md` §6 for guidance.
     """
-    for k, v in scope.get("headers") or ():
-        if k == b"x-forwarded-for":
-            try:
-                first = v.decode("latin-1").split(",", 1)[0].strip()
-            except Exception:
-                first = ""
-            if first:
-                return first
     client = scope.get("client") or ()
     if isinstance(client, (list, tuple)) and client:
         return str(client[0])
@@ -120,29 +121,31 @@ async def _is_blocked(ip: str) -> bool:
 async def _record_outcome(ip: str, status_code: int) -> None:
     """Update the bucket for *ip* based on the response *status_code*.
 
-    A 401/403 records a failure (and may flip the bucket into the
-    blocked state); any other status drops the bucket entirely so a
-    successful login resets the counter.
+    A 401/403 appends a failure timestamp (and may flip the bucket
+    into the blocked state). Any other status is ignored: an attacker
+    can hit unauthenticated endpoints under the same prefix
+    (``/api/v1/admin/status``, ``/manage`` itself) to draw a 200, so
+    "200 clears the bucket" would let them launder failures and
+    bypass the limit. The sliding window already evicts old failures
+    once they fall out of ``_WINDOW_SECONDS``, which is the only
+    legitimate reset path.
     """
+    if status_code not in (401, 403):
+        return
     now = time.monotonic()
     async with _lock:
-        if status_code in (401, 403):
-            bucket = _buckets.get(ip)
-            if bucket is None:
-                bucket = _Bucket()
-                _buckets[ip] = bucket
-                if len(_buckets) > _MAX_CLIENTS:
-                    _buckets.popitem(last=False)
-            else:
-                _buckets.move_to_end(ip)
-            _trim_failures_locked(bucket, now)
-            bucket.failures.append(now)
-            if len(bucket.failures) >= _MAX_FAILURES:
-                bucket.blocked_until = now + _BLOCK_SECONDS
+        bucket = _buckets.get(ip)
+        if bucket is None:
+            bucket = _Bucket()
+            _buckets[ip] = bucket
+            if len(_buckets) > _MAX_CLIENTS:
+                _buckets.popitem(last=False)
         else:
-            # Any non-auth-failure outcome (200, 422, 404, 500, …)
-            # clears the bucket. We only care about repeated 401/403.
-            _buckets.pop(ip, None)
+            _buckets.move_to_end(ip)
+        _trim_failures_locked(bucket, now)
+        bucket.failures.append(now)
+        if len(bucket.failures) >= _MAX_FAILURES:
+            bucket.blocked_until = now + _BLOCK_SECONDS
 
 
 def _reset_for_tests() -> None:

--- a/app/api/middleware/errors.py
+++ b/app/api/middleware/errors.py
@@ -8,11 +8,20 @@ then re-raise so the framework's own handler still produces the response.
 
 HTTPException is allowed to propagate untouched: it is not an "error" in
 the application sense, just a structured response signal.
+
+The log message itself includes the request method, path, exception
+class name, and request id, so even text-formatted logs (`LOG_FORMAT=text`)
+carry enough context to grep for a specific failure. JSON-formatted
+logs additionally surface the same fields under structured keys via
+the ``extra`` payload, which makes them queryable in observability
+tools without parsing the free-form message.
 """
 
 import logging
 
 from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from app.logging_context import get_request_id
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +38,22 @@ class ExceptionLoggingMiddleware:
             await self.app(scope, receive, send)
         except StarletteHTTPException:
             raise
-        except Exception:
+        except Exception as exc:
+            method = scope.get("method") or scope["type"].upper()
+            path = scope.get("path", "<unknown>")
+            exc_class = type(exc).__name__
+            # ``extra`` keys must not shadow built-in LogRecord
+            # attributes (``message``, ``levelname``, …) — we use the
+            # ``exc_class`` / ``http_method`` / ``http_path`` prefix
+            # so a JSON formatter surfaces them under unambiguous
+            # field names.
             logger.exception(
-                "Unhandled %s error on %s",
-                scope["type"], scope.get("path", "<unknown>"),
+                "Unhandled %s on %s %s — %s (request_id=%s)",
+                scope["type"], method, path, exc_class, get_request_id(),
+                extra={
+                    "exc_class": exc_class,
+                    "http_method": method,
+                    "http_path": path,
+                },
             )
             raise

--- a/app/api/middleware/security_headers.py
+++ b/app/api/middleware/security_headers.py
@@ -1,0 +1,214 @@
+"""ASGI middleware that adds baseline HTTP security response headers.
+
+The middleware is configured with conservative defaults that work for
+the bundled SPA, the ``/manage`` admin page, the ``/match/{id}/report``
+print page, and the OBS-facing ``/overlay/{id}`` templates without
+forcing a CSP nonce migration. Operators can override the defaults via
+environment variables when they want a stricter posture (e.g. drop
+``'unsafe-inline'`` after auditing inline scripts).
+
+Headers applied to every response:
+
+* ``X-Content-Type-Options: nosniff`` — disables MIME-type guessing.
+* ``Referrer-Policy: strict-origin-when-cross-origin`` — keeps the path
+  out of cross-origin referers.
+* ``Permissions-Policy`` — denies geolocation/microphone/camera by
+  default; the app does not use them.
+
+Headers applied only to HTML responses:
+
+* ``Content-Security-Policy`` — locks ``default-src``/``script-src`` to
+  ``'self'`` plus ``'unsafe-inline'`` so the existing inline match-report
+  styles keep rendering. ``img-src`` allows ``https:`` and ``data:`` so
+  team logos still load from arbitrary CDNs and embedded data URLs.
+  Overlay routes (``/overlay/*``) get a relaxed ``frame-ancestors *``
+  because OBS browser sources embed them off-origin.
+* ``X-Frame-Options: SAMEORIGIN`` for non-overlay routes (legacy
+  fallback for browsers that ignore CSP ``frame-ancestors``).
+
+Headers applied to ``/api/v1/`` responses:
+
+* ``Cache-Control: no-store`` — authenticated API responses must not
+  be cached by intermediaries. Existing endpoints that already set
+  ``Cache-Control`` (e.g. the SPA shell) are not overridden.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, Optional
+
+
+def _env(name: str, default: str) -> str:
+    raw = os.environ.get(name)
+    if raw is None or not str(raw).strip():
+        return default
+    return str(raw).strip()
+
+
+_DEFAULT_CSP = (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data: https: http:; "
+    "font-src 'self' data:; "
+    "connect-src 'self' ws: wss: https:; "
+    "object-src 'none'; "
+    "base-uri 'self'; "
+    "form-action 'self'; "
+    "frame-ancestors 'self'"
+)
+
+_OVERLAY_CSP_FRAME_ANCESTORS = "frame-ancestors *"
+_DEFAULT_PERMISSIONS_POLICY = (
+    "geolocation=(), microphone=(), camera=(), payment=(), usb=()"
+)
+_DEFAULT_REFERRER_POLICY = "strict-origin-when-cross-origin"
+
+# Paths whose responses are HTML and therefore receive CSP / X-Frame-Options.
+# We treat the catch-all SPA mount, the manage page, the match report, and
+# the overlay templates as HTML; explicit "html=True" responses elsewhere
+# still get the headers because we sniff the Content-Type at send time.
+_OVERLAY_PREFIXES: tuple[str, ...] = ("/overlay/",)
+
+
+def _build_html_csp(path: str) -> str:
+    """Return the CSP string for an HTML response on *path*.
+
+    Overlay routes are embedded in OBS browser sources, which load the
+    page off-origin; ``frame-ancestors 'self'`` would break them. The
+    overlay-specific override only relaxes that one directive — every
+    other ``script-src`` / ``style-src`` / ``img-src`` policy stays in
+    force.
+    """
+    csp = _env("SECURITY_CSP", _DEFAULT_CSP)
+    if any(path.startswith(prefix) for prefix in _OVERLAY_PREFIXES):
+        # Replace any frame-ancestors directive with the overlay-friendly
+        # value. Falls back to appending if the env override removed it.
+        parts = [p.strip() for p in csp.split(";") if p.strip()]
+        replaced = False
+        for i, p in enumerate(parts):
+            if p.lower().startswith("frame-ancestors"):
+                parts[i] = _OVERLAY_CSP_FRAME_ANCESTORS
+                replaced = True
+                break
+        if not replaced:
+            parts.append(_OVERLAY_CSP_FRAME_ANCESTORS)
+        csp = "; ".join(parts)
+    return csp
+
+
+def _is_html_content_type(content_type: bytes) -> bool:
+    return content_type.lower().startswith(b"text/html")
+
+
+def _has_header(headers: Iterable[tuple[bytes, bytes]], name: bytes) -> bool:
+    target = name.lower()
+    return any(k.lower() == target for k, _ in headers)
+
+
+class SecurityHeadersMiddleware:
+    """Pure-ASGI middleware that injects baseline security response headers.
+
+    Hooks into ``http.response.start`` so it can inspect the outgoing
+    Content-Type and tailor CSP / X-Frame-Options to HTML responses
+    only. Non-HTTP scopes (lifespan, websocket) are passed through
+    untouched.
+
+    Existing ``Cache-Control`` headers are preserved; the middleware
+    only sets ``no-store`` on ``/api/v1/`` responses that don't already
+    carry the directive (so explicit ``no-cache`` choices in
+    ``bootstrap`` are respected).
+    """
+
+    def __init__(self, app, *, hsts_seconds: Optional[int] = None) -> None:
+        self.app = app
+        # HSTS is opt-in: setting it on a deployment that's not HTTPS-only
+        # will lock browsers out. Operators enable it via env var.
+        env_hsts = _env("SECURITY_HSTS_SECONDS", "")
+        if hsts_seconds is None and env_hsts:
+            try:
+                hsts_seconds = max(0, int(env_hsts))
+            except ValueError:
+                hsts_seconds = None
+        self._hsts_seconds = hsts_seconds
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "") or ""
+
+        async def send_wrapper(message):
+            if message.get("type") != "http.response.start":
+                await send(message)
+                return
+
+            headers: list[tuple[bytes, bytes]] = list(
+                message.get("headers") or []
+            )
+            content_type = b""
+            for k, v in headers:
+                if k.lower() == b"content-type":
+                    content_type = v
+                    break
+
+            # Always-on headers.
+            if not _has_header(headers, b"x-content-type-options"):
+                headers.append((b"x-content-type-options", b"nosniff"))
+            if not _has_header(headers, b"referrer-policy"):
+                headers.append((
+                    b"referrer-policy",
+                    _env(
+                        "SECURITY_REFERRER_POLICY",
+                        _DEFAULT_REFERRER_POLICY,
+                    ).encode("latin-1"),
+                ))
+            if not _has_header(headers, b"permissions-policy"):
+                headers.append((
+                    b"permissions-policy",
+                    _env(
+                        "SECURITY_PERMISSIONS_POLICY",
+                        _DEFAULT_PERMISSIONS_POLICY,
+                    ).encode("latin-1"),
+                ))
+
+            # HSTS — opt in only.
+            if self._hsts_seconds and not _has_header(
+                headers, b"strict-transport-security",
+            ):
+                headers.append((
+                    b"strict-transport-security",
+                    f"max-age={self._hsts_seconds}; includeSubDomains".encode(
+                        "latin-1",
+                    ),
+                ))
+
+            # HTML-only headers (CSP + X-Frame-Options).
+            if _is_html_content_type(content_type):
+                if not _has_header(headers, b"content-security-policy"):
+                    headers.append((
+                        b"content-security-policy",
+                        _build_html_csp(path).encode("latin-1"),
+                    ))
+                if not _has_header(headers, b"x-frame-options"):
+                    # Overlay routes intentionally allow cross-origin
+                    # framing (OBS browser source). Everything else is
+                    # SAMEORIGIN as a legacy fallback for browsers that
+                    # ignore CSP frame-ancestors.
+                    if not any(
+                        path.startswith(prefix) for prefix in _OVERLAY_PREFIXES
+                    ):
+                        headers.append((b"x-frame-options", b"SAMEORIGIN"))
+
+            # API JSON responses — disable intermediary caching.
+            if path.startswith("/api/v1/") and not _has_header(
+                headers, b"cache-control",
+            ):
+                headers.append((b"cache-control", b"no-store"))
+
+            message = {**message, "headers": headers}
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)

--- a/app/api/middleware/security_headers.py
+++ b/app/api/middleware/security_headers.py
@@ -50,7 +50,11 @@ _DEFAULT_CSP = (
     "default-src 'self'; "
     "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
     "style-src 'self' 'unsafe-inline'; "
-    "img-src 'self' data: https: http:; "
+    # ``http:`` deliberately omitted: HTTPS deployments would block
+    # mixed-content images anyway, and ``'self'`` already covers
+    # plain-HTTP localhost dev servers. Operators that genuinely need
+    # third-party HTTP logos can override via ``SECURITY_CSP``.
+    "img-src 'self' data: https:; "
     "font-src 'self' data:; "
     "connect-src 'self' ws: wss: https:; "
     "object-src 'none'; "

--- a/app/api/routes/websocket.py
+++ b/app/api/routes/websocket.py
@@ -15,6 +15,51 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+# Subprotocol convention: the client opens the WebSocket with the
+# subprotocols ``["bearer", "<token>"]``. The server picks
+# ``bearer`` as the chosen subprotocol (echoed in the handshake) and
+# uses the second list entry as the token. This is the RFC 6455
+# pattern that browser ``new WebSocket(url, [...])`` clients can
+# use without exposing the credential in the URL.
+_BEARER_SUBPROTOCOL = "bearer"
+
+
+def _resolve_ws_auth(ws: WebSocket) -> tuple[str, str | None]:
+    """Return ``(authorization_header, selected_subprotocol)``.
+
+    Resolution order:
+
+    1. ``Sec-WebSocket-Protocol: bearer, <token>`` — preferred,
+       no secret on the URL line.
+    2. ``Authorization: Bearer <token>`` — for non-browser clients
+       that can set headers on the upgrade request.
+    3. ``?token=<value>`` — legacy fallback, kept for the existing
+       CLI/script clients. Documented as deprecated.
+
+    The selected subprotocol must be echoed back when calling
+    ``ws.accept(subprotocol=...)``; otherwise a browser client drops
+    the connection with a protocol-mismatch error.
+    """
+    raw_proto = ws.headers.get("sec-websocket-protocol", "")
+    protocols = [p.strip() for p in raw_proto.split(",") if p.strip()]
+    if (
+        len(protocols) >= 2
+        and protocols[0].lower() == _BEARER_SUBPROTOCOL
+    ):
+        token = protocols[1]
+        return f"Bearer {token}", _BEARER_SUBPROTOCOL
+
+    auth = ws.headers.get("authorization", "")
+    if auth:
+        return auth, None
+
+    legacy_token = ws.query_params.get("token")
+    if legacy_token:
+        return f"Bearer {legacy_token}", None
+
+    return "", None
+
+
 @router.websocket("/ws")
 async def websocket_endpoint(
     ws: WebSocket,
@@ -26,8 +71,7 @@ async def websocket_endpoint(
         await ws.close(code=4400, reason="Missing 'oid' (or alias 'control') query parameter.")
         return
 
-    token = ws.query_params.get("token")
-    auth_header = f"Bearer {token}" if token else ws.headers.get("authorization", "")
+    auth_header, selected_subprotocol = _resolve_ws_auth(ws)
 
     try:
         check_oid_access(auth_header, resolved)
@@ -40,7 +84,7 @@ async def websocket_endpoint(
         await ws.close(code=4004, reason="No active session for this OID.")
         return
 
-    await WSHub.connect(ws, resolved)
+    await WSHub.connect(ws, resolved, subprotocol=selected_subprotocol)
     try:
         state_data = GameService.get_state(session).model_dump()
         await ws.send_json({"type": "state_update", "data": state_data})

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -83,6 +83,47 @@ ALLOWED_CUSTOMIZATION_KEYS = {
     'preferredStyle',
 }
 
+# Per-value bounds for ``PUT /customization``. Logos can hold base64
+# data URLs so they get a much larger budget than the rest. Everything
+# else maps to a short label or a numeric position, so 256 chars is
+# generous and keeps a malicious operator from stuffing megabyte
+# strings into the broadcast state.
+LOGO_KEYS = frozenset({'Team 1 Logo', 'Team 2 Logo'})
+MAX_LOGO_VALUE_LENGTH = 8192
+MAX_STRING_VALUE_LENGTH = 256
+MAX_CUSTOMIZATION_KEYS = 64
+
+# Logo URL schemes accepted by the customization endpoint. Any other
+# scheme (``javascript:``, ``vbscript:``, ``data:text/html`` …) is
+# rejected so a compromised client cannot plant XSS payloads via a
+# logo string that downstream surfaces (match report, /links preview,
+# overlay templates) interpolate into ``<img src=…>``.
+ALLOWED_LOGO_PREFIXES = (
+    "http://",
+    "https://",
+    "data:image/",
+)
+
+
+def is_safe_logo_url(value: object) -> bool:
+    """Return True iff *value* is a non-empty string with an allowed scheme.
+
+    Protocol-relative URLs (``//cdn.example.com/logo.png``) are accepted
+    because :func:`app.customization.Customization.fix_icon` rewrites
+    them to ``https://`` before they are persisted.
+    """
+    if not isinstance(value, str):
+        return False
+    candidate = value.strip()
+    if not candidate:
+        return False
+    if len(candidate) > MAX_LOGO_VALUE_LENGTH:
+        return False
+    if candidate.startswith("//"):
+        candidate = "https:" + candidate
+    lowered = candidate.lower()
+    return lowered.startswith(ALLOWED_LOGO_PREFIXES)
+
 
 # ---------------------------------------------------------------------------
 # Response models

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -31,12 +31,15 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import ipaddress
 import json
 import logging
+import socket
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Iterable, Optional
+from urllib.parse import urlparse
 
 import requests
 
@@ -49,6 +52,98 @@ KNOWN_EVENTS = frozenset({"set_end", "match_end", "timeout", "serve_change"})
 
 _DEFAULT_TIMEOUT_S = 5.0
 _MAX_WORKERS = 4
+
+_TRUTHY = ("1", "true", "t", "yes", "on")
+
+
+def _allow_private_targets() -> bool:
+    """Return True iff the operator opted into private-IP webhook targets.
+
+    The default posture is fail-closed: a webhook URL whose host
+    resolves to a private / loopback / link-local / multicast /
+    reserved IP is dropped before the HTTP request fires. This blocks
+    classic SSRF (``http://localhost/admin``, ``http://169.254.169.254``
+    cloud metadata, ``http://10.0.0.5/``) without operator effort.
+
+    Trusted-LAN deployments that legitimately need to call internal
+    webhooks (a Home Assistant bridge on the same network, an
+    on-premises Slack relay) set ``WEBHOOKS_ALLOW_PRIVATE_IPS=true``
+    to opt out.
+    """
+    raw = EnvVarsManager.get_env_var("WEBHOOKS_ALLOW_PRIVATE_IPS", "false")
+    return str(raw).strip().lower() in _TRUTHY
+
+
+def _is_private_ip(ip_str: str) -> bool:
+    """Return True iff *ip_str* is in any IP range we refuse to call."""
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        # Anything that isn't a parseable IP literal is suspicious.
+        return True
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _resolve_target_addresses(host: str) -> Optional[list[str]]:
+    """Return every IP the *host* resolves to, or ``None`` on failure.
+
+    The resolution is intentionally fresh on every delivery so a CDN
+    that swaps IPs doesn't accumulate stale entries. ``None`` (a
+    DNS failure) is distinct from ``[]`` (resolution succeeded but
+    yielded no addresses, which would be unusual): the caller passes
+    through on ``None`` so a temporarily unreachable real domain
+    isn't mistaken for a malicious one — the actual ``requests.post``
+    call will surface the network error a moment later.
+    """
+    try:
+        addrinfo = socket.getaddrinfo(
+            host, None, type=socket.SOCK_STREAM,
+        )
+    except (socket.gaierror, UnicodeError):
+        return None
+    return [sockaddr[0] for _, _, _, _, sockaddr in addrinfo]
+
+
+def _is_target_safe(url: str) -> tuple[bool, str]:
+    """Return ``(safe, reason)`` for the given webhook *url*.
+
+    The ``reason`` string is empty when ``safe`` is True; otherwise
+    it explains the rejection so the operator can debug from log
+    output. The function only refuses targets whose host resolves
+    to a positively-private IP — DNS failures pass through so
+    flaky resolvers don't silently break legitimate webhook
+    deliveries.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return False, f"scheme {parsed.scheme!r} not allowed (use http/https)"
+    host = parsed.hostname
+    if not host:
+        return False, "URL has no hostname"
+    # If the hostname is a literal IP, classify it directly.
+    try:
+        literal_ip = ipaddress.ip_address(host)
+    except ValueError:
+        literal_ip = None
+    if literal_ip is not None:
+        if _is_private_ip(str(literal_ip)):
+            return False, f"host literal {host} is private/loopback"
+        return True, ""
+    addresses = _resolve_target_addresses(host)
+    if addresses is None:
+        # DNS failure — let ``requests.post`` surface the error.
+        return True, ""
+    for addr in addresses:
+        if _is_private_ip(addr):
+            return False, f"host resolves to private/loopback IP {addr}"
+    return True, ""
 
 
 def _safe_json_list(raw: str) -> list[dict]:
@@ -210,6 +305,27 @@ class WebhookDispatcher:
         return f"sha256={digest}"
 
     def _deliver(self, target: WebhookTarget, body: bytes) -> None:
+        # SSRF guard: refuse to call URLs that resolve to private,
+        # loopback, link-local, or otherwise non-public IPs unless
+        # the operator explicitly opted in. Resolution happens here
+        # rather than at config time so a target whose DNS rotates
+        # between deliveries is still vetted on every send. This
+        # does not fully mitigate DNS rebinding (the IP at delivery
+        # could differ from the one ``requests.post`` ultimately
+        # connects to), but it stops the most common foot-guns:
+        # accidental ``http://localhost/...`` typos and cloud
+        # metadata endpoints (``http://169.254.169.254``).
+        if not _allow_private_targets():
+            safe, reason = _is_target_safe(target.url)
+            if not safe:
+                logger.warning(
+                    "Webhook %s blocked by SSRF guard: %s. Set "
+                    "WEBHOOKS_ALLOW_PRIVATE_IPS=true to opt into "
+                    "private-network targets.",
+                    target.url, reason,
+                )
+                return
+
         headers = {"Content-Type": "application/json"}
         if target.secret:
             headers["X-Webhook-Signature"] = self._sign(target.secret, body)

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -108,7 +108,11 @@ def _resolve_target_addresses(host: str) -> Optional[list[str]]:
         )
     except (socket.gaierror, UnicodeError):
         return None
-    return [sockaddr[0] for _, _, _, _, sockaddr in addrinfo]
+    # Dedupe: ``getaddrinfo`` returns one entry per (family, socktype,
+    # proto) tuple, so the same IP literal can appear multiple times
+    # for a host that supports several socket flavours. The caller
+    # only cares about the unique address set.
+    return list({sockaddr[0] for _, _, _, _, sockaddr in addrinfo})
 
 
 def _is_target_safe(url: str) -> tuple[bool, str]:

--- a/app/api/ws_hub.py
+++ b/app/api/ws_hub.py
@@ -19,8 +19,21 @@ class WSHub:
     _connections: dict = {}
 
     @classmethod
-    async def connect(cls, ws: WebSocket, oid: str):
-        await ws.accept()
+    async def connect(cls, ws: WebSocket, oid: str, *,
+                      subprotocol: str | None = None):
+        """Accept *ws* and register it under *oid*.
+
+        ``subprotocol`` is echoed back to the client during the
+        WebSocket handshake. The Bearer-token-as-subprotocol pattern
+        (RFC 6455 §4.1) requires the server to confirm the chosen
+        subprotocol, otherwise the browser drops the connection
+        with a protocol-mismatch error. Callers that authenticated
+        via subprotocol must pass the same value here.
+        """
+        if subprotocol is not None:
+            await ws.accept(subprotocol=subprotocol)
+        else:
+            await ws.accept()
         cls._connections.setdefault(oid, set()).add(ws)
         logger.info(
             "WS client connected for OID=%s (total=%d)",

--- a/app/auth_utils.py
+++ b/app/auth_utils.py
@@ -1,21 +1,34 @@
 """Shared admin-token helpers.
 
 Both the match-report routes (``app.match_report``) and the custom-overlay
-admin routes (``app.admin.routes``) gate access behind the same
-``OVERLAY_MANAGER_PASSWORD`` environment variable. Centralising the
-password lookup and the Bearer/``?token=`` resolution keeps the auth
-ladder (503 → 401 → 403) consistent across both surfaces while still
-letting each caller customise the error strings shown to the operator.
+admin routes (``app.admin.routes``) gate access behind the same admin
+credential. Centralising the lookup and the Bearer/``?token=`` resolution
+keeps the auth ladder (503 → 401 → 403) consistent across both surfaces
+while still letting each caller customise the error strings shown to
+the operator.
+
+Two env vars provide the credential:
+
+* ``OVERLAY_MANAGER_PASSWORD`` — legacy plaintext value.
+* ``OVERLAY_MANAGER_PASSWORD_HASH`` — scrypt record produced by
+  :mod:`app.password_hash`. Preferred when both are set, since
+  storing a hash means the cleartext password never lands on disk.
+
+The signing key for match-report capability URLs
+(:mod:`app.match_report_signing`) still uses the plaintext password
+when one is configured — operators who migrate to the hashed form
+pin the key to the hash bytes instead, which keeps the same
+"rotating the credential invalidates outstanding URLs" property.
 """
 
 from __future__ import annotations
 
-import secrets
 from typing import Optional
 
 from fastapi import HTTPException
 
 from app.env_vars_manager import EnvVarsManager
+from app.password_hash import verify_password
 
 _DEFAULT_MISSING_TOKEN_DETAIL = (  # nosec B105
     "Authentication required. Pass Authorization: Bearer "
@@ -24,11 +37,44 @@ _DEFAULT_MISSING_TOKEN_DETAIL = (  # nosec B105
 _DEFAULT_INVALID_TOKEN_DETAIL = "Invalid token."  # nosec B105
 
 
-def get_admin_password() -> Optional[str]:
-    """Return the configured admin password, or ``None`` if unset/empty."""
+def get_admin_credential() -> Optional[str]:
+    """Return the configured admin credential, hash-preferred.
+
+    Returns ``OVERLAY_MANAGER_PASSWORD_HASH`` when set (the verifier
+    in :mod:`app.password_hash` recognises and consumes it), else the
+    legacy plaintext ``OVERLAY_MANAGER_PASSWORD``. ``None`` when
+    neither is set so callers can render a 503.
+    """
+    h = EnvVarsManager.get_env_var("OVERLAY_MANAGER_PASSWORD_HASH", None)
+    if h is not None:
+        h = str(h).strip()
+        if h:
+            return h
     raw = EnvVarsManager.get_env_var("OVERLAY_MANAGER_PASSWORD", None)
     if raw is None:
         return None
+    raw = str(raw).strip()
+    return raw or None
+
+
+def get_admin_password() -> Optional[str]:
+    """Return the legacy plaintext admin password, or ``None``.
+
+    Kept for the match-report signing flow, which uses the password
+    bytes (or the hash bytes when only the hash is configured) as
+    the HMAC key. Most callers should use :func:`get_admin_credential`
+    instead, since that wraps both forms in a verifier-friendly value.
+    """
+    raw = EnvVarsManager.get_env_var("OVERLAY_MANAGER_PASSWORD", None)
+    if raw is None:
+        # When only the hash is configured we still need a stable
+        # signing key for capability URLs, so use the hash bytes.
+        # Rotating the hash still invalidates outstanding signatures.
+        h = EnvVarsManager.get_env_var("OVERLAY_MANAGER_PASSWORD_HASH", None)
+        if h is None:
+            return None
+        h = str(h).strip()
+        return h or None
     raw = str(raw).strip()
     return raw or None
 
@@ -47,11 +93,17 @@ def require_admin_token(
     first, then from the ``token`` query parameter (when supplied).
     Raises:
 
-    * ``503`` with *missing_password_detail* — ``OVERLAY_MANAGER_PASSWORD`` unset.
+    * ``503`` with *missing_password_detail* — neither
+      ``OVERLAY_MANAGER_PASSWORD`` nor
+      ``OVERLAY_MANAGER_PASSWORD_HASH`` is set.
     * ``401`` with *missing_token_detail* — no credential provided.
     * ``403`` with *invalid_token_detail* — credential doesn't match.
+
+    When the configured credential is a hash, verification goes
+    through :func:`app.password_hash.verify_password`, which accepts
+    both hash records and plaintext (constant-time in either branch).
     """
-    expected = get_admin_password()
+    expected = get_admin_credential()
     if expected is None:
         raise HTTPException(status_code=503, detail=missing_password_detail)
     provided: Optional[str] = None
@@ -61,5 +113,5 @@ def require_admin_token(
         provided = token.strip() or None
     if provided is None:
         raise HTTPException(status_code=401, detail=missing_token_detail)
-    if not secrets.compare_digest(provided, expected):
+    if not verify_password(provided, expected):
         raise HTTPException(status_code=403, detail=invalid_token_detail)

--- a/app/auth_utils.py
+++ b/app/auth_utils.py
@@ -36,6 +36,12 @@ _DEFAULT_MISSING_TOKEN_DETAIL = (  # nosec B105
 )
 _DEFAULT_INVALID_TOKEN_DETAIL = "Invalid token."  # nosec B105
 
+# RFC 7235 §4.1: every 401 response MUST carry a WWW-Authenticate
+# header. The realm hint helps the OpenAPI UI label the credential
+# prompt and lets operators tell at a glance which ladder rejected
+# them when grepping access logs.
+_ADMIN_WWW_AUTH = {"WWW-Authenticate": 'Bearer realm="admin"'}
+
 
 def get_admin_credential() -> Optional[str]:
     """Return the configured admin credential, hash-preferred.
@@ -112,6 +118,10 @@ def require_admin_token(
     if provided is None and token:
         provided = token.strip() or None
     if provided is None:
-        raise HTTPException(status_code=401, detail=missing_token_detail)
+        raise HTTPException(
+            status_code=401,
+            detail=missing_token_detail,
+            headers=_ADMIN_WWW_AUTH,
+        )
     if not verify_password(provided, expected):
         raise HTTPException(status_code=403, detail=invalid_token_detail)

--- a/app/authentication.py
+++ b/app/authentication.py
@@ -1,29 +1,56 @@
+import hashlib
 import json
 import logging
-import secrets
+import threading
+import time
 
 from app.env_vars_manager import EnvVarsManager
 from app.oid_utils import UNO_OUTPUT_BASE_URL
+from app.password_hash import is_hashed, verify_password
 
 logger = logging.getLogger(__name__)
 
 
 class PasswordAuthenticator:
-    """Validates API keys against the ``SCOREBOARD_USERS`` env var."""
+    """Validates API keys against the ``SCOREBOARD_USERS`` env var.
+
+    Each user entry may carry either ``password`` (plaintext) or
+    ``password_hash`` (a scrypt record produced by
+    :mod:`app.password_hash`). When both are present, the hash wins —
+    operators in the middle of a migration shouldn't have to delete the
+    plaintext value to switch over.
+
+    Hash verification is intentionally slow (~50 ms per check at the
+    default scrypt parameters), so a per-process cache short-circuits
+    repeat lookups within a 60-second TTL. The cache is keyed on the
+    SHA-256 of the *provided* token so the cleartext value never sits
+    in memory beyond the request that produced it. The cache is
+    flushed automatically whenever :data:`SCOREBOARD_USERS` changes —
+    a removed user's previously-cached entry stops being trusted on
+    the very next ``_get_users`` call.
+    """
 
     _cached_users = None
     _cached_users_raw = None
+    _verify_cache: dict = {}
+    _verify_cache_lock = threading.Lock()
+    _VERIFY_CACHE_TTL = 60.0
+    _VERIFY_CACHE_MAX = 256
 
     @classmethod
     def _get_users(cls):
         """Return parsed SCOREBOARD_USERS, caching the result.
 
-        Re-parses only when the raw env var value changes.
+        Re-parses only when the raw env var value changes. Any change
+        also flushes the verify cache so a removed user can't stay
+        authenticated past the env-var rotation.
         """
         raw = EnvVarsManager.get_env_var('SCOREBOARD_USERS', None)
         if raw == cls._cached_users_raw:
             return cls._cached_users
         cls._cached_users_raw = raw
+        with cls._verify_cache_lock:
+            cls._verify_cache.clear()
         if not raw or not raw.strip():
             cls._cached_users = None
             return None
@@ -39,26 +66,79 @@ class PasswordAuthenticator:
         return passwords_json is not None and passwords_json.strip() != ''
 
     @classmethod
-    def get_username_for_api_key(cls, key: str):
-        """Return the username whose password matches *key*, or ``None``.
+    def _cache_hit(cls, key_hash: str, users: dict, now: float):
+        cached = cls._verify_cache.get(key_hash)
+        if cached is None:
+            return None
+        username, expires_at = cached
+        if expires_at <= now or username not in users:
+            # Stale entry — drop it lazily.
+            cls._verify_cache.pop(key_hash, None)
+            return None
+        return username
 
-        Uses ``secrets.compare_digest`` for each comparison so individual
-        password checks are constant-time and don't leak a matching prefix
-        via timing (see AUTHENTICATION.md §3 and PR #149 review).
+    @classmethod
+    def _cache_store(cls, key_hash: str, username: str, now: float) -> None:
+        cls._verify_cache[key_hash] = (username, now + cls._VERIFY_CACHE_TTL)
+        if len(cls._verify_cache) > cls._VERIFY_CACHE_MAX:
+            # Evict the entry with the soonest expiry — bounded
+            # memory without paying for an LRU structure.
+            soonest = min(
+                cls._verify_cache.items(), key=lambda kv: kv[1][1],
+            )
+            cls._verify_cache.pop(soonest[0], None)
+
+    @classmethod
+    def get_username_for_api_key(cls, key: str):
+        """Return the username whose credential matches *key*, or ``None``.
+
+        Verification accepts either the legacy ``password`` (plaintext)
+        or the new ``password_hash`` (scrypt) on each user entry.
+        Successful verifications are cached for
+        :data:`_VERIFY_CACHE_TTL` seconds so the per-request cost
+        stays negligible even with hashed credentials.
         """
         users = cls._get_users()
         if users is None or not isinstance(key, str):
             return None
+
+        key_hash = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        now = time.monotonic()
+        with cls._verify_cache_lock:
+            cached = cls._cache_hit(key_hash, users, now)
+            if cached is not None:
+                return cached
+
         for username, userconf in users.items():
-            password = userconf.get("password")
-            if isinstance(password, str) and secrets.compare_digest(password, key):
+            stored = userconf.get("password_hash") or userconf.get("password")
+            if not isinstance(stored, str) or not stored:
+                continue
+            if verify_password(key, stored):
+                with cls._verify_cache_lock:
+                    cls._cache_store(key_hash, username, now)
                 return username
         return None
 
     @staticmethod
     def check_api_key(key: str) -> bool:
-        """Check if *key* matches any configured user password."""
+        """Check if *key* matches any configured user credential."""
         return PasswordAuthenticator.get_username_for_api_key(key) is not None
+
+    @staticmethod
+    def has_hashed_credentials() -> bool:
+        """Return True iff at least one user entry uses ``password_hash``.
+
+        Exposed for the startup audit log: an operator who has half-
+        migrated a user list can quickly confirm which entries are
+        still on plaintext.
+        """
+        users = PasswordAuthenticator._get_users()
+        if not isinstance(users, dict):
+            return False
+        for cfg in users.values():
+            if isinstance(cfg, dict) and is_hashed(cfg.get("password_hash")):
+                return True
+        return False
 
     @staticmethod
     def compose_output(output: str) -> str:

--- a/app/authentication.py
+++ b/app/authentication.py
@@ -44,6 +44,11 @@ class PasswordAuthenticator:
         Re-parses only when the raw env var value changes. Any change
         also flushes the verify cache so a removed user can't stay
         authenticated past the env-var rotation.
+
+        Returns ``None`` for any malformed payload — invalid JSON,
+        a top-level JSON value that isn't an object, etc. — so every
+        caller can assume the cached value is either ``None`` or a
+        ``dict`` and skip the type check.
         """
         raw = EnvVarsManager.get_env_var('SCOREBOARD_USERS', None)
         if raw == cls._cached_users_raw:
@@ -55,9 +60,22 @@ class PasswordAuthenticator:
             cls._cached_users = None
             return None
         try:
-            cls._cached_users = json.loads(raw)
+            parsed = json.loads(raw)
         except json.JSONDecodeError:
             cls._cached_users = None
+            return None
+        if not isinstance(parsed, dict):
+            # ``SCOREBOARD_USERS=[]`` or any other non-object payload
+            # would later trip ``.items()`` / ``.get()``; reject at
+            # the cache boundary so callers can trust the type.
+            logger.warning(
+                "SCOREBOARD_USERS top-level JSON value must be an object; "
+                "got %s — treating as no users configured.",
+                type(parsed).__name__,
+            )
+            cls._cached_users = None
+            return None
+        cls._cached_users = parsed
         return cls._cached_users
 
     @staticmethod
@@ -99,7 +117,10 @@ class PasswordAuthenticator:
         stays negligible even with hashed credentials.
         """
         users = cls._get_users()
-        if users is None or not isinstance(key, str):
+        # ``_get_users`` already guarantees ``None`` or ``dict``, but
+        # the explicit ``isinstance`` makes the contract obvious to
+        # static analysis and future refactors.
+        if not isinstance(users, dict) or not isinstance(key, str):
             return None
 
         key_hash = hashlib.sha256(key.encode("utf-8")).hexdigest()
@@ -110,6 +131,11 @@ class PasswordAuthenticator:
                 return cached
 
         for username, userconf in users.items():
+            # A ``SCOREBOARD_USERS`` payload like ``{"alice": "secret"}``
+            # would parse fine but trip ``userconf.get`` if we trusted
+            # the dict shape. Skip non-object entries.
+            if not isinstance(userconf, dict):
+                continue
             stored = userconf.get("password_hash") or userconf.get("password")
             if not isinstance(stored, str) or not stored:
                 continue

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -16,7 +16,9 @@ from functools import lru_cache
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
+from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -370,6 +372,72 @@ def _register_spa(application: FastAPI) -> None:
     )
 
 
+def _split_csv_env(name: str) -> list[str]:
+    """Parse a comma-separated env var into a stripped, non-empty list."""
+    raw = os.environ.get(name, "")
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _maybe_register_trusted_hosts(application: FastAPI) -> None:
+    """Wire ``TrustedHostMiddleware`` when ``TRUSTED_HOSTS`` is configured.
+
+    Without this middleware, ``request.base_url`` and any link composed
+    from ``Host`` (``/links``, ``/api/config/{id}``) can be poisoned by
+    a caller setting an arbitrary ``Host`` header. Operators behind a
+    reverse proxy should set ``TRUSTED_HOSTS`` to the comma-separated
+    list of hostnames they actually serve from. Wildcards are honoured
+    by Starlette (``*.example.com`` matches any subdomain).
+
+    Default: unset → no host enforcement, backwards compatible.
+    """
+    hosts = _split_csv_env("TRUSTED_HOSTS")
+    if not hosts:
+        return
+    application.add_middleware(TrustedHostMiddleware, allowed_hosts=hosts)
+    logger.info(
+        "TrustedHostMiddleware enabled (allowed_hosts=%s)",
+        ",".join(hosts),
+    )
+
+
+def _maybe_register_cors(application: FastAPI) -> None:
+    """Wire ``CORSMiddleware`` when ``CORS_ALLOWED_ORIGINS`` is configured.
+
+    Default: unset → no CORS, same-origin only (backwards compatible —
+    the bundled SPA is served by FastAPI itself, no cross-origin
+    requests). Operators running the React UI from a separate origin
+    (a CDN, a dev server, a custom domain) populate the env var with
+    a comma-separated allow-list. ``*`` is **not** accepted to prevent
+    a copy-paste footgun on credentialed APIs; explicit hosts only.
+    """
+    origins = _split_csv_env("CORS_ALLOWED_ORIGINS")
+    if not origins:
+        return
+    if any(o == "*" for o in origins):
+        logger.error(
+            "CORS_ALLOWED_ORIGINS=* is not accepted on a credentialed "
+            "API — refusing to enable CORS. Use explicit origins."
+        )
+        return
+    application.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
+        # Authorization is the credential the browser must be allowed
+        # to forward; the rest of the list mirrors the headers the
+        # control UI sends so preflight does not strip them.
+        allow_headers=[
+            "Authorization", "Content-Type", "X-Request-ID",
+            "Sec-WebSocket-Protocol",
+        ],
+    )
+    logger.info(
+        "CORSMiddleware enabled (origins=%s)",
+        ",".join(origins),
+    )
+
+
 def create_app() -> FastAPI:
     """Build and return the FastAPI application.
 
@@ -391,14 +459,21 @@ def create_app() -> FastAPI:
     _register_spa(application)
     # Middleware ordering — Starlette wraps in reverse registration order, so
     # the LAST add_middleware ends up outermost. We want:
-    #   AuthRateLimit  (outermost — reject brute-force IPs before any work)
-    #     SecurityHeaders  (annotates every outgoing response)
-    #       GZip           (compresses after headers are decided)
-    #         RequestContext (populates contextvars for logging)
-    #           ExceptionLogging (innermost — sees raw handler exceptions)
+    #   TrustedHost     (outermost — reject Host-header attacks before
+    #                    anything else inspects request.base_url)
+    #     CORS          (browser preflight short-circuits before auth)
+    #       AuthRateLimit  (reject brute-force IPs before any work)
+    #         SecurityHeaders  (annotates every outgoing response)
+    #           GZip           (compresses after headers are decided)
+    #             RequestContext (populates contextvars for logging)
+    #               ExceptionLogging (innermost — sees raw handler exceptions)
     application.add_middleware(ExceptionLoggingMiddleware)
     application.add_middleware(RequestContextMiddleware)
     application.add_middleware(GZipMiddleware, minimum_size=1024)
     application.add_middleware(SecurityHeadersMiddleware)
     application.add_middleware(AuthRateLimitMiddleware)
+    # CORS and TrustedHost are opt-in; the helpers no-op when the env
+    # vars are unset so existing deployments are unaffected.
+    _maybe_register_cors(application)
+    _maybe_register_trusted_hosts(application)
     return application

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -30,6 +30,7 @@ from app.api.middleware.security_headers import SecurityHeadersMiddleware
 from app.app_config import get_app_title
 from app.authentication import PasswordAuthenticator
 from app.match_report import match_report_router
+from app.security_bootstrap import run_security_bootstrap
 
 logger = logging.getLogger(__name__)
 
@@ -206,13 +207,10 @@ def _register_overlay_routes(application: FastAPI) -> None:
     )
     application.include_router(overlay_router)
     logger.info("Overlay routes mounted (templates: %s)", OVERLAY_TEMPLATES_DIR)
-
-    if not os.environ.get("OVERLAY_SERVER_TOKEN", "").strip():
-        logger.warning(
-            "OVERLAY_SERVER_TOKEN is not set — overlay server mutation "
-            "and config endpoints are unauthenticated. See "
-            "AUTHENTICATION.md (F-3, F-5) for details."
-        )
+    # The bootstrap.run_security_bootstrap call earlier in create_app
+    # has already either populated OVERLAY_SERVER_TOKEN (auto-generated
+    # or persisted) or logged the fail-open opt-out warning, so no
+    # additional warning is needed here.
 
 
 def _register_static_mounts(application: FastAPI) -> None:
@@ -379,6 +377,11 @@ def create_app() -> FastAPI:
     registered before the SPA catch-all mount, otherwise the SPA consumes
     every unmatched path.
     """
+    # Resolve / mint credentials BEFORE any router is included so the
+    # auth dependencies see the same token that the rest of the app does.
+    # ``run_security_bootstrap`` mutates os.environ in place; idempotent
+    # across repeated create_app calls (e.g. in tests).
+    run_security_bootstrap()
     application = FastAPI(title="Volley Overlay Control", lifespan=_lifespan)
     _register_auth(application)
     _register_api_routes(application)

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -23,8 +23,10 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.admin import admin_page_router, admin_router
 from app.api import api_router
+from app.api.middleware.auth_rate_limit import AuthRateLimitMiddleware
 from app.api.middleware.errors import ExceptionLoggingMiddleware
 from app.api.middleware.logging import RequestContextMiddleware
+from app.api.middleware.security_headers import SecurityHeadersMiddleware
 from app.app_config import get_app_title
 from app.authentication import PasswordAuthenticator
 from app.match_report import match_report_router
@@ -384,11 +386,16 @@ def create_app() -> FastAPI:
     _register_static_mounts(application)
     _register_system_endpoints(application)
     _register_spa(application)
-    # Outermost-first: RequestContextMiddleware must wrap ExceptionLoggingMiddleware
-    # so the contextvars are populated by the time we log unhandled exceptions.
-    # GZip is registered last so it ends up outermost and compresses the final
-    # response body after observability middlewares have annotated it.
+    # Middleware ordering — Starlette wraps in reverse registration order, so
+    # the LAST add_middleware ends up outermost. We want:
+    #   AuthRateLimit  (outermost — reject brute-force IPs before any work)
+    #     SecurityHeaders  (annotates every outgoing response)
+    #       GZip           (compresses after headers are decided)
+    #         RequestContext (populates contextvars for logging)
+    #           ExceptionLogging (innermost — sees raw handler exceptions)
     application.add_middleware(ExceptionLoggingMiddleware)
     application.add_middleware(RequestContextMiddleware)
     application.add_middleware(GZipMiddleware, minimum_size=1024)
+    application.add_middleware(SecurityHeadersMiddleware)
+    application.add_middleware(AuthRateLimitMiddleware)
     return application

--- a/app/match_report.py
+++ b/app/match_report.py
@@ -75,19 +75,40 @@ def _public_delete_enabled() -> bool:
     return _is_env_enabled("MATCH_REPORT_PUBLIC_DELETE")
 
 
-def _check_access(authorization: Optional[str], token: Optional[str]) -> None:
+def _check_access(
+    authorization: Optional[str],
+    token: Optional[str],
+    *,
+    match_id: Optional[str] = None,
+    exp: Optional[str] = None,
+    sig: Optional[str] = None,
+) -> None:
     """Raise an ``HTTPException`` unless the caller is allowed to read.
 
     Order of precedence:
       1. ``MATCH_REPORT_PUBLIC=true`` — open access (matches the
          existing ``/overlay/{output_key}`` model);
-      2. otherwise, ``OVERLAY_MANAGER_PASSWORD`` must be set and
-         provided via Bearer header or ``?token=`` query;
-      3. when neither is configured, return 503 to make
-         misconfiguration loud rather than silently public.
+      2. a valid HMAC signature on ``(match_id, exp)`` (capability URL
+         minted by the admin endpoint, no password in the link);
+      3. otherwise, ``OVERLAY_MANAGER_PASSWORD`` must be set and
+         provided via Bearer header or ``?token=`` query (legacy);
+      4. when neither password nor signature works and no public-read
+         mode is enabled, return 503 to make misconfiguration loud
+         rather than silently public.
     """
     if _public_mode_enabled():
         return
+    # Capability URL — no need for the password to be on the wire.
+    # Signed URLs are minted by the admin endpoint and embed an
+    # ``exp`` that lets the operator share a short-lived link
+    # without leaking ``OVERLAY_MANAGER_PASSWORD``.
+    if match_id is not None and (exp or sig):
+        from app.match_report_signing import verify_signed_query
+        if verify_signed_query(match_id, exp, sig):
+            return
+        # Falling through is intentional: an invalid sig should not
+        # leak via a different error than an invalid token, so the
+        # require_admin_token call below produces the canonical 401/403.
     _require_admin_token(
         authorization, token,
         # Bandit B106 false positive: this is the error message shown
@@ -1376,9 +1397,15 @@ async def match_report(
     token: Optional[str] = Query(default=None,
                                  description="OVERLAY_MANAGER_PASSWORD; "
                                              "alternative to Bearer header."),
+    exp: Optional[str] = Query(default=None,
+                               description="Signed-URL expiry (unix seconds)."),
+    sig: Optional[str] = Query(default=None,
+                               description="Signed-URL HMAC-SHA256 hex digest."),
     accept_language: Optional[str] = Header(default=None),
 ):
-    _check_access(authorization, token)
+    _check_access(
+        authorization, token, match_id=match_id, exp=exp, sig=sig,
+    )
     payload = match_archive.load_match(match_id)
     if payload is None:
         raise HTTPException(status_code=404, detail="Match not found.")
@@ -1804,6 +1831,11 @@ async def matches_index(
                                  description="OVERLAY_MANAGER_PASSWORD; "
                                              "alternative to Bearer header."),
 ):
+    # Signed-URL auth deliberately not honoured on the index — a
+    # signature pins one specific match_id; the index would need a
+    # separate "list-all" capability that's a different feature
+    # (and intentionally not provided yet, since the index gives
+    # destructive access via per-row Delete).
     _check_access(authorization, token)
     summaries = match_archive.list_matches(oid=oid)
 

--- a/app/match_report_signing.py
+++ b/app/match_report_signing.py
@@ -44,11 +44,6 @@ from app.auth_utils import get_admin_password
 logger = logging.getLogger(__name__)
 
 
-# ``urlsafe_b64`` would shave a few bytes off the URL but operators
-# tend to copy-paste these into chat tools that mangle ``-`` / ``_`` in
-# unpredictable ways. Hex is uglier but bulletproof.
-_SIG_ENCODING = "hex"
-
 # Cap the TTL the admin endpoint will mint. Operators who want a
 # permanent share-link should set ``MATCH_REPORT_PUBLIC=true`` and
 # share the bare URL — that's the documented model. The cap stops

--- a/app/match_report_signing.py
+++ b/app/match_report_signing.py
@@ -1,0 +1,151 @@
+"""HMAC-signed URLs for ``/match/{match_id}/report``.
+
+The legacy access mechanism for the gated match-report is
+``?token=<OVERLAY_MANAGER_PASSWORD>``: the operator pastes the
+report URL into a chat tool and the URL contains the actual admin
+password. Any browser bookmark, server access log, or HTTP
+``Referer`` header that touches that URL leaks the credential.
+
+This module replaces that flow with capability-style signed URLs.
+The operator mints a per-match URL via the new admin endpoint
+``POST /api/v1/admin/match/{match_id}/sign-url``; the resulting URL
+carries an ``exp`` (expiry) and ``sig`` (HMAC-SHA256) parameter
+instead of the raw password. Anyone who holds the URL can read the
+report until ``exp`` passes; the admin password itself never leaves
+the server.
+
+The signing key is derived from ``OVERLAY_MANAGER_PASSWORD`` so the
+deployment story stays a single secret. Rotating the admin password
+invalidates every outstanding signed URL — that's the desired
+behaviour, since a rotation is usually motivated by a compromise.
+
+Format
+------
+
+* Query parameters: ``?exp=<unix_seconds>&sig=<hex>``.
+* Signature payload: ``f"{match_id}|{exp}".encode("utf-8")``.
+* Algorithm: HMAC-SHA256, lowercase hex digest.
+
+The verifier checks ``exp`` first (cheap reject for stale links)
+and only then computes the HMAC, using ``hmac.compare_digest`` to
+avoid a timing oracle.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import time
+from typing import Optional
+
+from app.auth_utils import get_admin_password
+
+logger = logging.getLogger(__name__)
+
+
+# ``urlsafe_b64`` would shave a few bytes off the URL but operators
+# tend to copy-paste these into chat tools that mangle ``-`` / ``_`` in
+# unpredictable ways. Hex is uglier but bulletproof.
+_SIG_ENCODING = "hex"
+
+# Cap the TTL the admin endpoint will mint. Operators who want a
+# permanent share-link should set ``MATCH_REPORT_PUBLIC=true`` and
+# share the bare URL — that's the documented model. The cap stops
+# someone from accidentally minting a year-long link in chat.
+DEFAULT_TTL_SECONDS = 24 * 60 * 60        # 1 day
+MAX_TTL_SECONDS = 30 * 24 * 60 * 60       # 30 days
+MIN_TTL_SECONDS = 60                      # 1 minute
+
+
+def _signing_key() -> Optional[bytes]:
+    """Return the HMAC key derived from ``OVERLAY_MANAGER_PASSWORD``.
+
+    Returns ``None`` when the password is unset — callers should fall
+    back to whatever auth mode is configured (typically a 503 in the
+    consuming endpoint).
+    """
+    pw = get_admin_password()
+    if pw is None:
+        return None
+    return pw.encode("utf-8")
+
+
+def _digest(match_id: str, exp_unix: int) -> Optional[str]:
+    key = _signing_key()
+    if key is None:
+        return None
+    msg = f"{match_id}|{exp_unix}".encode("utf-8")
+    return hmac.new(key, msg, hashlib.sha256).hexdigest()
+
+
+def clamp_ttl(ttl_seconds: Optional[int]) -> int:
+    """Bound *ttl_seconds* to ``[MIN_TTL_SECONDS, MAX_TTL_SECONDS]``.
+
+    ``None`` and non-positive values fall back to ``DEFAULT_TTL_SECONDS``.
+    """
+    if ttl_seconds is None:
+        return DEFAULT_TTL_SECONDS
+    try:
+        ttl = int(ttl_seconds)
+    except (TypeError, ValueError):
+        return DEFAULT_TTL_SECONDS
+    if ttl <= 0:
+        return DEFAULT_TTL_SECONDS
+    return max(MIN_TTL_SECONDS, min(MAX_TTL_SECONDS, ttl))
+
+
+def make_signed_query(
+    match_id: str,
+    ttl_seconds: Optional[int] = None,
+    *,
+    now: Optional[float] = None,
+) -> Optional[dict]:
+    """Return ``{exp, sig, expires_at}`` for the signed URL, or ``None``.
+
+    ``None`` means signing is unavailable because the admin password
+    is unset; callers translate that to a 503.
+
+    *now* is a test seam for deterministic expiry; production callers
+    should leave it as ``None``.
+    """
+    ttl = clamp_ttl(ttl_seconds)
+    base_now = time.time() if now is None else float(now)
+    exp = int(base_now) + ttl
+    sig = _digest(match_id, exp)
+    if sig is None:
+        return None
+    return {"exp": exp, "sig": sig, "expires_at": exp}
+
+
+def verify_signed_query(
+    match_id: str,
+    exp: object,
+    sig: object,
+    *,
+    now: Optional[float] = None,
+) -> bool:
+    """Return ``True`` iff ``(exp, sig)`` is a valid signature for *match_id*.
+
+    Both arguments come from raw query-string parsing so they may be
+    ``None`` or arbitrary strings — the function tolerates everything
+    and just returns ``False`` on malformed input.
+    """
+    if not isinstance(sig, str) or not sig:
+        return False
+    if isinstance(exp, str):
+        try:
+            exp_int = int(exp)
+        except ValueError:
+            return False
+    elif isinstance(exp, int):
+        exp_int = exp
+    else:
+        return False
+    base_now = time.time() if now is None else float(now)
+    if exp_int <= int(base_now):
+        return False
+    expected = _digest(match_id, exp_int)
+    if expected is None:
+        return False
+    return hmac.compare_digest(sig, expected)

--- a/app/overlay/routes.py
+++ b/app/overlay/routes.py
@@ -73,6 +73,11 @@ def require_overlay_server_token(authorization: str = Header(None)) -> None:
         raise HTTPException(
             status_code=401,
             detail="Missing overlay server token. Use 'Authorization: Bearer <token>'.",
+            # RFC 7235 §4.1: 401 responses must advertise the auth
+            # scheme. ``realm="overlay-server"`` distinguishes this
+            # ladder from the scoreboard and admin ones in client
+            # / proxy logs.
+            headers={"WWW-Authenticate": 'Bearer realm="overlay-server"'},
         )
     provided = authorization.removeprefix("Bearer ").strip()
     if not verify_password(provided, expected):

--- a/app/overlay/routes.py
+++ b/app/overlay/routes.py
@@ -39,10 +39,14 @@ def _get_overlay_server_token() -> Optional[str]:
 def require_overlay_server_token(authorization: str = Header(None)) -> None:
     """Gate overlay-server mutation / leaky read endpoints.
 
-    When ``OVERLAY_SERVER_TOKEN`` is unset the check is a no-op so
-    existing deployments keep working (with a startup warning; see
-    ``AUTHENTICATION.md`` F-3 and F-5). When the env var is set, the
-    request must include ``Authorization: Bearer <token>``.
+    ``OVERLAY_SERVER_TOKEN`` is normally populated at startup by
+    :func:`app.security_bootstrap.ensure_overlay_server_token` (auto-
+    generated on first run, persisted to ``data/.overlay_server_token``).
+    When the env var is set the request must include
+    ``Authorization: Bearer <token>``. The dependency stays a no-op
+    only when the operator explicitly opted into legacy fail-open
+    via ``OVERLAY_SERVER_TOKEN_DISABLED=true`` — see
+    ``AUTHENTICATION.md`` §5 for the migration notes.
     """
     token = _get_overlay_server_token()
     if token is None:

--- a/app/overlay/routes.py
+++ b/app/overlay/routes.py
@@ -9,7 +9,6 @@ import json
 import logging
 import os
 import re
-import secrets
 import time
 from typing import Any, Dict, Optional
 
@@ -23,12 +22,25 @@ from starlette.concurrency import run_in_threadpool
 from app.admin.routes import require_admin
 from app.env_vars_manager import EnvVarsManager
 from app.overlay.state_store import OverlayStateStore
+from app.password_hash import verify_password
 
 logger = logging.getLogger(__name__)
 
 
-def _get_overlay_server_token() -> Optional[str]:
-    """Return the configured overlay-server token (or None if unset)."""
+def _get_overlay_server_credential() -> Optional[str]:
+    """Return the configured overlay-server credential, hash-preferred.
+
+    ``OVERLAY_SERVER_TOKEN_HASH`` (a scrypt record from
+    :mod:`app.password_hash`) wins over the legacy plaintext
+    ``OVERLAY_SERVER_TOKEN`` when both are set, so an operator
+    migrating to hashed credentials does not have to delete the
+    plaintext to switch over. Returns ``None`` when neither is set.
+    """
+    h = EnvVarsManager.get_env_var("OVERLAY_SERVER_TOKEN_HASH", None)
+    if h is not None:
+        h = str(h).strip()
+        if h:
+            return h
     token = EnvVarsManager.get_env_var("OVERLAY_SERVER_TOKEN", None)
     if token is None:
         return None
@@ -42,14 +54,20 @@ def require_overlay_server_token(authorization: str = Header(None)) -> None:
     ``OVERLAY_SERVER_TOKEN`` is normally populated at startup by
     :func:`app.security_bootstrap.ensure_overlay_server_token` (auto-
     generated on first run, persisted to ``data/.overlay_server_token``).
-    When the env var is set the request must include
-    ``Authorization: Bearer <token>``. The dependency stays a no-op
-    only when the operator explicitly opted into legacy fail-open
-    via ``OVERLAY_SERVER_TOKEN_DISABLED=true`` — see
+    Operators who prefer hash-only configuration can set
+    ``OVERLAY_SERVER_TOKEN_HASH`` instead — the bootstrap detects
+    that and skips auto-generation.
+
+    When either credential is set the request must include
+    ``Authorization: Bearer <token>``; verification goes through
+    :func:`app.password_hash.verify_password` which accepts plaintext
+    or hash records (constant-time in either branch). The dependency
+    stays a no-op only when the operator explicitly opted into legacy
+    fail-open via ``OVERLAY_SERVER_TOKEN_DISABLED=true`` — see
     ``AUTHENTICATION.md`` §5 for the migration notes.
     """
-    token = _get_overlay_server_token()
-    if token is None:
+    expected = _get_overlay_server_credential()
+    if expected is None:
         return
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(
@@ -57,7 +75,7 @@ def require_overlay_server_token(authorization: str = Header(None)) -> None:
             detail="Missing overlay server token. Use 'Authorization: Bearer <token>'.",
         )
     provided = authorization.removeprefix("Bearer ").strip()
-    if not secrets.compare_digest(provided, token):
+    if not verify_password(provided, expected):
         raise HTTPException(status_code=403, detail="Invalid overlay server token.")
 
 

--- a/app/password_hash.py
+++ b/app/password_hash.py
@@ -1,0 +1,247 @@
+"""Credential hashing using ``hashlib.scrypt`` (zero dependencies).
+
+The original auth ladder stored every credential as plaintext in
+``.env``/compose env vars. ``secrets.compare_digest`` made the
+*comparison* constant-time, but the source value still sat in cleartext
+on disk where any operator with shell access could read it. This
+module offers a hashed alternative without pulling in a new dependency.
+
+Format
+------
+
+A hash string looks like::
+
+    scrypt$n=16384,r=8,p=1$<salt-hex>$<hash-hex>
+
+* ``n``, ``r``, ``p`` are the standard scrypt parameters.
+* ``salt`` is 16 random bytes, lowercase hex (32 chars).
+* ``hash`` is the 32-byte derived key, lowercase hex (64 chars).
+
+The format is deliberately PHC-flavoured but not strictly compliant —
+parsers in other languages should be straightforward to write. The
+fields are bound together by the ``$``-delimited frame so a malformed
+record fails closed (``verify_password`` returns ``False`` rather than
+raising).
+
+Why scrypt
+----------
+
+* It ships in the Python standard library — no new wheel to vet, no
+  cross-platform build of a C extension.
+* It is memory-hard, which makes mass GPU brute-force impractical at
+  the chosen parameters (~16 MiB working set per guess at ``n=16384``).
+* The verification cost is tunable: operators who want stronger hashes
+  bump ``n`` when minting; verification reads the parameters from the
+  hash itself, so existing records keep working.
+
+CLI
+---
+
+``python -m app.password_hash`` prompts for a password (no echo) and
+prints the hash string. Operators paste that into ``SCOREBOARD_USERS``,
+``OVERLAY_MANAGER_PASSWORD_HASH``, or ``OVERLAY_SERVER_TOKEN_HASH``.
+"""
+
+from __future__ import annotations
+
+import getpass
+import hashlib
+import hmac
+import logging
+import re
+import secrets
+import sys
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+# scrypt parameters. Tunable via the CLI; the verifier reads whatever
+# values the hash record carries, so existing hashes keep working when
+# the defaults change.
+DEFAULT_N = 1 << 14   # 16384 — light, ~50 ms on a modern CPU
+DEFAULT_R = 8
+DEFAULT_P = 1
+_SALT_BYTES = 16
+_HASH_BYTES = 32
+
+# scrypt's memory footprint is ~128 * n * r bytes. At the defaults
+# (n=16384, r=8) that's 16 MiB per hash. ``hashlib.scrypt`` enforces
+# a ``maxmem`` ceiling so a misconfigured ``n`` cannot wedge the
+# server with a multi-GiB allocation. We size the cap ten-fold above
+# the default so operators can bump ``n`` to ~131072 without recompiling.
+_SCRYPT_MAXMEM = 10 * (128 * (1 << 17) * 8)
+
+_HASH_PREFIX = "scrypt$"
+# ``n`` must be a power of 2 ≥ 2; cap at 2^20 so a malformed hash with
+# ``n=10**12`` cannot cause a multi-GiB allocation before maxmem fires.
+_MAX_N_LOG2 = 20
+_HASH_RE = re.compile(
+    r"^scrypt\$"
+    r"n=(?P<n>\d+),r=(?P<r>\d+),p=(?P<p>\d+)\$"
+    r"(?P<salt>[0-9a-f]+)\$"
+    r"(?P<hash>[0-9a-f]+)$"
+)
+
+
+def is_hashed(value: object) -> bool:
+    """Return True if *value* looks like a hash record produced by this module.
+
+    A loose check — full validation happens inside :func:`verify_password`,
+    which fails closed on any structural problem.
+    """
+    return isinstance(value, str) and value.startswith(_HASH_PREFIX)
+
+
+def _is_power_of_two(n: int) -> bool:
+    return n > 1 and (n & (n - 1)) == 0
+
+
+def hash_password(
+    password: str,
+    *,
+    n: int = DEFAULT_N,
+    r: int = DEFAULT_R,
+    p: int = DEFAULT_P,
+    salt: Optional[bytes] = None,
+) -> str:
+    """Return a freshly-salted hash string for *password*.
+
+    Parameters mirror scrypt's; sensible defaults are documented above.
+    *salt* is exposed only for tests — production callers leave it
+    ``None`` so a CSPRNG-sourced salt is generated.
+    """
+    if not isinstance(password, str):
+        raise TypeError("password must be str")
+    if not password:
+        raise ValueError("password must be non-empty")
+    if not _is_power_of_two(n):
+        raise ValueError("scrypt n must be a power of 2 ≥ 2")
+    if r < 1 or p < 1:
+        raise ValueError("scrypt r and p must be ≥ 1")
+
+    salt_bytes = salt if salt is not None else secrets.token_bytes(_SALT_BYTES)
+    derived = hashlib.scrypt(
+        password.encode("utf-8"),
+        salt=salt_bytes,
+        n=n, r=r, p=p,
+        dklen=_HASH_BYTES,
+        maxmem=_SCRYPT_MAXMEM,
+    )
+    return (
+        f"scrypt$n={n},r={r},p={p}$"
+        f"{salt_bytes.hex()}${derived.hex()}"
+    )
+
+
+def verify_password(provided: str, stored: str) -> bool:
+    """Return True iff *provided* matches *stored*.
+
+    *stored* may be either a hash record produced by :func:`hash_password`
+    or a plaintext credential (for backwards compatibility with
+    deployments that have not migrated yet). Both paths are
+    constant-time:
+
+    * The hash branch uses :func:`hmac.compare_digest` over the derived
+      key bytes (scrypt itself runs in constant time for fixed
+      parameters).
+    * The plaintext branch uses :func:`secrets.compare_digest` directly.
+
+    Malformed hash records or any internal exception fail closed —
+    the function returns ``False`` rather than raising so callers can
+    treat it as a black-box auth check.
+    """
+    if not isinstance(provided, str) or not isinstance(stored, str):
+        return False
+    if not is_hashed(stored):
+        return secrets.compare_digest(provided, stored)
+    match = _HASH_RE.match(stored)
+    if match is None:
+        return False
+    try:
+        n = int(match.group("n"))
+        r = int(match.group("r"))
+        p = int(match.group("p"))
+        salt = bytes.fromhex(match.group("salt"))
+        expected = bytes.fromhex(match.group("hash"))
+    except ValueError:
+        return False
+    if not _is_power_of_two(n) or n.bit_length() - 1 > _MAX_N_LOG2:
+        return False
+    if r < 1 or p < 1:
+        return False
+    if not salt or not expected:
+        return False
+    try:
+        derived = hashlib.scrypt(
+            provided.encode("utf-8"),
+            salt=salt,
+            n=n, r=r, p=p,
+            dklen=len(expected),
+            maxmem=_SCRYPT_MAXMEM,
+        )
+    except (ValueError, MemoryError):
+        # Either the requested params exceeded ``maxmem`` (malformed
+        # record) or the platform refused to allocate. Treat as a
+        # mismatch — never raise out of the verifier.
+        return False
+    return hmac.compare_digest(derived, expected)
+
+
+# ---------------------------------------------------------------------------
+# CLI helper
+# ---------------------------------------------------------------------------
+
+
+def _cli(argv: list[str]) -> int:
+    """Mint a hash from interactive input and print to stdout.
+
+    Usage::
+
+        python -m app.password_hash               # prompts twice
+        python -m app.password_hash --n 32768     # heavier hash
+        echo -n 'pw' | python -m app.password_hash --stdin
+
+    Operators paste the printed line into ``SCOREBOARD_USERS``,
+    ``OVERLAY_MANAGER_PASSWORD_HASH``, or ``OVERLAY_SERVER_TOKEN_HASH``.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m app.password_hash",
+        description="Mint a scrypt-hashed credential string.",
+    )
+    parser.add_argument("--n", type=int, default=DEFAULT_N,
+                        help=f"scrypt N (power of 2; default {DEFAULT_N})")
+    parser.add_argument("--r", type=int, default=DEFAULT_R,
+                        help=f"scrypt r (default {DEFAULT_R})")
+    parser.add_argument("--p", type=int, default=DEFAULT_P,
+                        help=f"scrypt p (default {DEFAULT_P})")
+    parser.add_argument(
+        "--stdin", action="store_true",
+        help="Read the password from stdin (no terminal prompt).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.stdin:
+        password = sys.stdin.read().rstrip("\n")
+    else:
+        password = getpass.getpass("Password: ")
+        again = getpass.getpass("Confirm:  ")
+        if password != again:
+            print("Passwords do not match.", file=sys.stderr)
+            return 2
+    if not password:
+        print("Password must be non-empty.", file=sys.stderr)
+        return 2
+    try:
+        record = hash_password(password, n=args.n, r=args.r, p=args.p)
+    except ValueError as exc:
+        print(f"Invalid parameters: {exc}", file=sys.stderr)
+        return 2
+    print(record)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised via subprocess in tests
+    sys.exit(_cli(sys.argv[1:]))

--- a/app/security_bootstrap.py
+++ b/app/security_bootstrap.py
@@ -1,0 +1,224 @@
+"""Startup security bootstrap — fail-closed defaults for credentials.
+
+The original posture was "fail-open if unset": ``OVERLAY_SERVER_TOKEN``
+and ``SCOREBOARD_USERS`` would both default to "no auth required" with
+only a startup log line warning the operator. That is hostile to the
+common ``docker compose up`` install where the operator never reads
+the warning, and it leaves the seven mutation endpoints on the
+overlay router (``POST /api/state/{id}``, ``/create/overlay``,
+``/delete/overlay``, ``/api/raw_config``, ``/api/theme``) open to
+anyone who can reach the port.
+
+This module flips that default for ``OVERLAY_SERVER_TOKEN`` only —
+``SCOREBOARD_USERS`` is left fail-open because it gates user-level
+auth and forcing every "Friday-night team" deployment into a mandatory
+account model would be a real downgrade. We log loudly when it's
+unset instead.
+
+For ``OVERLAY_SERVER_TOKEN``, the resolution order at startup is:
+
+1. ``OVERLAY_SERVER_TOKEN_DISABLED=true`` → keep legacy fail-open.
+   Logs a critical warning so the choice is visible in the startup
+   tail. Useful for trusted-LAN deployments and local debugging.
+2. ``OVERLAY_SERVER_TOKEN=<value>`` already set → honour it.
+3. ``data/.overlay_server_token`` exists on disk → load it. This
+   keeps the auto-generated token stable across restarts so an
+   external ``CustomOverlayBackend`` peer doesn't lose its
+   credential every time the container reboots.
+4. None of the above → generate ``secrets.token_urlsafe(32)``,
+   persist with mode ``0o600`` to the data dir, and inject into
+   ``os.environ`` so the rest of the app picks it up via
+   ``EnvVarsManager.get_env_var``. Log the path once at INFO so
+   operators can capture the value (the log line itself does not
+   contain the token).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+import stat
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+_TOKEN_FILENAME = ".overlay_server_token"
+_TOKEN_BYTES = 32  # → 43-char URL-safe string
+
+_TRUTHY = ("1", "true", "t", "yes", "on")
+
+
+def _is_truthy_env(value: Optional[str]) -> bool:
+    return isinstance(value, str) and value.strip().lower() in _TRUTHY
+
+
+def _data_dir() -> str:
+    """Return the data directory used by the rest of the app.
+
+    Re-derives the path the same way :func:`app.api.action_log._data_dir`
+    does (``<repo>/data``) instead of importing it, because the bootstrap
+    runs before the API package is fully wired and we want to avoid
+    pulling in optional dependencies just to read a path.
+    """
+    here = Path(__file__).resolve().parent
+    return str(here.parent / "data")
+
+
+def _token_path() -> Path:
+    return Path(_data_dir()) / _TOKEN_FILENAME
+
+
+def _read_persisted_token(path: Path) -> Optional[str]:
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        logger.warning(
+            "Could not read persisted overlay-server token from %s: %s",
+            path, exc,
+        )
+        return None
+    return text or None
+
+
+def _write_persisted_token(path: Path, token: str) -> bool:
+    """Atomically write *token* to *path* with ``0o600`` permissions.
+
+    Returns ``True`` on success, ``False`` on any I/O error. Failures
+    are logged but never raise — the in-memory token still works for
+    this process; we just lose persistence across restart.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Write to a temp file first so a crash mid-write cannot leave a
+        # truncated token on disk. ``os.replace`` is atomic on POSIX.
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        # Write with restrictive perms from the start by opening through
+        # ``os.open`` with O_CREAT + O_EXCL + mode 0o600.
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        # Some platforms ignore the mode arg on subsequent opens, so
+        # chmod after-the-fact as a belt-and-suspenders.
+        fd = os.open(str(tmp), flags, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(token)
+        except BaseException:
+            try:
+                os.unlink(str(tmp))
+            except OSError:
+                pass
+            raise
+        try:
+            os.chmod(str(tmp), stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+        os.replace(str(tmp), str(path))
+    except OSError as exc:
+        logger.warning(
+            "Could not persist overlay-server token to %s: %s",
+            path, exc,
+        )
+        return False
+    return True
+
+
+def ensure_overlay_server_token() -> Optional[str]:
+    """Resolve / mint / persist the overlay-server token.
+
+    Returns the active token string, or ``None`` when fail-open mode is
+    explicitly enabled. Mutates ``os.environ`` so downstream callers
+    that read via :class:`EnvVarsManager` pick the value up
+    transparently.
+    """
+    if _is_truthy_env(os.environ.get("OVERLAY_SERVER_TOKEN_DISABLED")):
+        # Operator opted into the legacy fail-open behaviour. Make the
+        # choice loud so it shows up in the startup tail.
+        logger.critical(
+            "OVERLAY_SERVER_TOKEN_DISABLED=true — overlay server "
+            "mutation/config endpoints are UNAUTHENTICATED. Anyone "
+            "who can reach this port can mutate overlay state. Set "
+            "OVERLAY_SERVER_TOKEN to enable authentication."
+        )
+        return None
+
+    existing = (os.environ.get("OVERLAY_SERVER_TOKEN") or "").strip()
+    if existing:
+        return existing
+
+    path = _token_path()
+    persisted = _read_persisted_token(path)
+    if persisted:
+        os.environ["OVERLAY_SERVER_TOKEN"] = persisted
+        logger.info(
+            "Loaded persisted OVERLAY_SERVER_TOKEN from %s "
+            "(set OVERLAY_SERVER_TOKEN env var to override).",
+            path,
+        )
+        return persisted
+
+    new_token = secrets.token_urlsafe(_TOKEN_BYTES)
+    persisted_ok = _write_persisted_token(path, new_token)
+    os.environ["OVERLAY_SERVER_TOKEN"] = new_token
+    if persisted_ok:
+        logger.warning(
+            "Auto-generated OVERLAY_SERVER_TOKEN and persisted to %s. "
+            "External CustomOverlayBackend peers must use the same "
+            "value (read it from the file or set OVERLAY_SERVER_TOKEN "
+            "explicitly). Set OVERLAY_SERVER_TOKEN_DISABLED=true to "
+            "opt out and run unauthenticated.",
+            path,
+        )
+    else:
+        logger.warning(
+            "Auto-generated OVERLAY_SERVER_TOKEN but could not persist "
+            "to disk; the token will rotate on every restart. Set "
+            "OVERLAY_SERVER_TOKEN explicitly to fix."
+        )
+    return new_token
+
+
+def warn_if_open_scoreboard() -> None:
+    """Emit a loud startup warning when the scoreboard API is unauthenticated.
+
+    Unlike :func:`ensure_overlay_server_token`, we do not auto-generate
+    user records: ``SCOREBOARD_USERS`` is a JSON map of user→password
+    pairs and forcing one onto every fresh install would lock the
+    operator out of their own scoreboard. The right posture is "loud
+    warning by default, opt-out for trusted LANs".
+    """
+    raw = (os.environ.get("SCOREBOARD_USERS") or "").strip()
+    if raw:
+        return
+    if _is_truthy_env(os.environ.get("SCOREBOARD_USERS_DISABLED")):
+        # Same opt-out shape as the overlay token — operator
+        # acknowledged the open posture, no need to warn again.
+        return
+    logger.warning(
+        "SCOREBOARD_USERS is not set — every /api/v1/* scoreboard "
+        "endpoint is reachable without authentication. Configure "
+        "SCOREBOARD_USERS as a JSON map of {username: {password: ...}} "
+        "to require Bearer auth, or set SCOREBOARD_USERS_DISABLED=true "
+        "to silence this warning on trusted-LAN deployments."
+    )
+
+
+def run_security_bootstrap() -> None:
+    """Entry point invoked from :func:`app.bootstrap.create_app`.
+
+    Centralises the calls so future credential bootstraps (admin
+    password rotation, hashed-credential migration) only need a single
+    hook. Best-effort: a failure here logs but does not block startup,
+    because a missing token is not worse than a broken process.
+    """
+    try:
+        ensure_overlay_server_token()
+    except Exception:
+        logger.exception("ensure_overlay_server_token failed")
+    try:
+        warn_if_open_scoreboard()
+    except Exception:
+        logger.exception("warn_if_open_scoreboard failed")

--- a/app/security_bootstrap.py
+++ b/app/security_bootstrap.py
@@ -130,9 +130,11 @@ def ensure_overlay_server_token() -> Optional[str]:
     """Resolve / mint / persist the overlay-server token.
 
     Returns the active token string, or ``None`` when fail-open mode is
-    explicitly enabled. Mutates ``os.environ`` so downstream callers
-    that read via :class:`EnvVarsManager` pick the value up
-    transparently.
+    explicitly enabled or when the operator configured a hashed
+    credential (``OVERLAY_SERVER_TOKEN_HASH``) — in the hashed case the
+    plaintext lives only on the peer side, never on this server.
+    Mutates ``os.environ`` so downstream callers that read via
+    :class:`EnvVarsManager` pick the value up transparently.
     """
     if _is_truthy_env(os.environ.get("OVERLAY_SERVER_TOKEN_DISABLED")):
         # Operator opted into the legacy fail-open behaviour. Make the
@@ -141,7 +143,20 @@ def ensure_overlay_server_token() -> Optional[str]:
             "OVERLAY_SERVER_TOKEN_DISABLED=true — overlay server "
             "mutation/config endpoints are UNAUTHENTICATED. Anyone "
             "who can reach this port can mutate overlay state. Set "
-            "OVERLAY_SERVER_TOKEN to enable authentication."
+            "OVERLAY_SERVER_TOKEN or OVERLAY_SERVER_TOKEN_HASH to "
+            "enable authentication."
+        )
+        return None
+
+    # Hash-only configuration: the operator has set
+    # OVERLAY_SERVER_TOKEN_HASH and intentionally not set the
+    # plaintext. Auth is enforced (the verifier reads the hash) but
+    # we never store cleartext on this server. Skip auto-generation.
+    hashed = (os.environ.get("OVERLAY_SERVER_TOKEN_HASH") or "").strip()
+    if hashed:
+        logger.info(
+            "OVERLAY_SERVER_TOKEN_HASH is set — verifying against the "
+            "hash; auto-generated plaintext will not be persisted."
         )
         return None
 

--- a/app/security_bootstrap.py
+++ b/app/security_bootstrap.py
@@ -97,8 +97,10 @@ def _write_persisted_token(path: Path, token: str) -> bool:
         # Write to a temp file first so a crash mid-write cannot leave a
         # truncated token on disk. ``os.replace`` is atomic on POSIX.
         tmp = path.with_suffix(path.suffix + ".tmp")
-        # Write with restrictive perms from the start by opening through
-        # ``os.open`` with O_CREAT + O_EXCL + mode 0o600.
+        # Open with restrictive perms from the start by going through
+        # ``os.open(..., O_CREAT | O_TRUNC, 0o600)``. ``O_EXCL`` is
+        # deliberately not set: a stale ``.tmp`` from a crashed
+        # previous run should be overwritten, not block startup.
         flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
         # Some platforms ignore the mode arg on subsequent opens, so
         # chmod after-the-fact as a belt-and-suspenders.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,12 +32,16 @@ services:
       - PREDEFINED_OVERLAYS=${PREDEFINED_OVERLAYS:-}
       - HIDE_CUSTOM_OVERLAY_WHEN_PREDEFINED=${HIDE_CUSTOM_OVERLAY_WHEN_PREDEFINED:-}
       - OVERLAY_MANAGER_PASSWORD=${OVERLAY_MANAGER_PASSWORD:-} #Optional: unlocks the /manage admin page
+      - OVERLAY_MANAGER_PASSWORD_HASH=${OVERLAY_MANAGER_PASSWORD_HASH:-} #Optional: scrypt-hashed alternative (mint via `python -m app.password_hash`)
       # OVERLAY_SERVER_TOKEN is auto-generated and persisted to data/.overlay_server_token
       # on first start. Set it explicitly here to override (e.g. when an external
       # CustomOverlayBackend peer must use the same value), or set
-      # OVERLAY_SERVER_TOKEN_DISABLED=true to opt back into legacy unauthenticated
-      # behaviour (only safe on a trusted LAN).
+      # OVERLAY_SERVER_TOKEN_HASH for a hash-only deployment that stores zero
+      # cleartext on this server (peer still needs the plaintext token).
+      # Set OVERLAY_SERVER_TOKEN_DISABLED=true to opt back into legacy
+      # unauthenticated behaviour (only safe on a trusted LAN).
       - OVERLAY_SERVER_TOKEN=${OVERLAY_SERVER_TOKEN:-}
+      - OVERLAY_SERVER_TOKEN_HASH=${OVERLAY_SERVER_TOKEN_HASH:-} #Optional: scrypt-hashed alternative
       - OVERLAY_SERVER_TOKEN_DISABLED=${OVERLAY_SERVER_TOKEN_DISABLED:-} #Optional: opt out of overlay-server auth
       - SCOREBOARD_USERS_DISABLED=${SCOREBOARD_USERS_DISABLED:-} #Optional: silence the open-API startup warning
       - MATCH_REPORT_PUBLIC=${MATCH_REPORT_PUBLIC:-false} #Optional: open match-report routes to anonymous reads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,14 @@ services:
       - PREDEFINED_OVERLAYS=${PREDEFINED_OVERLAYS:-}
       - HIDE_CUSTOM_OVERLAY_WHEN_PREDEFINED=${HIDE_CUSTOM_OVERLAY_WHEN_PREDEFINED:-}
       - OVERLAY_MANAGER_PASSWORD=${OVERLAY_MANAGER_PASSWORD:-} #Optional: unlocks the /manage admin page
-      - OVERLAY_SERVER_TOKEN=${OVERLAY_SERVER_TOKEN:-} #Optional: bearer token for the external overlay server
+      # OVERLAY_SERVER_TOKEN is auto-generated and persisted to data/.overlay_server_token
+      # on first start. Set it explicitly here to override (e.g. when an external
+      # CustomOverlayBackend peer must use the same value), or set
+      # OVERLAY_SERVER_TOKEN_DISABLED=true to opt back into legacy unauthenticated
+      # behaviour (only safe on a trusted LAN).
+      - OVERLAY_SERVER_TOKEN=${OVERLAY_SERVER_TOKEN:-}
+      - OVERLAY_SERVER_TOKEN_DISABLED=${OVERLAY_SERVER_TOKEN_DISABLED:-} #Optional: opt out of overlay-server auth
+      - SCOREBOARD_USERS_DISABLED=${SCOREBOARD_USERS_DISABLED:-} #Optional: silence the open-API startup warning
       - MATCH_REPORT_PUBLIC=${MATCH_REPORT_PUBLIC:-false} #Optional: open match-report routes to anonymous reads
       - SCOREBOARD_USERS=${SCOREBOARD_USERS:-}
       - REST_USER_AGENT=${REST_USER_AGENT:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       - WEBHOOKS_URL=${WEBHOOKS_URL:-} #Optional: single outbound webhook endpoint
       - WEBHOOKS_SECRET=${WEBHOOKS_SECRET:-} #Optional: HMAC-SHA256 secret for the single endpoint
       - WEBHOOKS_JSON=${WEBHOOKS_JSON:-} #Optional: multi-target webhook config as JSON
+      - WEBHOOKS_ALLOW_PRIVATE_IPS=${WEBHOOKS_ALLOW_PRIVATE_IPS:-} #Optional: allow webhook targets on private/loopback IPs (SSRF opt-out)
       - PERF_GET_STATE_WARN_MS=${PERF_GET_STATE_WARN_MS:-50} #Optional: slow-path threshold for GET /api/v1/state
     healthcheck:
       # python:3.12-slim does not ship with curl; use urllib instead of

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - OVERLAY_SERVER_TOKEN_HASH=${OVERLAY_SERVER_TOKEN_HASH:-} #Optional: scrypt-hashed alternative
       - OVERLAY_SERVER_TOKEN_DISABLED=${OVERLAY_SERVER_TOKEN_DISABLED:-} #Optional: opt out of overlay-server auth
       - SCOREBOARD_USERS_DISABLED=${SCOREBOARD_USERS_DISABLED:-} #Optional: silence the open-API startup warning
+      - TRUSTED_HOSTS=${TRUSTED_HOSTS:-} #Optional: comma-separated allow-list of Host header values (wildcards OK)
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-} #Optional: comma-separated allow-list of cross-origin SPA hosts (no wildcards)
       - MATCH_REPORT_PUBLIC=${MATCH_REPORT_PUBLIC:-false} #Optional: open match-report routes to anonymous reads
       - SCOREBOARD_USERS=${SCOREBOARD_USERS:-}
       - REST_USER_AGENT=${REST_USER_AGENT:-}

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -427,6 +427,52 @@
         "title": "MatchPointInfo",
         "type": "object"
       },
+      "MatchSignUrlRequest": {
+        "properties": {
+          "ttl_seconds": {
+            "anyOf": [
+              {
+                "maximum": 2592000.0,
+                "minimum": 60.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "URL lifetime in seconds. Bounded to [60, 2592000]; defaults to 86400.",
+            "title": "Ttl Seconds"
+          }
+        },
+        "title": "MatchSignUrlRequest",
+        "type": "object"
+      },
+      "MatchSignUrlResponse": {
+        "properties": {
+          "expires_at": {
+            "description": "Unix-seconds expiry the URL was signed for.",
+            "title": "Expires At",
+            "type": "integer"
+          },
+          "expires_in": {
+            "description": "Seconds remaining until expiry, at mint time.",
+            "title": "Expires In",
+            "type": "integer"
+          },
+          "url": {
+            "description": "Absolute capability URL \u2014 anyone holding it can read the report until ``expires_at``.",
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "expires_at",
+          "expires_in"
+        ],
+        "title": "MatchSignUrlResponse",
+        "type": "object"
+      },
       "OverlayControlModel": {
         "additionalProperties": true,
         "properties": {
@@ -1519,6 +1565,68 @@
           }
         },
         "summary": "Admin Login",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/v1/admin/match/{match_id}/sign-url": {
+      "post": {
+        "description": "Return a capability URL the operator can paste into chat tools.\n\nThe legacy share flow (``/match/{id}/report?token=<password>``)\nembeds the actual ``OVERLAY_MANAGER_PASSWORD`` in the URL \u2014\nevery browser bookmark, server log, or HTTP ``Referer`` that\ntouches the link leaks the credential. This endpoint replaces\nthat flow with an HMAC-signed URL of the form\n``/match/{id}/report?exp=<ts>&sig=<hex>``: the password stays\non the server and the URL expires automatically.\n\nRotating the admin password invalidates every outstanding\nsigned URL \u2014 that's the desired behaviour, since rotations are\ntypically motivated by suspected leaks.\n\nThe endpoint deliberately does *not* check whether the\n``match_id`` exists: a 404 here would be a free oracle for\nenumerating archived matches by anyone holding the admin\npassword (who could already do far worse anyway). Signing a\nbogus match id just produces a URL that 404s on use.",
+        "operationId": "sign_match_report_url_api_v1_admin_match__match_id__sign_url_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "match_id",
+            "required": true,
+            "schema": {
+              "title": "Match Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MatchSignUrlRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MatchSignUrlResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mint a short-lived signed URL for a match report",
         "tags": [
           "Admin"
         ]
@@ -3820,6 +3928,42 @@
               ],
               "description": "OVERLAY_MANAGER_PASSWORD; alternative to Bearer header.",
               "title": "Token"
+            }
+          },
+          {
+            "description": "Signed-URL expiry (unix seconds).",
+            "in": "query",
+            "name": "exp",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Signed-URL expiry (unix seconds).",
+              "title": "Exp"
+            }
+          },
+          {
+            "description": "Signed-URL HMAC-SHA256 hex digest.",
+            "in": "query",
+            "name": "sig",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Signed-URL HMAC-SHA256 hex digest.",
+              "title": "Sig"
             }
           },
           {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -179,6 +179,44 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/match/{match_id}/sign-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Mint a short-lived signed URL for a match report
+         * @description Return a capability URL the operator can paste into chat tools.
+         *
+         *     The legacy share flow (``/match/{id}/report?token=<password>``)
+         *     embeds the actual ``OVERLAY_MANAGER_PASSWORD`` in the URL —
+         *     every browser bookmark, server log, or HTTP ``Referer`` that
+         *     touches the link leaks the credential. This endpoint replaces
+         *     that flow with an HMAC-signed URL of the form
+         *     ``/match/{id}/report?exp=<ts>&sig=<hex>``: the password stays
+         *     on the server and the URL expires automatically.
+         *
+         *     Rotating the admin password invalidates every outstanding
+         *     signed URL — that's the desired behaviour, since rotations are
+         *     typically motivated by suspected leaks.
+         *
+         *     The endpoint deliberately does *not* check whether the
+         *     ``match_id`` exists: a 404 here would be a free oracle for
+         *     enumerating archived matches by anyone holding the admin
+         *     password (who could already do far worse anyway). Signing a
+         *     bogus match id just produces a URL that 404s on use.
+         */
+        post: operations["sign_match_report_url_api_v1_admin_match__match_id__sign_url_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/status": {
         parameters: {
             query?: never;
@@ -1081,6 +1119,32 @@ export interface components {
             /** Team 2 Set Point */
             team_2_set_point: boolean;
         };
+        /** MatchSignUrlRequest */
+        MatchSignUrlRequest: {
+            /**
+             * Ttl Seconds
+             * @description URL lifetime in seconds. Bounded to [60, 2592000]; defaults to 86400.
+             */
+            ttl_seconds?: number | null;
+        };
+        /** MatchSignUrlResponse */
+        MatchSignUrlResponse: {
+            /**
+             * Expires At
+             * @description Unix-seconds expiry the URL was signed for.
+             */
+            expires_at: number;
+            /**
+             * Expires In
+             * @description Seconds remaining until expiry, at mint time.
+             */
+            expires_in: number;
+            /**
+             * Url
+             * @description Absolute capability URL — anyone holding it can read the report until ``expires_at``.
+             */
+            url: string;
+        };
         /** OverlayControlModel */
         OverlayControlModel: {
             /** Colors */
@@ -1625,6 +1689,43 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sign_match_report_url_api_v1_admin_match__match_id__sign_url_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string;
+            };
+            path: {
+                match_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MatchSignUrlRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MatchSignUrlResponse"];
                 };
             };
             /** @description Validation Error */
@@ -2881,6 +2982,10 @@ export interface operations {
             query?: {
                 /** @description OVERLAY_MANAGER_PASSWORD; alternative to Bearer header. */
                 token?: string | null;
+                /** @description Signed-URL expiry (unix seconds). */
+                exp?: string | null;
+                /** @description Signed-URL HMAC-SHA256 hex digest. */
+                sig?: string | null;
             };
             header?: {
                 authorization?: string | null;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,27 @@ def isolate_match_archive(tmp_path_factory, monkeypatch):
     monkeypatch.setattr(match_archive, "_data_dir", lambda: str(seed_dir))
 
 
+@pytest.fixture(autouse=True)
+def isolate_security_bootstrap(tmp_path_factory, monkeypatch):
+    """Redirect the security bootstrap's data dir to a per-test temp dir.
+
+    ``app.security_bootstrap.ensure_overlay_server_token`` writes a
+    persisted token file to ``data/.overlay_server_token`` on first
+    invocation. Tests that build a real FastAPI app via
+    ``bootstrap.create_app()`` (e.g. ``test_trusted_hosts_and_cors``)
+    trigger the bootstrap and would otherwise pollute the dev tree's
+    real ``data/`` directory and leak token state between tests.
+
+    Mirrors the per-module isolation used for ``action_log``,
+    ``match_archive``, ``session_persistence``, and
+    ``overlay_state_store``.
+    """
+    from app import security_bootstrap
+
+    seed_dir = tmp_path_factory.mktemp("security_bootstrap")
+    monkeypatch.setattr(security_bootstrap, "_data_dir", lambda: str(seed_dir))
+
+
 def load_fixture(name):
     """Auxiliary function to load a JSON file from the fixtures folder."""
     path = os.path.join(os.path.dirname(__file__), 'fixtures', f'{name}.json')

--- a/tests/test_hashed_credentials.py
+++ b/tests/test_hashed_credentials.py
@@ -1,0 +1,357 @@
+"""Integration coverage for hashed-credential support across the three
+auth surfaces extended in PR 4 of the security plan:
+
+* ``SCOREBOARD_USERS`` user entries — ``password_hash`` field accepted
+  alongside legacy ``password``.
+* ``OVERLAY_MANAGER_PASSWORD_HASH`` — admin Bearer credential.
+* ``OVERLAY_SERVER_TOKEN_HASH`` — overlay-server mutation gate.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app import password_hash, security_bootstrap
+from app.admin import admin_router
+from app.api.middleware import auth_rate_limit
+from app.api.session_manager import SessionManager
+from app.api.ws_hub import WSHub
+from app.authentication import PasswordAuthenticator
+from app.overlay.routes import _get_overlay_server_credential
+
+
+# Use light scrypt parameters so the test suite stays under a second.
+@pytest.fixture
+def fast_hash(monkeypatch):
+    """Return a callable that produces hashes with light scrypt params.
+
+    Default ``n=16384`` would add ~50 ms × 30 tests = ~1.5 s; the
+    light params (``n=1024``) keep verification well under 5 ms.
+    """
+    def _hash(pw: str) -> str:
+        return password_hash.hash_password(pw, n=1024, r=4, p=1)
+    return _hash
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    monkeypatch.delenv("SCOREBOARD_USERS", raising=False)
+    monkeypatch.delenv("OVERLAY_MANAGER_PASSWORD", raising=False)
+    monkeypatch.delenv("OVERLAY_MANAGER_PASSWORD_HASH", raising=False)
+    monkeypatch.delenv("OVERLAY_SERVER_TOKEN", raising=False)
+    monkeypatch.delenv("OVERLAY_SERVER_TOKEN_HASH", raising=False)
+    monkeypatch.delenv("OVERLAY_SERVER_TOKEN_DISABLED", raising=False)
+    PasswordAuthenticator._cached_users = None
+    PasswordAuthenticator._cached_users_raw = None
+    PasswordAuthenticator._verify_cache.clear()
+    SessionManager.clear()
+    WSHub.clear()
+    auth_rate_limit._reset_for_tests()
+    yield
+    PasswordAuthenticator._cached_users = None
+    PasswordAuthenticator._cached_users_raw = None
+    PasswordAuthenticator._verify_cache.clear()
+    SessionManager.clear()
+    WSHub.clear()
+    auth_rate_limit._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# SCOREBOARD_USERS — password_hash field
+# ---------------------------------------------------------------------------
+
+
+def test_scoreboard_users_accepts_password_hash(monkeypatch, fast_hash):
+    monkeypatch.setenv(
+        "SCOREBOARD_USERS",
+        json.dumps({
+            "alice": {"password_hash": fast_hash("alice-pw")},
+        }),
+    )
+    assert PasswordAuthenticator.check_api_key("alice-pw") is True
+    assert PasswordAuthenticator.check_api_key("wrong") is False
+    assert PasswordAuthenticator.get_username_for_api_key("alice-pw") == "alice"
+
+
+def test_scoreboard_users_legacy_plaintext_still_works(monkeypatch):
+    monkeypatch.setenv(
+        "SCOREBOARD_USERS",
+        json.dumps({"bob": {"password": "bob-pw"}}),
+    )
+    assert PasswordAuthenticator.check_api_key("bob-pw") is True
+
+
+def test_scoreboard_users_hash_takes_precedence_over_plaintext(
+    monkeypatch, fast_hash,
+):
+    """An entry with both fields uses the hash; the plaintext is ignored.
+
+    Operators in the middle of a migration shouldn't have to delete
+    the plaintext value to switch over.
+    """
+    monkeypatch.setenv(
+        "SCOREBOARD_USERS",
+        json.dumps({
+            "carol": {
+                "password": "old-plaintext",
+                "password_hash": fast_hash("new-hashed"),
+            },
+        }),
+    )
+    assert PasswordAuthenticator.check_api_key("new-hashed") is True
+    # The plaintext field is ignored when a hash is also configured —
+    # otherwise the migration would leave both credentials valid
+    # forever, which defeats the rotation story.
+    assert PasswordAuthenticator.check_api_key("old-plaintext") is False
+
+
+def test_scoreboard_users_mixed_entries(monkeypatch, fast_hash):
+    """One user on plaintext, another on hash — both authenticate."""
+    monkeypatch.setenv(
+        "SCOREBOARD_USERS",
+        json.dumps({
+            "legacy": {"password": "legacy-pw"},
+            "modern": {"password_hash": fast_hash("modern-pw")},
+        }),
+    )
+    assert PasswordAuthenticator.get_username_for_api_key("legacy-pw") == "legacy"
+    assert PasswordAuthenticator.get_username_for_api_key("modern-pw") == "modern"
+
+
+def test_verify_cache_short_circuits_repeat_lookups(monkeypatch, fast_hash):
+    """Cached verifications skip the expensive scrypt path."""
+    monkeypatch.setenv(
+        "SCOREBOARD_USERS",
+        json.dumps({"dave": {"password_hash": fast_hash("dave-pw")}}),
+    )
+    # First call populates the cache.
+    assert PasswordAuthenticator.get_username_for_api_key("dave-pw") == "dave"
+    # Pin a different verifier to detect cache use: if the cache is
+    # working, the second call must return the cached "dave" without
+    # invoking ``verify_password`` at all.
+    calls = {"n": 0}
+
+    def counting_verify(provided, stored):
+        calls["n"] += 1
+        return password_hash.verify_password(provided, stored)
+
+    monkeypatch.setattr(
+        "app.authentication.verify_password", counting_verify,
+    )
+    # Within the TTL, the cache returns the username immediately.
+    assert PasswordAuthenticator.get_username_for_api_key("dave-pw") == "dave"
+    assert calls["n"] == 0
+
+
+def test_verify_cache_invalidated_on_user_rotation(monkeypatch, fast_hash):
+    """Removing a user from SCOREBOARD_USERS must invalidate cached entries."""
+    monkeypatch.setenv(
+        "SCOREBOARD_USERS",
+        json.dumps({"erin": {"password_hash": fast_hash("erin-pw")}}),
+    )
+    assert PasswordAuthenticator.check_api_key("erin-pw") is True
+    # Rotate the env var: erin is gone.
+    monkeypatch.setenv(
+        "SCOREBOARD_USERS",
+        json.dumps({"frank": {"password_hash": fast_hash("frank-pw")}}),
+    )
+    assert PasswordAuthenticator.check_api_key("erin-pw") is False
+    assert PasswordAuthenticator.check_api_key("frank-pw") is True
+
+
+def test_has_hashed_credentials_reports_correctly(monkeypatch, fast_hash):
+    monkeypatch.setenv(
+        "SCOREBOARD_USERS",
+        json.dumps({"u": {"password": "p"}}),
+    )
+    assert PasswordAuthenticator.has_hashed_credentials() is False
+    monkeypatch.setenv(
+        "SCOREBOARD_USERS",
+        json.dumps({"u": {"password_hash": fast_hash("p")}}),
+    )
+    assert PasswordAuthenticator.has_hashed_credentials() is True
+
+
+# ---------------------------------------------------------------------------
+# OVERLAY_MANAGER_PASSWORD_HASH — admin Bearer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def admin_app(monkeypatch):
+    app = FastAPI()
+    app.include_router(admin_router)
+    return app
+
+
+def test_admin_login_accepts_hashed_credential(monkeypatch, fast_hash, admin_app):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD_HASH", fast_hash("admin-pw"))
+    client = TestClient(admin_app)
+    res = client.post(
+        "/api/v1/admin/login",
+        headers={"Authorization": "Bearer admin-pw"},
+    )
+    assert res.status_code == 200
+    bad = client.post(
+        "/api/v1/admin/login",
+        headers={"Authorization": "Bearer wrong"},
+    )
+    assert bad.status_code == 403
+
+
+def test_admin_login_legacy_plaintext_still_works(monkeypatch, admin_app):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "admin-pw")
+    client = TestClient(admin_app)
+    res = client.post(
+        "/api/v1/admin/login",
+        headers={"Authorization": "Bearer admin-pw"},
+    )
+    assert res.status_code == 200
+
+
+def test_admin_hash_takes_precedence_over_plaintext(
+    monkeypatch, fast_hash, admin_app,
+):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "old-plaintext")
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD_HASH", fast_hash("new-hashed"))
+    client = TestClient(admin_app)
+    # The hash wins — the plaintext value no longer authenticates.
+    res = client.post(
+        "/api/v1/admin/login",
+        headers={"Authorization": "Bearer old-plaintext"},
+    )
+    assert res.status_code == 403
+    res = client.post(
+        "/api/v1/admin/login",
+        headers={"Authorization": "Bearer new-hashed"},
+    )
+    assert res.status_code == 200
+
+
+def test_admin_status_503_when_neither_credential_set(monkeypatch, admin_app):
+    client = TestClient(admin_app)
+    res = client.get("/api/v1/admin/custom-overlays",
+                     headers={"Authorization": "Bearer x"})
+    assert res.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# OVERLAY_SERVER_TOKEN_HASH — overlay router gate
+# ---------------------------------------------------------------------------
+
+
+def _build_overlay_app(tmp_path: Path):
+    """Mount the overlay router with isolated state for the auth tests."""
+    from fastapi.templating import Jinja2Templates
+
+    from app.overlay.broadcast import ObsBroadcastHub
+    from app.overlay.routes import create_overlay_router
+    from app.overlay.state_store import OverlayStateStore
+
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "index.html").write_text("ok")
+    store = OverlayStateStore(
+        data_dir=str(tmp_path / "overlays"),
+        templates_dir=str(templates_dir),
+    )
+    store.create_overlay("ovl-1")
+    hub = ObsBroadcastHub()
+    app = FastAPI()
+    app.include_router(create_overlay_router(store, hub, Jinja2Templates(directory=str(templates_dir))))
+    return app
+
+
+def test_overlay_token_hash_gates_mutation_endpoint(
+    monkeypatch, fast_hash, tmp_path,
+):
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN_HASH", fast_hash("server-pw"))
+    client = TestClient(_build_overlay_app(tmp_path))
+
+    # Missing header → 401.
+    res = client.post("/api/state/ovl-1", json={})
+    assert res.status_code == 401
+    # Wrong token → 403.
+    res = client.post(
+        "/api/state/ovl-1", json={},
+        headers={"Authorization": "Bearer wrong"},
+    )
+    assert res.status_code == 403
+    # Correct token → 200.
+    res = client.post(
+        "/api/state/ovl-1", json={},
+        headers={"Authorization": "Bearer server-pw"},
+    )
+    assert res.status_code == 200
+
+
+def test_overlay_token_legacy_plaintext_still_works(monkeypatch, tmp_path):
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN", "server-pw")
+    client = TestClient(_build_overlay_app(tmp_path))
+    res = client.post(
+        "/api/state/ovl-1", json={},
+        headers={"Authorization": "Bearer server-pw"},
+    )
+    assert res.status_code == 200
+
+
+def test_overlay_token_hash_takes_precedence(monkeypatch, fast_hash, tmp_path):
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN", "old-plaintext")
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN_HASH", fast_hash("new-hashed"))
+    client = TestClient(_build_overlay_app(tmp_path))
+    bad = client.post(
+        "/api/state/ovl-1", json={},
+        headers={"Authorization": "Bearer old-plaintext"},
+    )
+    assert bad.status_code == 403
+    good = client.post(
+        "/api/state/ovl-1", json={},
+        headers={"Authorization": "Bearer new-hashed"},
+    )
+    assert good.status_code == 200
+
+
+def test_get_overlay_server_credential_prefers_hash(monkeypatch, fast_hash):
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN", "old-plaintext")
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN_HASH", fast_hash("new-hashed"))
+    cred = _get_overlay_server_credential()
+    assert cred is not None
+    assert cred.startswith("scrypt$")
+
+
+# ---------------------------------------------------------------------------
+# security_bootstrap — hash-only configuration skips auto-generation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(security_bootstrap, "_data_dir", lambda: str(tmp_path))
+    return tmp_path
+
+
+def test_bootstrap_skips_auto_gen_when_hash_set(
+    isolated_data_dir, monkeypatch, fast_hash,
+):
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN_HASH", fast_hash("server-pw"))
+    result = security_bootstrap.ensure_overlay_server_token()
+    # Hash-only deployments deliberately keep no plaintext on this
+    # server: bootstrap returns None and never writes the persisted
+    # token file.
+    assert result is None
+    assert "OVERLAY_SERVER_TOKEN" not in __import__("os").environ
+    assert not (isolated_data_dir / ".overlay_server_token").exists()
+
+
+def test_bootstrap_auto_gen_when_hash_unset(isolated_data_dir, monkeypatch):
+    """Without a hash, auto-generation still runs (regression check)."""
+    monkeypatch.delenv("OVERLAY_SERVER_TOKEN_HASH", raising=False)
+    monkeypatch.delenv("OVERLAY_SERVER_TOKEN", raising=False)
+    result = security_bootstrap.ensure_overlay_server_token()
+    assert result is not None
+    assert (isolated_data_dir / ".overlay_server_token").exists()

--- a/tests/test_hashed_credentials.py
+++ b/tests/test_hashed_credentials.py
@@ -177,6 +177,45 @@ def test_has_hashed_credentials_reports_correctly(monkeypatch, fast_hash):
     assert PasswordAuthenticator.has_hashed_credentials() is True
 
 
+@pytest.mark.parametrize("malformed", [
+    "[]",                              # JSON array, not object
+    '"a string"',                      # JSON string
+    "42",                              # JSON number
+    "null",                            # JSON null
+    "not json at all",                 # syntactic garbage
+])
+def test_malformed_scoreboard_users_does_not_crash(monkeypatch, malformed):
+    """Non-dict ``SCOREBOARD_USERS`` payloads must fail closed, not raise.
+
+    Pre-PR-261 the verifier called ``users.items()`` / ``userconf.get``
+    without type checks, so a misconfigured env var would 500 the
+    request instead of cleanly rejecting the credential.
+    """
+    monkeypatch.setenv("SCOREBOARD_USERS", malformed)
+    # Reach for a credential — the result must be False/None even
+    # though the JSON is structurally invalid.
+    assert PasswordAuthenticator.check_api_key("anything") is False
+    assert PasswordAuthenticator.has_hashed_credentials() is False
+
+
+def test_per_user_non_dict_entry_is_skipped(monkeypatch, fast_hash):
+    """One bogus entry shouldn't poison the rest of the user list.
+
+    ``SCOREBOARD_USERS={"bogus": "string", "real": {...}}`` should
+    authenticate ``real`` and silently skip ``bogus`` rather than
+    raising on ``"string".get("password")``.
+    """
+    monkeypatch.setenv(
+        "SCOREBOARD_USERS",
+        json.dumps({
+            "bogus": "not-a-dict",
+            "real": {"password_hash": fast_hash("real-pw")},
+        }),
+    )
+    assert PasswordAuthenticator.check_api_key("real-pw") is True
+    assert PasswordAuthenticator.check_api_key("bogus") is False
+
+
 # ---------------------------------------------------------------------------
 # OVERLAY_MANAGER_PASSWORD_HASH — admin Bearer
 # ---------------------------------------------------------------------------

--- a/tests/test_low_priority_hardening.py
+++ b/tests/test_low_priority_hardening.py
@@ -1,0 +1,312 @@
+"""Coverage for the L-1 / L-2 / L-6 hardening additions.
+
+* L-1 — :mod:`app.api.middleware.errors` enriches its log record with
+  the request id, request method, path, and exception class.
+* L-2 — every 401 response from the auth ladders carries
+  ``WWW-Authenticate: Bearer realm="..."`` per RFC 7235 §4.1.
+* L-6 — :mod:`app.api.webhooks` refuses to call URLs that resolve
+  to private / loopback / link-local IPs unless the operator opts
+  in via ``WEBHOOKS_ALLOW_PRIVATE_IPS=true``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.admin import admin_router
+from app.api import api_router
+from app.api.middleware.errors import ExceptionLoggingMiddleware
+from app.api.middleware.logging import RequestContextMiddleware
+from app.api.webhooks import (
+    WebhookDispatcher,
+    WebhookTarget,
+    _is_private_ip,
+    _is_target_safe,
+)
+
+# ---------------------------------------------------------------------------
+# L-1 — exception logging enrichment
+# ---------------------------------------------------------------------------
+
+
+def test_exception_log_includes_method_path_class_and_request_id(caplog):
+    """An unhandled exception logs ``method``, ``path``, ``request_id``,
+    and the exception class — both in the message text and as
+    structured ``extra`` fields.
+    """
+    app = FastAPI()
+
+    @app.get("/boom")
+    def boom():
+        raise RuntimeError("kaboom")
+
+    # Outermost-first: RequestContext sets the contextvars before the
+    # exception logger reads them.
+    app.add_middleware(ExceptionLoggingMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    with caplog.at_level(logging.ERROR, logger="app.api.middleware.errors"):
+        res = client.get(
+            "/boom", headers={"X-Request-ID": "test-rid-42"},
+        )
+    assert res.status_code == 500
+    error_records = [
+        r for r in caplog.records
+        if r.name == "app.api.middleware.errors"
+    ]
+    assert error_records, "expected an error log record"
+    rec = error_records[-1]
+    msg = rec.getMessage()
+    assert "GET" in msg
+    assert "/boom" in msg
+    assert "RuntimeError" in msg
+    assert "test-rid-42" in msg
+    # And the same fields as structured ``extra`` so JSON formatters
+    # surface them as queryable keys, not just inside the free-form
+    # message.
+    assert getattr(rec, "exc_class", None) == "RuntimeError"
+    assert getattr(rec, "http_method", None) == "GET"
+    assert getattr(rec, "http_path", None) == "/boom"
+
+
+# ---------------------------------------------------------------------------
+# L-2 — WWW-Authenticate on 401
+# ---------------------------------------------------------------------------
+
+
+def test_scoreboard_401_carries_bearer_challenge(monkeypatch):
+    monkeypatch.setenv(
+        "SCOREBOARD_USERS",
+        json.dumps({"alice": {"password": "alice-pw"}}),
+    )
+    # Force re-parse since other tests may have cached an older value.
+    from app.authentication import PasswordAuthenticator
+    PasswordAuthenticator._cached_users = None
+    PasswordAuthenticator._cached_users_raw = None
+
+    app = FastAPI()
+    app.include_router(api_router)
+    client = TestClient(app)
+
+    # 401 — missing header.
+    res = client.get("/api/v1/state?oid=test_overlay")
+    assert res.status_code == 401
+    assert (
+        res.headers.get("www-authenticate")
+        == 'Bearer realm="scoreboard"'
+    )
+
+
+def test_scoreboard_401_check_oid_path_carries_challenge(monkeypatch):
+    """The second 401 site (``check_oid_access`` for missing header)
+    must also emit the WWW-Authenticate challenge.
+
+    Exercise the WebSocket route, which calls ``check_oid_access``
+    explicitly. A bare ``401`` from that path was previously
+    silent on the challenge.
+    """
+    monkeypatch.setenv(
+        "SCOREBOARD_USERS",
+        json.dumps({"alice": {"password": "alice-pw"}}),
+    )
+    from fastapi import HTTPException
+
+    from app.api.dependencies import check_oid_access
+
+    with pytest.raises(HTTPException) as excinfo:
+        check_oid_access("", "test_overlay")
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.headers is not None
+    assert (
+        excinfo.value.headers.get("WWW-Authenticate")
+        == 'Bearer realm="scoreboard"'
+    )
+
+
+def test_admin_401_carries_admin_realm(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "admin-pw")
+    app = FastAPI()
+    app.include_router(admin_router)
+    client = TestClient(app)
+    res = client.post("/api/v1/admin/login")
+    assert res.status_code == 401
+    assert (
+        res.headers.get("www-authenticate")
+        == 'Bearer realm="admin"'
+    )
+
+
+def test_overlay_server_401_carries_overlay_realm(monkeypatch, tmp_path):
+    """When ``OVERLAY_SERVER_TOKEN`` gates an endpoint, missing-header
+    rejections include the overlay-server realm."""
+    from fastapi.templating import Jinja2Templates
+
+    from app.overlay.broadcast import ObsBroadcastHub
+    from app.overlay.routes import create_overlay_router
+    from app.overlay.state_store import OverlayStateStore
+
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN", "server-pw")
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "index.html").write_text("ok")
+    store = OverlayStateStore(
+        data_dir=str(tmp_path / "overlays"),
+        templates_dir=str(templates_dir),
+    )
+    store.create_overlay("ovl-1")
+    hub = ObsBroadcastHub()
+    app = FastAPI()
+    app.include_router(create_overlay_router(
+        store, hub, Jinja2Templates(directory=str(templates_dir)),
+    ))
+    client = TestClient(app)
+    res = client.post("/api/state/ovl-1", json={})
+    assert res.status_code == 401
+    assert (
+        res.headers.get("www-authenticate")
+        == 'Bearer realm="overlay-server"'
+    )
+
+
+# ---------------------------------------------------------------------------
+# L-6 — webhook SSRF guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("ip", [
+    "127.0.0.1", "127.255.255.255",   # loopback
+    "::1",                              # loopback v6
+    "10.0.0.1", "10.255.255.254",       # RFC1918
+    "172.16.0.1", "172.31.255.254",
+    "192.168.0.1",
+    "169.254.169.254",                  # link-local (cloud metadata)
+    "224.0.0.1",                        # multicast
+    "0.0.0.0",                          # unspecified
+    "fc00::1",                          # IPv6 ULA
+    "fe80::1",                          # IPv6 link-local
+    "not-an-ip",                        # non-parseable → suspicious
+])
+def test_is_private_ip_classifies_correctly(ip):
+    assert _is_private_ip(ip) is True
+
+
+@pytest.mark.parametrize("ip", [
+    "8.8.8.8",            # Google DNS
+    "1.1.1.1",            # Cloudflare DNS
+    "9.9.9.9",            # Quad9 DNS
+    "2606:4700::1111",    # public IPv6 (Cloudflare)
+])
+def test_is_private_ip_allows_public(ip):
+    assert _is_private_ip(ip) is False
+
+
+def test_is_private_ip_blocks_documentation_ranges():
+    """RFC 5737 / RFC 3849 documentation ranges shouldn't be reachable
+    in production either — ``ipaddress`` flags them as reserved and
+    our guard rolls them in with private/loopback rejections.
+    """
+    for ip in ("192.0.2.1", "198.51.100.1", "203.0.113.1", "2001:db8::1"):
+        assert _is_private_ip(ip) is True
+
+
+def test_is_target_safe_rejects_loopback_literal():
+    safe, reason = _is_target_safe("http://127.0.0.1/admin")
+    assert safe is False
+    assert "loopback" in reason.lower() or "private" in reason.lower()
+
+
+def test_is_target_safe_rejects_cloud_metadata_literal():
+    safe, reason = _is_target_safe("http://169.254.169.254/latest/meta-data/")
+    assert safe is False
+
+
+def test_is_target_safe_accepts_public_literal():
+    safe, reason = _is_target_safe("http://1.1.1.1/")
+    assert safe is True
+    assert reason == ""
+
+
+def test_is_target_safe_rejects_non_http_scheme():
+    safe, reason = _is_target_safe("file:///etc/passwd")
+    assert safe is False
+    assert "scheme" in reason.lower()
+
+
+def test_is_target_safe_rejects_missing_host():
+    safe, reason = _is_target_safe("http:///")
+    assert safe is False
+
+
+def test_is_target_safe_passes_through_dns_failure():
+    """A non-resolving public hostname must pass through the guard so
+    ``requests.post`` can surface the actual network error rather
+    than this guard masking it as an SSRF rejection."""
+    safe, reason = _is_target_safe("http://this-does-not-resolve.invalid/")
+    assert safe is True
+
+
+def test_webhook_delivery_blocks_private_ip(monkeypatch):
+    """End-to-end: a webhook target on 127.0.0.1 must not be POSTed."""
+    monkeypatch.setenv(
+        "WEBHOOKS_URL", "http://127.0.0.1:9/should-not-be-called",
+    )
+    monkeypatch.delenv("WEBHOOKS_ALLOW_PRIVATE_IPS", raising=False)
+    d = WebhookDispatcher()
+    with patch("app.api.webhooks.requests.post") as post:
+        post.return_value.status_code = 200
+        d.dispatch("set_end", "oid", {})
+        if d._executor is not None:
+            d._executor.shutdown(wait=True)
+            d._executor = None
+        post.assert_not_called()
+
+
+def test_webhook_delivery_allows_private_ip_when_opted_in(monkeypatch):
+    """``WEBHOOKS_ALLOW_PRIVATE_IPS=true`` lets internal targets through."""
+    monkeypatch.setenv(
+        "WEBHOOKS_URL", "http://127.0.0.1:9/internal",
+    )
+    monkeypatch.setenv("WEBHOOKS_ALLOW_PRIVATE_IPS", "true")
+    d = WebhookDispatcher()
+    with patch("app.api.webhooks.requests.post") as post:
+        post.return_value.status_code = 200
+        d.dispatch("set_end", "oid", {})
+        if d._executor is not None:
+            d._executor.shutdown(wait=True)
+            d._executor = None
+        post.assert_called_once()
+
+
+def test_webhook_blocked_emits_warning(monkeypatch, caplog):
+    monkeypatch.setenv(
+        "WEBHOOKS_URL", "http://127.0.0.1:9/blocked",
+    )
+    monkeypatch.delenv("WEBHOOKS_ALLOW_PRIVATE_IPS", raising=False)
+    d = WebhookDispatcher()
+    with caplog.at_level(logging.WARNING, logger="app.api.webhooks"):
+        with patch("app.api.webhooks.requests.post"):
+            d.dispatch("set_end", "oid", {})
+            if d._executor is not None:
+                d._executor.shutdown(wait=True)
+                d._executor = None
+    assert any(
+        "blocked by SSRF guard" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_webhook_target_can_be_constructed_with_any_url():
+    """Constructing a ``WebhookTarget`` does not run the SSRF guard —
+    the guard fires at delivery time only. This keeps config-time
+    parsing cheap and lets unit tests exercise the dispatcher with
+    URLs that need DNS in the test sandbox.
+    """
+    t = WebhookTarget("http://localhost:9/x")
+    assert t.url == "http://localhost:9/x"

--- a/tests/test_password_hash.py
+++ b/tests/test_password_hash.py
@@ -1,0 +1,168 @@
+"""Coverage for :mod:`app.password_hash`.
+
+Pins the wire format, the round-trip behaviour, the plaintext-fallback
+contract that lets deployments migrate without a flag day, and the
+defensive ``False``-on-malformed behaviour that callers rely on to
+treat the verifier as a black box.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+import pytest
+
+from app import password_hash as ph
+
+# ---------------------------------------------------------------------------
+# hash_password / verify_password round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_hash_format_matches_documented_regex():
+    record = ph.hash_password("hunter2")
+    assert ph.is_hashed(record)
+    assert ph._HASH_RE.match(record) is not None
+
+
+def test_round_trip_default_params():
+    record = ph.hash_password("correct horse battery staple")
+    assert ph.verify_password("correct horse battery staple", record)
+    assert ph.verify_password("wrong", record) is False
+
+
+def test_round_trip_custom_params():
+    record = ph.hash_password("pw", n=4096, r=4, p=2)
+    assert ph.verify_password("pw", record)
+    # The stored params must be honoured on verify; verifying with a
+    # different password still fails.
+    assert ph.verify_password("nope", record) is False
+
+
+def test_each_hash_uses_a_fresh_salt():
+    a = ph.hash_password("same")
+    b = ph.hash_password("same")
+    assert a != b
+    # Both hashes verify the same password, despite different salts.
+    assert ph.verify_password("same", a)
+    assert ph.verify_password("same", b)
+
+
+def test_hash_rejects_empty_password():
+    with pytest.raises(ValueError):
+        ph.hash_password("")
+
+
+def test_hash_rejects_non_string_password():
+    with pytest.raises(TypeError):
+        ph.hash_password(b"bytes")  # type: ignore[arg-type]
+
+
+def test_hash_rejects_non_power_of_two_n():
+    with pytest.raises(ValueError):
+        ph.hash_password("pw", n=12345)
+
+
+# ---------------------------------------------------------------------------
+# Plaintext fallback (legacy compatibility)
+# ---------------------------------------------------------------------------
+
+
+def test_verify_falls_through_to_constant_time_compare_for_plaintext():
+    """``verify_password`` accepts a plaintext stored value too.
+
+    This is the migration path: existing deployments keep working even
+    when individual entries have not been re-encoded as hashes yet.
+    """
+    assert ph.verify_password("hunter2", "hunter2")
+    assert ph.verify_password("hunter2", "different") is False
+
+
+def test_is_hashed_only_recognises_the_documented_prefix():
+    assert ph.is_hashed("scrypt$n=16384,r=8,p=1$ab$cd")
+    assert not ph.is_hashed("hunter2")
+    assert not ph.is_hashed("$argon2id$v=19$...")  # other formats are not ours
+    assert not ph.is_hashed(123)
+    assert not ph.is_hashed(None)
+
+
+# ---------------------------------------------------------------------------
+# Defensive failure modes — never raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("malformed", [
+    "scrypt$",
+    "scrypt$n=16384",
+    "scrypt$n=16384,r=8,p=1$",
+    "scrypt$n=16384,r=8,p=1$nothex$nothex",
+    "scrypt$n=12345,r=8,p=1$abcd$abcd",         # non-power-of-2 n
+    "scrypt$n=16384,r=0,p=1$abcd$abcd",         # r < 1
+    "scrypt$n=16384,r=8,p=0$abcd$abcd",         # p < 1
+    "scrypt$n=99999999,r=8,p=1$abcd$abcd",      # huge n — exceeds maxmem
+    "",
+])
+def test_verify_returns_false_on_malformed_record(malformed):
+    assert ph.verify_password("any", malformed) is False
+
+
+def test_verify_returns_false_for_non_string_inputs():
+    assert ph.verify_password(123, "scrypt$n=16384,r=8,p=1$ab$cd") is False  # type: ignore[arg-type]
+    assert ph.verify_password("pw", None) is False  # type: ignore[arg-type]
+
+
+def test_verify_rejects_n_above_max_log2_cap():
+    """A record with ``n=2**32`` must fail closed before scrypt allocates GiBs."""
+    record = f"scrypt$n={1 << 32},r=8,p=1${'ab' * 8}${'cd' * 16}"
+    assert ph.verify_password("any", record) is False
+
+
+# ---------------------------------------------------------------------------
+# CLI helper (``python -m app.password_hash``)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_stdin_mode_round_trips():
+    """Mint a hash via ``--stdin`` and verify it inline."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "app.password_hash", "--stdin"],
+        input="cli-pw",
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    record = proc.stdout.strip()
+    assert ph.is_hashed(record)
+    assert ph.verify_password("cli-pw", record)
+    assert not ph.verify_password("other", record)
+
+
+def test_cli_rejects_empty_password():
+    proc = subprocess.run(
+        [sys.executable, "-m", "app.password_hash", "--stdin"],
+        input="",
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert proc.returncode == 2
+    assert "non-empty" in proc.stderr.lower()
+
+
+def test_cli_respects_custom_n():
+    proc = subprocess.run(
+        [sys.executable, "-m", "app.password_hash",
+         "--stdin", "--n", "4096"],
+        input="pw",
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0
+    record = proc.stdout.strip()
+    m = re.match(r"scrypt\$n=(\d+),", record)
+    assert m is not None
+    assert int(m.group(1)) == 4096

--- a/tests/test_security_bootstrap.py
+++ b/tests/test_security_bootstrap.py
@@ -1,0 +1,226 @@
+"""Coverage for :mod:`app.security_bootstrap`.
+
+Pins the four resolution paths of :func:`ensure_overlay_server_token`
+plus the open-scoreboard warning:
+
+1. ``OVERLAY_SERVER_TOKEN_DISABLED=true`` → returns ``None`` and
+   logs CRITICAL; ``os.environ`` is not touched.
+2. ``OVERLAY_SERVER_TOKEN`` already set → returned verbatim.
+3. Persisted file exists → loaded and injected into ``os.environ``.
+4. Nothing set, nothing persisted → mint a fresh token, persist with
+   ``0o600`` permissions, inject into ``os.environ``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from app import security_bootstrap
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch):
+    monkeypatch.delenv("OVERLAY_SERVER_TOKEN", raising=False)
+    monkeypatch.delenv("OVERLAY_SERVER_TOKEN_DISABLED", raising=False)
+    monkeypatch.delenv("SCOREBOARD_USERS", raising=False)
+    monkeypatch.delenv("SCOREBOARD_USERS_DISABLED", raising=False)
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    """Redirect the bootstrap's data dir to a per-test tmp dir.
+
+    Avoids touching the repo's real ``data/`` directory and lets us
+    inspect the persisted token file directly.
+    """
+    monkeypatch.setattr(security_bootstrap, "_data_dir", lambda: str(tmp_path))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Path 1 — explicit opt-out
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_opt_out_returns_none(isolated_data_dir, monkeypatch, caplog):
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN_DISABLED", "true")
+    with caplog.at_level(logging.CRITICAL, logger="app.security_bootstrap"):
+        result = security_bootstrap.ensure_overlay_server_token()
+    assert result is None
+    # Env var must not be set even by mistake — the operator chose
+    # fail-open and the rest of the app gates on emptiness.
+    assert os.environ.get("OVERLAY_SERVER_TOKEN") is None
+    # Persisted file must not be created either.
+    assert not (isolated_data_dir / ".overlay_server_token").exists()
+    # The opt-out is logged at CRITICAL so it surfaces in the startup tail.
+    assert any("UNAUTHENTICATED" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.parametrize("flag", ["1", "true", "TRUE", "yes", "on"])
+def test_opt_out_accepts_truthy_aliases(flag, isolated_data_dir, monkeypatch):
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN_DISABLED", flag)
+    assert security_bootstrap.ensure_overlay_server_token() is None
+
+
+# ---------------------------------------------------------------------------
+# Path 2 — already configured
+# ---------------------------------------------------------------------------
+
+
+def test_existing_env_var_is_passthrough(isolated_data_dir, monkeypatch):
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN", "operator-supplied")
+    result = security_bootstrap.ensure_overlay_server_token()
+    assert result == "operator-supplied"
+    assert os.environ["OVERLAY_SERVER_TOKEN"] == "operator-supplied"
+    # Pre-set tokens must not be persisted — operator already manages
+    # the value via env, persisting would shadow a future change.
+    assert not (isolated_data_dir / ".overlay_server_token").exists()
+
+
+def test_whitespace_only_env_treated_as_unset(isolated_data_dir, monkeypatch):
+    monkeypatch.setenv("OVERLAY_SERVER_TOKEN", "   ")
+    result = security_bootstrap.ensure_overlay_server_token()
+    # Falls through to mint a fresh token rather than honouring "   ".
+    assert result is not None and len(result) > 10
+    assert os.environ["OVERLAY_SERVER_TOKEN"] == result
+
+
+# ---------------------------------------------------------------------------
+# Path 3 — persisted file
+# ---------------------------------------------------------------------------
+
+
+def test_persisted_token_is_loaded(isolated_data_dir, monkeypatch):
+    persisted = isolated_data_dir / ".overlay_server_token"
+    persisted.write_text("from-disk-token", encoding="utf-8")
+    result = security_bootstrap.ensure_overlay_server_token()
+    assert result == "from-disk-token"
+    assert os.environ["OVERLAY_SERVER_TOKEN"] == "from-disk-token"
+
+
+def test_persisted_token_with_trailing_whitespace_is_trimmed(
+    isolated_data_dir, monkeypatch,
+):
+    persisted = isolated_data_dir / ".overlay_server_token"
+    persisted.write_text("trimmed-token\n", encoding="utf-8")
+    assert security_bootstrap.ensure_overlay_server_token() == "trimmed-token"
+
+
+def test_empty_persisted_file_falls_through_to_generation(
+    isolated_data_dir, monkeypatch,
+):
+    persisted = isolated_data_dir / ".overlay_server_token"
+    persisted.write_text("", encoding="utf-8")
+    result = security_bootstrap.ensure_overlay_server_token()
+    assert result is not None and len(result) > 10
+    # The empty file should have been overwritten with the new token.
+    assert persisted.read_text(encoding="utf-8") == result
+
+
+# ---------------------------------------------------------------------------
+# Path 4 — auto-generation
+# ---------------------------------------------------------------------------
+
+
+def test_auto_generates_persists_and_sets_env(isolated_data_dir):
+    result = security_bootstrap.ensure_overlay_server_token()
+    assert result is not None
+    assert len(result) >= 32  # token_urlsafe(32) → ~43 chars
+    assert os.environ["OVERLAY_SERVER_TOKEN"] == result
+    persisted = isolated_data_dir / ".overlay_server_token"
+    assert persisted.exists()
+    assert persisted.read_text(encoding="utf-8") == result
+
+
+def test_persisted_file_has_owner_only_permissions(isolated_data_dir):
+    security_bootstrap.ensure_overlay_server_token()
+    persisted = isolated_data_dir / ".overlay_server_token"
+    mode = persisted.stat().st_mode
+    # Group and other bits must be cleared — the token is a credential.
+    assert not (mode & stat.S_IRGRP)
+    assert not (mode & stat.S_IWGRP)
+    assert not (mode & stat.S_IROTH)
+    assert not (mode & stat.S_IWOTH)
+
+
+def test_subsequent_calls_are_idempotent(isolated_data_dir):
+    """A second call must reuse the persisted token rather than rotating it."""
+    first = security_bootstrap.ensure_overlay_server_token()
+    # Simulate a process restart by clearing the env var only — the
+    # file on disk should drive the next resolution.
+    del os.environ["OVERLAY_SERVER_TOKEN"]
+    second = security_bootstrap.ensure_overlay_server_token()
+    assert first == second
+
+
+def test_generation_failure_to_persist_still_returns_token(
+    isolated_data_dir, monkeypatch, caplog,
+):
+    """If the data dir is unwritable, the in-memory token still works."""
+    def fail_write(path: Path, token: str) -> bool:
+        return False
+
+    monkeypatch.setattr(security_bootstrap, "_write_persisted_token", fail_write)
+    with caplog.at_level(logging.WARNING, logger="app.security_bootstrap"):
+        result = security_bootstrap.ensure_overlay_server_token()
+    assert result is not None
+    assert os.environ["OVERLAY_SERVER_TOKEN"] == result
+    assert any("could not persist" in rec.message.lower()
+               for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# SCOREBOARD_USERS warning
+# ---------------------------------------------------------------------------
+
+
+def test_scoreboard_warning_when_unset(monkeypatch, caplog):
+    with caplog.at_level(logging.WARNING, logger="app.security_bootstrap"):
+        security_bootstrap.warn_if_open_scoreboard()
+    assert any("SCOREBOARD_USERS" in rec.message for rec in caplog.records)
+
+
+def test_scoreboard_no_warning_when_set(monkeypatch, caplog):
+    monkeypatch.setenv("SCOREBOARD_USERS", '{"alice": {"password": "x"}}')
+    with caplog.at_level(logging.WARNING, logger="app.security_bootstrap"):
+        security_bootstrap.warn_if_open_scoreboard()
+    assert not any("SCOREBOARD_USERS" in rec.message
+                   for rec in caplog.records)
+
+
+def test_scoreboard_no_warning_when_explicitly_disabled(monkeypatch, caplog):
+    monkeypatch.setenv("SCOREBOARD_USERS_DISABLED", "true")
+    with caplog.at_level(logging.WARNING, logger="app.security_bootstrap"):
+        security_bootstrap.warn_if_open_scoreboard()
+    assert not any("SCOREBOARD_USERS" in rec.message
+                   for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+def test_run_security_bootstrap_swallows_exceptions(monkeypatch, caplog):
+    """A failure in one bootstrap step must not block startup."""
+    def boom() -> None:
+        raise RuntimeError("simulated")
+
+    monkeypatch.setattr(
+        security_bootstrap, "ensure_overlay_server_token", boom,
+    )
+    monkeypatch.setattr(
+        security_bootstrap, "warn_if_open_scoreboard", boom,
+    )
+    with caplog.at_level(logging.ERROR, logger="app.security_bootstrap"):
+        security_bootstrap.run_security_bootstrap()
+    # Both failures should have been logged via logger.exception.
+    failure_records = [
+        rec for rec in caplog.records if "failed" in rec.message.lower()
+    ]
+    assert len(failure_records) >= 2

--- a/tests/test_security_enhancements.py
+++ b/tests/test_security_enhancements.py
@@ -82,6 +82,14 @@ def test_html_response_carries_csp_and_xframe(headers_client):
     csp = res.headers.get("content-security-policy", "")
     assert "default-src 'self'" in csp
     assert "frame-ancestors 'self'" in csp
+    # Default img-src must not contain a bare ``http:`` token —
+    # HTTPS deployments would block mixed-content images anyway.
+    img_directive = next(
+        (p.strip() for p in csp.split(";") if p.strip().startswith("img-src")),
+        "",
+    )
+    assert " http:" not in f" {img_directive} "
+    assert "https:" in img_directive
     assert res.headers.get("x-frame-options") == "SAMEORIGIN"
 
 
@@ -174,8 +182,17 @@ def test_rate_limit_blocks_after_repeated_failures(monkeypatch):
     assert res.status_code == 429
 
 
-def test_rate_limit_resets_on_success(monkeypatch):
-    monkeypatch.setenv("AUTH_RATE_LIMIT_MAX_FAILURES", "5")
+def test_rate_limit_does_not_reset_on_intervening_success(monkeypatch):
+    """A successful response on a public endpoint must not launder failures.
+
+    Earlier revisions cleared the bucket on any non-401/403 outcome,
+    which let an attacker interleave login attempts with hits to
+    ``/api/v1/admin/status`` (a 200, no auth) to keep the failure
+    count below the threshold. The current implementation only ever
+    appends to the bucket — old failures fall out of the sliding
+    window on their own.
+    """
+    monkeypatch.setenv("AUTH_RATE_LIMIT_MAX_FAILURES", "3")
     import importlib
 
     importlib.reload(auth_rate_limit)
@@ -188,14 +205,52 @@ def test_rate_limit_resets_on_success(monkeypatch):
     client = TestClient(app)
 
     bad = {"Authorization": "Bearer wrong"}
-    good = {"Authorization": "Bearer correct-horse"}
+    # Two failures, then a public 200 (status check), then a third
+    # failure must still trip the limit on the next attempt.
     for _ in range(2):
         assert client.post("/api/v1/admin/login", headers=bad).status_code == 403
-    # A success drops the bucket entirely.
-    assert client.post("/api/v1/admin/login", headers=good).status_code == 200
-    # Another four failures should still be allowed (fresh bucket).
-    for _ in range(4):
-        assert client.post("/api/v1/admin/login", headers=bad).status_code == 403
+    assert client.get("/api/v1/admin/status").status_code == 200
+    assert client.post("/api/v1/admin/login", headers=bad).status_code == 403
+    # 3 failures in the window; the 4th request must be blocked even
+    # though a 200 happened in the middle.
+    res = client.post("/api/v1/admin/login", headers=bad)
+    assert res.status_code == 429
+
+
+def test_rate_limit_uses_socket_peer_not_xff(monkeypatch):
+    """The limiter must ignore client-supplied ``X-Forwarded-For``.
+
+    Trusting the leftmost XFF would let an attacker mint a fresh
+    bucket per request by varying the header. The middleware now
+    relies on ``scope["client"]`` only, which the ASGI server
+    populates from the socket peer (or from a trusted proxy hop
+    when ``--proxy-headers`` is configured).
+    """
+    monkeypatch.setenv("AUTH_RATE_LIMIT_MAX_FAILURES", "3")
+    import importlib
+
+    importlib.reload(auth_rate_limit)
+    from app.api.middleware.auth_rate_limit import AuthRateLimitMiddleware as M
+
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "correct-horse")
+    app = FastAPI()
+    app.include_router(admin_router)
+    app.add_middleware(M)
+    client = TestClient(app)
+
+    bad = {"Authorization": "Bearer wrong"}
+    # Vary X-Forwarded-For across requests; if it were trusted, each
+    # request would hit a fresh bucket and never trip the limit.
+    for i in range(3):
+        spoof = {**bad, "X-Forwarded-For": f"10.0.0.{i}"}
+        assert client.post(
+            "/api/v1/admin/login", headers=spoof,
+        ).status_code == 403
+    res = client.post(
+        "/api/v1/admin/login",
+        headers={**bad, "X-Forwarded-For": "10.0.0.99"},
+    )
+    assert res.status_code == 429
 
 
 def test_rate_limit_ignores_unwatched_paths(monkeypatch):
@@ -308,3 +363,41 @@ def test_update_customization_rejects_non_dict(api_session):
 
     res = GameService.update_customization(api_session, "not a dict")
     assert res.success is False
+
+
+@pytest.mark.parametrize("bad_value", [
+    {"nested": "object"},
+    ["array", "of", "strings"],
+    [],
+    {},
+])
+def test_update_customization_rejects_nested_types(api_session, bad_value):
+    """Only scalar JSON types may be stored — arrays / objects bypass
+    the per-string length cap and would balloon the broadcast payload
+    via deep merge.
+    """
+    from app.api.game_service import GameService
+
+    res = GameService.update_customization(
+        api_session, {"Team 1 Name": bad_value},
+    )
+    assert res.success is False
+    assert "string" in (res.message or "").lower() or "type" in (res.message or "").lower()
+
+
+@pytest.mark.parametrize("scalar_value", [
+    True,
+    False,
+    None,
+    42,
+    1.5,
+    "short string",
+])
+def test_update_customization_accepts_scalar_types(api_session, scalar_value):
+    """Booleans, numbers, None, and short strings are all valid."""
+    from app.api.game_service import GameService
+
+    res = GameService.update_customization(
+        api_session, {"Team 1 Name": scalar_value},
+    )
+    assert res.success is True

--- a/tests/test_security_enhancements.py
+++ b/tests/test_security_enhancements.py
@@ -1,0 +1,310 @@
+"""Coverage for the security-hardening middlewares and validators.
+
+Pins:
+
+* :mod:`app.api.middleware.security_headers` — every response carries
+  the always-on headers; HTML responses additionally carry CSP and
+  ``X-Frame-Options``; ``/api/v1/`` JSON gains ``Cache-Control:
+  no-store``.
+* :mod:`app.api.middleware.auth_rate_limit` — repeated 401/403 from
+  the same client IP eventually flips to 429 with ``Retry-After``.
+* :mod:`app.api.schemas.is_safe_logo_url` and the customization
+  payload caps in :mod:`app.api.game_service`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.admin import admin_router
+from app.api.middleware import auth_rate_limit
+from app.api.middleware.auth_rate_limit import AuthRateLimitMiddleware
+from app.api.middleware.security_headers import SecurityHeadersMiddleware
+from app.api.schemas import (
+    MAX_LOGO_VALUE_LENGTH,
+    MAX_STRING_VALUE_LENGTH,
+    is_safe_logo_url,
+)
+
+# ---------------------------------------------------------------------------
+# Security headers
+# ---------------------------------------------------------------------------
+
+
+def _build_headers_app() -> FastAPI:
+    """Minimal app exercising all three response-shape branches."""
+    app = FastAPI()
+
+    @app.get("/api/v1/state")
+    def api_json():
+        return {"ok": True}
+
+    @app.get("/manage", response_class=None)
+    def manage_html():
+        from fastapi.responses import HTMLResponse
+        return HTMLResponse("<!doctype html><title>x</title>")
+
+    @app.get("/overlay/x", response_class=None)
+    def overlay_html():
+        from fastapi.responses import HTMLResponse
+        return HTMLResponse("<!doctype html><title>x</title>")
+
+    app.add_middleware(SecurityHeadersMiddleware)
+    return app
+
+
+@pytest.fixture
+def headers_client():
+    return TestClient(_build_headers_app())
+
+
+def test_always_on_headers_present_on_json(headers_client):
+    res = headers_client.get("/api/v1/state")
+    assert res.status_code == 200
+    assert res.headers["x-content-type-options"] == "nosniff"
+    assert "referrer-policy" in res.headers
+    assert "permissions-policy" in res.headers
+    # JSON responses should not get CSP / XFO (HTML-only headers).
+    assert "content-security-policy" not in res.headers
+    assert "x-frame-options" not in res.headers
+
+
+def test_api_v1_response_disables_caching(headers_client):
+    res = headers_client.get("/api/v1/state")
+    assert res.headers.get("cache-control") == "no-store"
+
+
+def test_html_response_carries_csp_and_xframe(headers_client):
+    res = headers_client.get("/manage")
+    assert res.status_code == 200
+    csp = res.headers.get("content-security-policy", "")
+    assert "default-src 'self'" in csp
+    assert "frame-ancestors 'self'" in csp
+    assert res.headers.get("x-frame-options") == "SAMEORIGIN"
+
+
+def test_overlay_html_relaxes_frame_ancestors(headers_client):
+    res = headers_client.get("/overlay/x")
+    csp = res.headers.get("content-security-policy", "")
+    # OBS browser sources need to embed cross-origin.
+    assert "frame-ancestors *" in csp
+    # No legacy XFO that would block embedding either.
+    assert "x-frame-options" not in res.headers
+
+
+def test_existing_cache_control_is_preserved(headers_client, monkeypatch):
+    app = FastAPI()
+
+    @app.get("/api/v1/cached")
+    def cached():
+        from fastapi.responses import JSONResponse
+        return JSONResponse(
+            {"ok": True}, headers={"Cache-Control": "public, max-age=60"},
+        )
+
+    app.add_middleware(SecurityHeadersMiddleware)
+    client = TestClient(app)
+    res = client.get("/api/v1/cached")
+    assert res.headers["cache-control"] == "public, max-age=60"
+
+
+def test_hsts_opt_in(monkeypatch):
+    monkeypatch.setenv("SECURITY_HSTS_SECONDS", "86400")
+    app = FastAPI()
+
+    @app.get("/api/v1/state")
+    def s():
+        return {"ok": True}
+
+    app.add_middleware(SecurityHeadersMiddleware)
+    res = TestClient(app).get("/api/v1/state")
+    assert "strict-transport-security" in res.headers
+    assert "max-age=86400" in res.headers["strict-transport-security"]
+
+
+# ---------------------------------------------------------------------------
+# Auth rate limiting
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limit():
+    auth_rate_limit._reset_for_tests()
+    yield
+    auth_rate_limit._reset_for_tests()
+
+
+def _build_rate_limit_app(monkeypatch) -> FastAPI:
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "correct-horse")
+    app = FastAPI()
+    app.include_router(admin_router)
+    app.add_middleware(AuthRateLimitMiddleware)
+    return app
+
+
+def test_rate_limit_blocks_after_repeated_failures(monkeypatch):
+    monkeypatch.setenv("AUTH_RATE_LIMIT_MAX_FAILURES", "3")
+    monkeypatch.setenv("AUTH_RATE_LIMIT_WINDOW_SECONDS", "60")
+    monkeypatch.setenv("AUTH_RATE_LIMIT_BLOCK_SECONDS", "60")
+    # Module reads its tunables at import time, so reload them.
+    import importlib
+
+    importlib.reload(auth_rate_limit)
+    from app.api.middleware.auth_rate_limit import AuthRateLimitMiddleware as M
+
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "correct-horse")
+    app = FastAPI()
+    app.include_router(admin_router)
+    app.add_middleware(M)
+    client = TestClient(app)
+
+    bad = {"Authorization": "Bearer wrong"}
+    # 3 failures fill the bucket, the 4th request must be blocked.
+    for _ in range(3):
+        assert client.post("/api/v1/admin/login", headers=bad).status_code == 403
+    res = client.post("/api/v1/admin/login", headers=bad)
+    assert res.status_code == 429
+    assert res.headers.get("retry-after")
+    # And subsequent attempts stay blocked, including with a *correct*
+    # password — the bucket gates the IP, not the credential.
+    good = {"Authorization": "Bearer correct-horse"}
+    res = client.post("/api/v1/admin/login", headers=good)
+    assert res.status_code == 429
+
+
+def test_rate_limit_resets_on_success(monkeypatch):
+    monkeypatch.setenv("AUTH_RATE_LIMIT_MAX_FAILURES", "5")
+    import importlib
+
+    importlib.reload(auth_rate_limit)
+    from app.api.middleware.auth_rate_limit import AuthRateLimitMiddleware as M
+
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "correct-horse")
+    app = FastAPI()
+    app.include_router(admin_router)
+    app.add_middleware(M)
+    client = TestClient(app)
+
+    bad = {"Authorization": "Bearer wrong"}
+    good = {"Authorization": "Bearer correct-horse"}
+    for _ in range(2):
+        assert client.post("/api/v1/admin/login", headers=bad).status_code == 403
+    # A success drops the bucket entirely.
+    assert client.post("/api/v1/admin/login", headers=good).status_code == 200
+    # Another four failures should still be allowed (fresh bucket).
+    for _ in range(4):
+        assert client.post("/api/v1/admin/login", headers=bad).status_code == 403
+
+
+def test_rate_limit_ignores_unwatched_paths(monkeypatch):
+    """A 401 from outside the watched prefix list should not poison the bucket."""
+    import importlib
+
+    importlib.reload(auth_rate_limit)
+    from app.api.middleware.auth_rate_limit import AuthRateLimitMiddleware as M
+
+    app = FastAPI()
+    app.add_middleware(M)
+
+    @app.get("/random")
+    def r():
+        from fastapi import HTTPException
+        raise HTTPException(status_code=401, detail="nope")
+
+    client = TestClient(app)
+    # 100 failures on /random must never trigger 429; the path isn't watched.
+    for _ in range(100):
+        assert client.get("/random").status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Logo URL allow-list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("url", [
+    "https://cdn.example.com/logo.png",
+    "http://example.com/logo.svg",
+    "//cdn.example.com/logo.png",
+    "data:image/png;base64,iVBORw0KGgo=",
+    "  https://example.com/logo.png  ",
+])
+def test_logo_url_accepts_safe_schemes(url):
+    assert is_safe_logo_url(url) is True
+
+
+@pytest.mark.parametrize("url", [
+    "javascript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox",
+    "file:///etc/passwd",
+    "",
+    "   ",
+    None,
+    123,
+])
+def test_logo_url_rejects_unsafe(url):
+    assert is_safe_logo_url(url) is False
+
+
+def test_logo_url_rejects_overlong():
+    assert is_safe_logo_url("https://" + "a" * (MAX_LOGO_VALUE_LENGTH + 1)) is False
+
+
+# ---------------------------------------------------------------------------
+# Customization payload caps
+# ---------------------------------------------------------------------------
+
+
+def test_update_customization_rejects_unsafe_logo(api_session):
+    from app.api.game_service import GameService
+
+    res = GameService.update_customization(
+        api_session, {"Team 1 Logo": "javascript:alert(1)"},
+    )
+    assert res.success is False
+    assert "scheme" in (res.message or "").lower()
+
+
+def test_update_customization_rejects_overlong_string(api_session):
+    from app.api.game_service import GameService
+
+    res = GameService.update_customization(
+        api_session,
+        {"Team 1 Name": "A" * (MAX_STRING_VALUE_LENGTH + 1)},
+    )
+    assert res.success is False
+    assert "exceeds" in (res.message or "").lower()
+
+
+def test_update_customization_rejects_too_many_keys(api_session):
+    from app.api.game_service import GameService
+    from app.api.schemas import MAX_CUSTOMIZATION_KEYS
+
+    payload = {f"k{i}": "v" for i in range(MAX_CUSTOMIZATION_KEYS + 1)}
+    res = GameService.update_customization(api_session, payload)
+    assert res.success is False
+    assert "keys" in (res.message or "").lower()
+
+
+def test_update_customization_accepts_safe_payload(api_session):
+    from app.api.game_service import GameService
+
+    res = GameService.update_customization(
+        api_session,
+        {
+            "Team 1 Name": "Wolves",
+            "Team 1 Logo": "https://example.com/wolves.png",
+            "Team 2 Logo": "data:image/svg+xml;base64,PHN2Zy8+",
+        },
+    )
+    assert res.success is True
+
+
+def test_update_customization_rejects_non_dict(api_session):
+    from app.api.game_service import GameService
+
+    res = GameService.update_customization(api_session, "not a dict")
+    assert res.success is False

--- a/tests/test_signed_urls_and_ws_subprotocol.py
+++ b/tests/test_signed_urls_and_ws_subprotocol.py
@@ -1,0 +1,411 @@
+"""Coverage for the H-4 query-string-secret hardening.
+
+Two surfaces are pinned:
+
+* :mod:`app.match_report_signing` — HMAC-signed match-report URLs
+  and the corresponding admin endpoint
+  ``POST /api/v1/admin/match/{match_id}/sign-url``. The admin
+  password no longer needs to be on the URL line.
+* :mod:`app.api.routes.websocket` — the ``/api/v1/ws`` route now
+  prefers the Bearer subprotocol (``Sec-WebSocket-Protocol:
+  bearer, <token>``) over the legacy ``?token=`` query param,
+  echoing the chosen subprotocol back to the client during
+  ``ws.accept`` so browser clients don't drop the connection.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app import match_report_signing
+from app.admin import admin_router
+from app.api.middleware import auth_rate_limit
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch):
+    monkeypatch.delenv("OVERLAY_MANAGER_PASSWORD", raising=False)
+    monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
+    auth_rate_limit._reset_for_tests()
+    yield
+    auth_rate_limit._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# match_report_signing module
+# ---------------------------------------------------------------------------
+
+
+def test_signing_returns_none_when_admin_password_unset():
+    assert match_report_signing.make_signed_query("m") is None
+
+
+def test_signing_returns_none_for_verify_when_admin_password_unset():
+    assert (
+        match_report_signing.verify_signed_query("m", "100", "deadbeef")
+        is False
+    )
+
+
+def test_signed_query_round_trips(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "k")
+    out = match_report_signing.make_signed_query("match-1", ttl_seconds=600)
+    assert out is not None
+    assert out["expires_at"] == out["exp"]
+    assert match_report_signing.verify_signed_query(
+        "match-1", out["exp"], out["sig"],
+    )
+
+
+def test_verify_rejects_expired(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "k")
+    out = match_report_signing.make_signed_query(
+        "match-1", ttl_seconds=match_report_signing.MIN_TTL_SECONDS,
+    )
+    assert out is not None
+    # Pretend we're far in the future.
+    future = out["exp"] + 1
+    assert (
+        match_report_signing.verify_signed_query(
+            "match-1", out["exp"], out["sig"], now=future,
+        )
+        is False
+    )
+
+
+def test_verify_rejects_tampered_match_id(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "k")
+    out = match_report_signing.make_signed_query("match-1", ttl_seconds=600)
+    assert out is not None
+    # Same exp + sig, different match_id → must fail.
+    assert (
+        match_report_signing.verify_signed_query(
+            "match-2", out["exp"], out["sig"],
+        )
+        is False
+    )
+
+
+def test_verify_rejects_tampered_sig(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "k")
+    out = match_report_signing.make_signed_query("match-1", ttl_seconds=600)
+    assert out is not None
+    bad_sig = "0" * len(out["sig"])
+    assert (
+        match_report_signing.verify_signed_query(
+            "match-1", out["exp"], bad_sig,
+        )
+        is False
+    )
+
+
+def test_verify_handles_malformed_inputs(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "k")
+    # Non-numeric exp.
+    assert (
+        match_report_signing.verify_signed_query("m", "not-a-number", "x")
+        is False
+    )
+    # Empty sig.
+    assert match_report_signing.verify_signed_query("m", 100, "") is False
+    # None sig.
+    assert match_report_signing.verify_signed_query("m", 100, None) is False
+    # None exp.
+    assert match_report_signing.verify_signed_query("m", None, "x") is False
+
+
+def test_password_rotation_invalidates_old_signatures(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "old")
+    out = match_report_signing.make_signed_query("match-1", ttl_seconds=600)
+    assert out is not None
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "new")
+    assert (
+        match_report_signing.verify_signed_query(
+            "match-1", out["exp"], out["sig"],
+        )
+        is False
+    )
+
+
+def test_clamp_ttl_bounds():
+    assert (
+        match_report_signing.clamp_ttl(-1)
+        == match_report_signing.DEFAULT_TTL_SECONDS
+    )
+    assert (
+        match_report_signing.clamp_ttl(0)
+        == match_report_signing.DEFAULT_TTL_SECONDS
+    )
+    # Below floor → snapped up to MIN.
+    assert (
+        match_report_signing.clamp_ttl(1)
+        == match_report_signing.MIN_TTL_SECONDS
+    )
+    # Above ceiling → snapped down to MAX.
+    assert (
+        match_report_signing.clamp_ttl(10**9)
+        == match_report_signing.MAX_TTL_SECONDS
+    )
+    # ``None`` and garbage fall back to the default.
+    assert (
+        match_report_signing.clamp_ttl(None)
+        == match_report_signing.DEFAULT_TTL_SECONDS
+    )
+    assert (
+        match_report_signing.clamp_ttl("not-a-number")
+        == match_report_signing.DEFAULT_TTL_SECONDS
+    )
+
+
+# ---------------------------------------------------------------------------
+# Admin sign-url endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def admin_client(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "admin-pw")
+    app = FastAPI()
+    app.include_router(admin_router)
+    return TestClient(app)
+
+
+def _admin_headers(pw: str = "admin-pw"):
+    return {"Authorization": f"Bearer {pw}"}
+
+
+def test_sign_url_requires_admin(admin_client):
+    res = admin_client.post(
+        "/api/v1/admin/match/m1/sign-url", json={},
+    )
+    assert res.status_code == 401
+
+
+def test_sign_url_returns_capability_url(admin_client):
+    res = admin_client.post(
+        "/api/v1/admin/match/match-abc/sign-url",
+        json={},
+        headers=_admin_headers(),
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["url"].endswith(
+        f"?exp={body['expires_at']}&sig=" + body["url"].rsplit("sig=", 1)[1],
+    )
+    # Crucial: the admin password must NOT appear in the URL.
+    assert "admin-pw" not in body["url"]
+    # And the URL is for the right match.
+    assert "/match/match-abc/report" in body["url"]
+
+
+def test_sign_url_respects_ttl(admin_client):
+    res = admin_client.post(
+        "/api/v1/admin/match/m1/sign-url",
+        json={"ttl_seconds": 60},
+        headers=_admin_headers(),
+    )
+    assert res.status_code == 200
+    body = res.json()
+    # Expires_in is bounded — we just minted it, should be near 60.
+    assert 50 <= body["expires_in"] <= 60
+
+
+def test_sign_url_rejects_out_of_range_ttl(admin_client):
+    # Above MAX_TTL_SECONDS → 422 from Pydantic Field bound.
+    res = admin_client.post(
+        "/api/v1/admin/match/m1/sign-url",
+        json={"ttl_seconds": 10**9},
+        headers=_admin_headers(),
+    )
+    assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /match/{match_id}/report — signed URL access path
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def gated_match(monkeypatch):
+    """Seed an archive entry that needs auth to read.
+
+    Returns ``(client, match_id)``.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from app.api import action_log, match_archive
+    from app.match_report import match_report_router
+
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "admin-pw")
+    monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
+
+    action_log.append(
+        "sig-oid", "add_point", {"team": 1, "undo": False},
+        {"team_1": {"score": 1}},
+    )
+    match_id = match_archive.archive_match(
+        oid="sig-oid",
+        final_state={
+            "current_set": 1,
+            "team_1": {"sets": 1, "timeouts": 0, "scores": {"set_1": 25}},
+            "team_2": {"sets": 0, "timeouts": 0, "scores": {"set_1": 20}},
+        },
+        customization={"Team 1 Name": "Home", "Team 2 Name": "Away"},
+        started_at=time.time() - 100,
+        winning_team=1,
+        points_limit=25,
+        points_limit_last_set=15,
+        sets_limit=3,
+    )
+    app = FastAPI()
+    app.include_router(match_report_router)
+    return TestClient(app), match_id
+
+
+def test_signed_url_grants_access_without_password(gated_match):
+    client, match_id = gated_match
+    out = match_report_signing.make_signed_query(match_id, ttl_seconds=600)
+    assert out is not None
+
+    res = client.get(
+        f"/match/{match_id}/report",
+        params={"exp": out["exp"], "sig": out["sig"]},
+    )
+    assert res.status_code == 200
+    assert "Home" in res.text
+
+
+def test_expired_signed_url_falls_back_to_password(gated_match):
+    client, match_id = gated_match
+    out = match_report_signing.make_signed_query(
+        match_id, ttl_seconds=match_report_signing.MIN_TTL_SECONDS,
+    )
+    assert out is not None
+    # Manually rewrite exp to the past.
+    res = client.get(
+        f"/match/{match_id}/report",
+        params={"exp": int(time.time()) - 60, "sig": out["sig"]},
+    )
+    # Falls through to the require-admin-token branch — without a
+    # Bearer header that's a 401.
+    assert res.status_code == 401
+
+
+def test_tampered_signature_is_rejected(gated_match):
+    client, match_id = gated_match
+    out = match_report_signing.make_signed_query(match_id, ttl_seconds=600)
+    assert out is not None
+    res = client.get(
+        f"/match/{match_id}/report",
+        params={"exp": out["exp"], "sig": "0" * len(out["sig"])},
+    )
+    assert res.status_code in (401, 403)
+
+
+def test_signed_url_for_other_match_does_not_grant_access(gated_match):
+    client, match_id = gated_match
+    other = match_report_signing.make_signed_query("other-match", 600)
+    assert other is not None
+    res = client.get(
+        f"/match/{match_id}/report",
+        params={"exp": other["exp"], "sig": other["sig"]},
+    )
+    # The signature is for ``other-match``, not this match_id; the
+    # signed-URL path must reject it and the request falls through to
+    # the password-required branch (no Bearer header → 401/403).
+    assert res.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket Bearer subprotocol auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ws_client(monkeypatch):
+    """SCOREBOARD_USERS-protected app with a single user."""
+    from fastapi import FastAPI
+
+    from app.api import api_router
+    from app.api.session_manager import SessionManager
+    from app.api.ws_hub import WSHub
+
+    SessionManager.clear()
+    WSHub.clear()
+    users = json.dumps({"alice": {"password": "alice-pw"}})
+    monkeypatch.setenv("SCOREBOARD_USERS", users)
+    app = FastAPI()
+    app.include_router(api_router)
+    client = TestClient(app)
+
+    # Initialise a session so the WS endpoint reaches the auth check
+    # before the SessionManager.get None branch.
+    res = client.post(
+        "/api/v1/session/init",
+        json={"oid": "test_overlay"},
+        headers={"Authorization": "Bearer alice-pw"},
+    )
+    assert res.status_code == 200, res.text
+
+    yield client
+    SessionManager.clear()
+    WSHub.clear()
+
+
+def test_ws_accepts_bearer_subprotocol(ws_client):
+    # TestClient.websocket_connect supports the ``subprotocols`` arg
+    # which becomes the ``Sec-WebSocket-Protocol`` header.
+    with ws_client.websocket_connect(
+        "/api/v1/ws?oid=test_overlay",
+        subprotocols=["bearer", "alice-pw"],
+    ) as ws:
+        # Server must echo back the chosen subprotocol so the browser
+        # accepts the connection.
+        assert ws.accepted_subprotocol == "bearer"
+        # Initial state_update should be delivered immediately.
+        msg = ws.receive_json()
+        assert msg["type"] == "state_update"
+
+
+def test_ws_rejects_invalid_bearer_subprotocol(ws_client):
+    from starlette.websockets import WebSocketDisconnect
+
+    with pytest.raises(WebSocketDisconnect):
+        with ws_client.websocket_connect(
+            "/api/v1/ws?oid=test_overlay",
+            subprotocols=["bearer", "wrong-password"],
+        ):
+            pass
+
+
+def test_ws_legacy_query_token_still_works(ws_client):
+    """Legacy ?token= path is preserved so older CLI clients keep working."""
+    with ws_client.websocket_connect(
+        "/api/v1/ws?oid=test_overlay&token=alice-pw",
+    ) as ws:
+        # No subprotocol negotiated — ``accepted_subprotocol`` is None.
+        assert ws.accepted_subprotocol is None
+        msg = ws.receive_json()
+        assert msg["type"] == "state_update"
+
+
+def test_ws_subprotocol_takes_precedence_over_query(ws_client):
+    """When both auth modes are present, the subprotocol wins.
+
+    Pinning this avoids a regression where a future refactor reorders
+    the resolution and silently downgrades a Bearer-subprotocol
+    client to query-token semantics (e.g. logging the legacy path).
+    """
+    with ws_client.websocket_connect(
+        "/api/v1/ws?oid=test_overlay&token=wrong-password",
+        subprotocols=["bearer", "alice-pw"],
+    ) as ws:
+        assert ws.accepted_subprotocol == "bearer"
+        msg = ws.receive_json()
+        assert msg["type"] == "state_update"

--- a/tests/test_trusted_hosts_and_cors.py
+++ b/tests/test_trusted_hosts_and_cors.py
@@ -1,0 +1,201 @@
+"""Coverage for the opt-in middlewares wired in PR 5 of the security plan.
+
+Both ``TrustedHostMiddleware`` and ``CORSMiddleware`` are off by
+default — operators that are happy with the bundled same-origin
+deployment see no behavior change. When they're configured via env
+vars, the helpers in :mod:`app.bootstrap` install them with a few
+defensive defaults (no wildcard CORS on a credentialed API, etc.)
+that are pinned here.
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib import reload
+from typing import Iterable
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _build_app(monkeypatch, *, trusted_hosts: Iterable[str] | None = None,
+               cors_origins: Iterable[str] | None = None) -> FastAPI:
+    """Re-create a FastAPI app with the given env-var configuration.
+
+    ``app.bootstrap._maybe_register_*`` reads from ``os.environ`` at
+    call time, so the test sets the env var, calls ``create_app``,
+    and gets a fresh wiring per case. Other env vars are deliberately
+    left to ``conftest`` defaults to keep the harness minimal.
+    """
+    monkeypatch.delenv("TRUSTED_HOSTS", raising=False)
+    monkeypatch.delenv("CORS_ALLOWED_ORIGINS", raising=False)
+    if trusted_hosts is not None:
+        monkeypatch.setenv("TRUSTED_HOSTS", ",".join(trusted_hosts))
+    if cors_origins is not None:
+        monkeypatch.setenv("CORS_ALLOWED_ORIGINS", ",".join(cors_origins))
+
+    # Reload bootstrap so any cached env-var reads are dropped — the
+    # helper functions read ``os.environ`` directly so this is mainly
+    # cosmetic, but it documents the intent.
+    from app import bootstrap as bootstrap_module
+    reload(bootstrap_module)
+    return bootstrap_module.create_app()
+
+
+# ---------------------------------------------------------------------------
+# TrustedHostMiddleware
+# ---------------------------------------------------------------------------
+
+
+def test_trusted_hosts_unset_does_not_enforce(monkeypatch):
+    app = _build_app(monkeypatch)
+    client = TestClient(app)
+    # Any Host header passes when the middleware isn't installed.
+    res = client.get("/health", headers={"Host": "evil.example.com"})
+    assert res.status_code == 200
+
+
+def test_trusted_hosts_rejects_unlisted_host(monkeypatch):
+    app = _build_app(monkeypatch, trusted_hosts=["scoreboard.example.com"])
+    client = TestClient(app)
+    res = client.get(
+        "/health",
+        headers={"Host": "evil.example.com"},
+    )
+    # Starlette returns 400 with body "Invalid host header".
+    assert res.status_code == 400
+    assert "host" in res.text.lower()
+
+
+def test_trusted_hosts_accepts_listed_host(monkeypatch):
+    app = _build_app(monkeypatch, trusted_hosts=["scoreboard.example.com"])
+    client = TestClient(app)
+    res = client.get(
+        "/health",
+        headers={"Host": "scoreboard.example.com"},
+    )
+    assert res.status_code == 200
+
+
+def test_trusted_hosts_supports_wildcard_subdomain(monkeypatch):
+    """Starlette's wildcard pattern is the cheapest way to allow many
+    subdomains; pin the syntax so a future swap doesn't silently
+    weaken host matching.
+    """
+    app = _build_app(monkeypatch, trusted_hosts=["*.example.com"])
+    client = TestClient(app)
+    ok = client.get("/health", headers={"Host": "a.example.com"})
+    assert ok.status_code == 200
+    rejected = client.get("/health", headers={"Host": "example.org"})
+    assert rejected.status_code == 400
+
+
+def test_trusted_hosts_csv_with_whitespace_is_split(monkeypatch):
+    app = _build_app(
+        monkeypatch,
+        trusted_hosts=["a.example.com", " b.example.com "],
+    )
+    client = TestClient(app)
+    assert client.get("/health", headers={"Host": "a.example.com"}).status_code == 200
+    # Whitespace must be stripped — ``b.example.com `` (trailing space)
+    # would never have matched a real Host header.
+    assert client.get("/health", headers={"Host": "b.example.com"}).status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# CORSMiddleware
+# ---------------------------------------------------------------------------
+
+
+def test_cors_unset_does_not_install_middleware(monkeypatch):
+    app = _build_app(monkeypatch)
+    client = TestClient(app)
+    res = client.get(
+        "/health",
+        headers={"Origin": "https://control.example.com"},
+    )
+    assert res.status_code == 200
+    # Without CORS the response carries no ``Access-Control-Allow-Origin``.
+    assert "access-control-allow-origin" not in res.headers
+
+
+def test_cors_explicit_origin_is_echoed(monkeypatch):
+    app = _build_app(
+        monkeypatch, cors_origins=["https://control.example.com"],
+    )
+    client = TestClient(app)
+    res = client.get(
+        "/health",
+        headers={"Origin": "https://control.example.com"},
+    )
+    assert res.status_code == 200
+    assert (
+        res.headers.get("access-control-allow-origin")
+        == "https://control.example.com"
+    )
+
+
+def test_cors_unlisted_origin_does_not_get_header(monkeypatch):
+    app = _build_app(
+        monkeypatch, cors_origins=["https://control.example.com"],
+    )
+    client = TestClient(app)
+    res = client.get(
+        "/health",
+        headers={"Origin": "https://evil.example.com"},
+    )
+    assert res.status_code == 200
+    # Unlisted origin: no CORS header echoed → browser blocks the
+    # response client-side.
+    assert "access-control-allow-origin" not in res.headers
+
+
+def test_cors_wildcard_is_rejected(monkeypatch, caplog):
+    """A bare ``*`` must be refused — it would defeat the
+    credentialed-API stance (Authorization header forwarding requires
+    an explicit allow-list)."""
+    with caplog.at_level(logging.ERROR, logger="app.bootstrap"):
+        app = _build_app(monkeypatch, cors_origins=["*"])
+    client = TestClient(app)
+    res = client.get(
+        "/health", headers={"Origin": "https://anything.example.com"},
+    )
+    # No CORS header — middleware was never installed.
+    assert res.status_code == 200
+    assert "access-control-allow-origin" not in res.headers
+    assert any("CORS_ALLOWED_ORIGINS=*" in rec.message for rec in caplog.records)
+
+
+def test_cors_preflight_passes_through(monkeypatch):
+    """Preflight requests must short-circuit without consulting auth."""
+    app = _build_app(
+        monkeypatch, cors_origins=["https://control.example.com"],
+    )
+    client = TestClient(app)
+    res = client.options(
+        "/api/v1/state",
+        headers={
+            "Origin": "https://control.example.com",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "Authorization",
+        },
+    )
+    # 200 from the CORS middleware — the route's auth dependency is
+    # never consulted on preflight.
+    assert res.status_code == 200
+    assert res.headers["access-control-allow-origin"] == "https://control.example.com"
+    assert "authorization" in res.headers.get(
+        "access-control-allow-headers", "",
+    ).lower()
+
+
+@pytest.fixture(autouse=True)
+def _restore_bootstrap():
+    """Reload bootstrap once at teardown so other test modules see a
+    clean module state (the fixture above reloads it per call but we
+    don't want a half-mutated module surviving the test class).
+    """
+    yield
+    from app import bootstrap as bootstrap_module
+    reload(bootstrap_module)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -131,12 +131,21 @@ class TestDispatch:
     def test_dispatch_posts_signed_body(self, monkeypatch):
         monkeypatch.setenv("WEBHOOKS_URL", "https://hooks.example.com/x")
         monkeypatch.setenv("WEBHOOKS_SECRET", "topsecret")
+        # Bypass the SSRF guard: ``hooks.example.com`` doesn't resolve
+        # in the test sandbox, but the existing tests assume the
+        # delivery proceeds. The guard's threat model is malicious /
+        # accidental private IPs, which is unrelated to this test.
+        monkeypatch.setenv("WEBHOOKS_ALLOW_PRIVATE_IPS", "true")
         d = WebhookDispatcher()
-        # Force synchronous delivery for assertion.
-        d._executor = None
         with patch("app.api.webhooks.requests.post") as post:
             post.return_value.status_code = 200
             queued = d.dispatch("set_end", "match-1", {"foo": 1})
+            # Drain the executor so the worker thread has run before
+            # we assert on the mock — pre-PR the assertion was racy
+            # and only worked because ``_deliver`` finished quickly.
+            if d._executor is not None:
+                d._executor.shutdown(wait=True)
+                d._executor = None
             assert queued == 1
             post.assert_called_once()
             kwargs = post.call_args.kwargs
@@ -160,11 +169,16 @@ class TestDispatch:
             {"url": "https://only-set.example.com", "events": ["set_end"]},
             {"url": "https://only-timeout.example.com", "events": ["timeout"]},
         ]))
+        # Sandbox DNS doesn't resolve example.com — bypass the SSRF
+        # guard so the original assertion still holds.
+        monkeypatch.setenv("WEBHOOKS_ALLOW_PRIVATE_IPS", "true")
         d = WebhookDispatcher()
-        d._executor = None
         with patch("app.api.webhooks.requests.post") as post:
             post.return_value.status_code = 200
             queued = d.dispatch("timeout", "oid", {})
+            if d._executor is not None:
+                d._executor.shutdown(wait=True)
+                d._executor = None
             assert queued == 1
             assert post.call_args.args[0] == "https://only-timeout.example.com"
 
@@ -173,8 +187,12 @@ class TestDispatch:
 
         import requests
         monkeypatch.setenv("WEBHOOKS_URL", "https://broken.example.com")
+        # Sandbox DNS doesn't resolve example.com; the SSRF guard
+        # would block this target before requests.post is reached
+        # and the test would assert on a different log record. The
+        # opt-out lets us still exercise the network-failure path.
+        monkeypatch.setenv("WEBHOOKS_ALLOW_PRIVATE_IPS", "true")
         d = WebhookDispatcher()
-        d._executor = None
 
         # Attach our own handler directly to the dispatcher's logger so the
         # assertion does not depend on caplog plumbing (which interacts
@@ -191,6 +209,11 @@ class TestDispatch:
             with patch("app.api.webhooks.requests.post",
                        side_effect=requests.ConnectionError("nope")):
                 d.dispatch("set_end", "oid", {})
+                # Drain the executor so the worker thread's log
+                # record lands before we inspect ``records``.
+                if d._executor is not None:
+                    d._executor.shutdown(wait=True)
+                    d._executor = None
         finally:
             webhook_logger.removeHandler(handler)
             webhook_logger.setLevel(prior_level)


### PR DESCRIPTION
## Summary

Promotes the merged six-PR security plan from `dev` to `main`. Every change has been merged individually into `dev` via PRs #258 through #263 (each Gemini-reviewed, each with green CI). This roll-up PR groups the work so the production branch picks them up in one named release.

## Findings closed

All H-tier and M-tier items from the original analysis, plus L-3 / L-4 / L-5 / L-6, plus the L-1 / L-2 polish.

## Sub-PRs (already on `dev`)

| PR | Title |
|---|---|
| #258 | Headers + rate limiting + customization validation |
| #259 | Auto-secure `OVERLAY_SERVER_TOKEN` + `SCOREBOARD_USERS` warning |
| #260 | Signed match-report URLs + WebSocket Bearer subprotocol |
| #261 | scrypt-hashed credentials at rest |
| #262 | TrustedHost + CORS + CI scanners + SECURITY.md |
| #263 | L-1 / L-2 / L-6 hardening (logging, `WWW-Authenticate`, webhook SSRF) |

## What ships

### New defensive middleware (opt-in or backwards-compatible)

- `SecurityHeadersMiddleware` — CSP, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy` on every response; CSP + `X-Frame-Options` on HTML; `Cache-Control: no-store` on `/api/v1/`. Override via `SECURITY_CSP`, `SECURITY_REFERRER_POLICY`, `SECURITY_PERMISSIONS_POLICY`, `SECURITY_HSTS_SECONDS`.
- `AuthRateLimitMiddleware` — per-IP brute-force limiter on `/api/v1/` and `/manage`. Uses `scope["client"]` (no `X-Forwarded-For` spoofing). Tunables: `AUTH_RATE_LIMIT_*`.
- `TrustedHostMiddleware` — opt-in via `TRUSTED_HOSTS`. Wildcard subdomains supported.
- `CORSMiddleware` — opt-in via `CORS_ALLOWED_ORIGINS` (explicit origins only; `*` rejected on this credentialed API).

### Auth ladder hardening

- `OVERLAY_SERVER_TOKEN` is **auto-generated and persisted** to `data/.overlay_server_token` on first start. `OVERLAY_SERVER_TOKEN_DISABLED=true` opts out (CRITICAL warning logged).
- `SCOREBOARD_USERS` unset emits a startup warning. `SCOREBOARD_USERS_DISABLED=true` silences it.
- All three credentials accept hashed-at-rest variants via `app/password_hash.py` (scrypt, zero-dependency, mint with `python -m app.password_hash`):
  - `SCOREBOARD_USERS.<user>.password_hash`
  - `OVERLAY_MANAGER_PASSWORD_HASH`
  - `OVERLAY_SERVER_TOKEN_HASH`
- 60-second per-process verify cache so hashed credentials don't slow the React UI's hot path.
- Every 401 carries `WWW-Authenticate: Bearer realm="..."` (RFC 7235 §4.1).

### Capability URLs replace query-string secrets

- `POST /api/v1/admin/match/{match_id}/sign-url` mints HMAC-signed match-report URLs (`?exp=&sig=`). The legacy `?token=<password>` flow is preserved but deprecated.
- `/api/v1/ws` accepts `Sec-WebSocket-Protocol: bearer, <token>`. Legacy `?token=` query still works.

### Input validation

- `PUT /api/v1/customization` enforces ≤64 keys, ≤256-char strings (8 KiB for logo URLs), only scalar JSON types, and an `http(s)`/`data:image` allow-list on logo URLs.

### Webhook SSRF guard

- Webhook dispatcher refuses targets that resolve to private/loopback/link-local/multicast/reserved IPs. Opt out via `WEBHOOKS_ALLOW_PRIVATE_IPS=true`.

### Operational

- `SECURITY.md` — vulnerability disclosure policy.
- New CI job: Bandit (MEDIUM+), pip-audit (both lockfiles), npm audit (HIGH+, runtime deps only). All scanners clean.
- `ExceptionLoggingMiddleware` — logs `request_id`, `http_method`, `http_path`, `exc_class` as structured `extra` fields.

## Test plan

- [x] `pytest tests/` — **853 passing** (was 684 before the security run; +169 new tests across 4 dedicated test files).
- [x] `ruff check app/ tests/` — clean.
- [x] `mypy app/` — no new errors (the 9 pre-existing `match_report.py` / `match_archive.py` / `requests` stubs warnings are unchanged).
- [x] `bandit -r app/ -q --severity-level medium` — clean.
- [x] `pip-audit --strict -r requirements.lock` — no known vulnerabilities.
- [x] `pip-audit --strict -r requirements-dev.lock` — no known vulnerabilities.
- [x] `cd frontend && npm audit --omit=dev --audit-level=high` — 0 vulnerabilities.
- [x] `cd frontend && npm test` — 325/325.

## Operator notes

Every behaviour change is opt-in or includes a clearly-logged default. The summarised migration matrix:

| Setting | Recommended for new deployments |
|---|---|
| `SCOREBOARD_USERS` | Use `password_hash` per user (mint via `python -m app.password_hash`). |
| `OVERLAY_MANAGER_PASSWORD_HASH` | Replace plaintext `OVERLAY_MANAGER_PASSWORD` after migrating. |
| `OVERLAY_SERVER_TOKEN` | Leave unset → auto-generated and persisted. Or set explicitly when an external `CustomOverlayBackend` peer must use the same value. |
| `TRUSTED_HOSTS` | Public hostname(s) the app serves from; e.g. `scoreboard.example.com` or `*.example.com`. |
| `CORS_ALLOWED_ORIGINS` | Empty unless serving the SPA from a different origin. |

Full reference in `AUTHENTICATION.md` (sections §1, §5, §6, §7, §8) and `README.md` env-var table.

## Out of scope

- L-7 (weak-password startup check). Easy follow-up if useful.

https://claude.ai/code/session_01BPyiEJ4eyUz9NHZy6zbRhy

---
_Generated by [Claude Code](https://claude.ai/code/session_01BPyiEJ4eyUz9NHZy6zbRhy)_