### PR TITLE
sec(match_archive): close CodeQL py/path-injection alerts (direct to main)

### DIFF
--- a/app/api/match_archive.py
+++ b/app/api/match_archive.py
@@ -296,14 +296,20 @@ def _safe_match_path(match_id: object) -> Optional[str]:
 
     1. ``isinstance`` + ``_MATCH_FILENAME_RE`` reject anything whose
        shape is not ``match_<20-hex>_<UTC-ISO>.json``.
-    2. The basename is rebuilt from the regex's named groups, so no
-       caller-controlled bytes flow into the filename.
+    2. The basename is rebuilt from the regex's named groups
+       (``oid_hash`` is fixed-length hex; ``ts`` is a fixed-shape
+       timestamp), so no caller-controlled bytes flow into the
+       filename.
     3. The canonicalized realpath is checked to live directly inside
-       the canonicalized data dir. This last step is the pattern
-       CodeQL's ``py/path-injection`` query recognizes as a
-       sanitizer — without it the prior two layers were correct but
-       still flagged because the static analyser cannot trace the
-       regex-as-sanitizer relationship.
+       the canonicalized data dir using **two redundant CodeQL-
+       recognized sanitizers**: ``os.path.commonpath`` (the
+       ``py/path-injection`` query's documented sanitizer pattern)
+       plus a ``startswith(base + os.sep)`` guard. Either one alone
+       is sufficient for correctness; both together silence the
+       static analyzer's data-flow tracker, which previously didn't
+       follow the ``os.path.dirname(...) != base`` form through and
+       still flagged the call sites at ``load_match`` /
+       ``delete_match``.
     """
     if not isinstance(match_id, str):
         return None
@@ -315,7 +321,18 @@ def _safe_match_path(match_id: object) -> Optional[str]:
     )
     base = os.path.realpath(_data_dir())
     candidate = os.path.realpath(os.path.join(base, safe_basename))
+    # ``commonpath`` raises ``ValueError`` if the candidate and base
+    # are on different drives (Windows) or share no prefix; treat
+    # that as a rejection too.
+    try:
+        if os.path.commonpath([candidate, base]) != base:
+            return None
+    except ValueError:
+        return None
+    if not candidate.startswith(base + os.sep):
+        return None
     if os.path.dirname(candidate) != base:
+        # No subdirectories under data/matches/ — only direct children.
         return None
     return candidate
 


### PR DESCRIPTION
## Summary

Closes the CodeQL `py/path-injection` alerts flagged on `main` at `app/api/match_archive.py` lines 343, 345, 348, 365 (and the analogous sinks in `load_match`).

The code was already safe — `_safe_match_path` rebuilds the basename from regex named groups (`oid_hash` is fixed-length hex, `ts` is a fixed-shape timestamp) before any `os.remove` / `os.path.exists` / `open` call — but CodeQL's data-flow tracker doesn't recognize the `os.path.dirname(candidate) != base` form as a sanitizer, so it traced `match_id` through `_safe_match_path` to the sinks and fired the alerts.

Targeting `main` directly because `dev` is currently 6 commits behind `main` (the security rollup + dependabot bumps live only on main); the fix branch was reset to `origin/main` before the change, so this is a clean fast-forward.

## What changes

`_safe_match_path` now uses the two sanitizer patterns the `py/path-injection` query documents as recognized:

```python
candidate = os.path.realpath(os.path.join(base, safe_basename))
try:
    if os.path.commonpath([candidate, base]) != base:
        return None
except ValueError:
    return None  # Cross-drive on Windows.
if not candidate.startswith(base + os.sep):
    return None
if os.path.dirname(candidate) != base:
    return None  # Kept: enforces "direct child only" invariant.
```

The original `dirname` check stays as the strictest layer (rejects subdirectory traversal); the `commonpath` and `startswith` checks are what CodeQL's tracker is looking for. All three pass simultaneously for every valid match-id.

## Sinks closed by this fix

| File | Line | Sink |
|---|---|---|
| `app/api/match_archive.py` | 343 | `os.path.exists(path)` in `load_match` |
| `app/api/match_archive.py` | 346 | `open(path, "r", …)` in `load_match` |
| `app/api/match_archive.py` | 362 | `os.path.exists(path)` in `delete_match` |
| `app/api/match_archive.py` | 365 | `os.remove(path)` in `delete_match` |

All four consume the path returned by `_safe_match_path`; sanitizing the helper closes every alert downstream of it.

## Test plan

- [x] `pytest tests/` — 853 passing, no regressions in `test_match_archive.py` or `test_match_report.py`.
- [x] `ruff check app/ tests/` — clean.
- [x] `bandit -r app/ -q --severity-level medium` — clean.
- [x] Manual review: every previously-rejected match-id shape (`..`, slashes, hex-with-extra-chars, mismatched timestamp shapes) still rejected; every valid match-id still resolves to the same canonical path.

https://claude.ai/code/session_01BPyiEJ4eyUz9NHZy6zbRhy