### PR TITLE
fix(ui): restore icons & overlay typography blocked by the new CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ once a first tagged release ships.
   ``/assets/``, so no third-party network request is made and the
   default CSP is unchanged. Side benefit: the UI now works in
   airgapped / firewalled deployments.
+- **Overlay templates' Google Fonts allowed by CSP.** Several overlay
+  styles (``clear_jersey``, ``neo_jersey``, ``split_jersey``,
+  ``compact``, ``original``, ``esports``, ``glass``, ``mosaic``,
+  ``pill``, ``ribbon``, ``shield``, ``vertical``, ``style``,
+  ``style_reference``, ``split``, ``diagonal``) load Outfit / Inter /
+  Roboto / Oswald / Montserrat / Rajdhani / Barlow Condensed / Chakra
+  Petch / Rubik from ``fonts.googleapis.com``. The strict default CSP
+  blocked them and OBS browser sources fell back to system sans-serif.
+  ``SecurityHeadersMiddleware._build_html_csp`` now appends
+  ``https://fonts.googleapis.com`` to ``style-src`` and
+  ``https://fonts.gstatic.com`` to ``font-src`` **only on
+  ``/overlay/*`` paths** (alongside the existing
+  ``frame-ancestors *`` relaxation). The control UI, ``/manage``, and
+  ``/match/{id}/report`` keep the strict 'self'-only CSP.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Material Icons no longer blocked by CSP.** The control UI used to
+  load the icon font from ``https://fonts.googleapis.com/icon?family=Material+Icons``,
+  which the security-headers CSP (``style-src 'self' 'unsafe-inline'``,
+  ``font-src 'self' data:``) blocks on fresh page loads — leaving the
+  timeout / serve / bottom-bar buttons rendered as text ligatures.
+  The font is now bundled with the frontend via the ``material-icons``
+  npm package (filled variant only) and served same-origin from
+  ``/assets/``, so no third-party network request is made and the
+  default CSP is unchanged. Side benefit: the UI now works in
+  airgapped / firewalled deployments.
+
 ### Security
 
 - **Webhook SSRF guard.** ``app/api/webhooks.py`` now refuses to POST

--- a/app/api/middleware/security_headers.py
+++ b/app/api/middleware/security_headers.py
@@ -64,6 +64,15 @@ _DEFAULT_CSP = (
 )
 
 _OVERLAY_CSP_FRAME_ANCESTORS = "frame-ancestors *"
+# Overlay templates pull webfonts from Google Fonts (Outfit, Inter,
+# Roboto, Oswald, Montserrat, Rajdhani, Barlow Condensed, Chakra Petch,
+# Rubik). The stylesheet is served from fonts.googleapis.com and the
+# woff2 files from fonts.gstatic.com — both must be allowed for the
+# OBS-rendered overlays to keep their intended typography. We only
+# relax this on /overlay/* paths; the control UI, /manage, and the
+# match report stay locked to 'self'.
+_OVERLAY_CSP_STYLE_HOSTS = "https://fonts.googleapis.com"
+_OVERLAY_CSP_FONT_HOSTS = "https://fonts.gstatic.com"
 _DEFAULT_PERMISSIONS_POLICY = (
     "geolocation=(), microphone=(), camera=(), payment=(), usb=()"
 )
@@ -76,19 +85,37 @@ _DEFAULT_REFERRER_POLICY = "strict-origin-when-cross-origin"
 _OVERLAY_PREFIXES: tuple[str, ...] = ("/overlay/",)
 
 
+def _augment_directive(parts: list[str], name: str, *extras: str) -> None:
+    """Append *extras* to the CSP directive *name* in-place.
+
+    If the directive is missing, a new one is appended that starts at
+    ``'self'`` and adds *extras*. Existing tokens are preserved so an
+    operator-supplied ``SECURITY_CSP`` override never loses entries.
+    """
+    lower = name.lower()
+    for i, part in enumerate(parts):
+        tokens = part.split()
+        if tokens and tokens[0].lower() == lower:
+            for extra in extras:
+                if extra not in tokens:
+                    tokens.append(extra)
+            parts[i] = " ".join(tokens)
+            return
+    parts.append(" ".join((name, "'self'", *extras)))
+
+
 def _build_html_csp(path: str) -> str:
     """Return the CSP string for an HTML response on *path*.
 
     Overlay routes are embedded in OBS browser sources, which load the
-    page off-origin; ``frame-ancestors 'self'`` would break them. The
-    overlay-specific override only relaxes that one directive — every
-    other ``script-src`` / ``style-src`` / ``img-src`` policy stays in
-    force.
+    page off-origin; ``frame-ancestors 'self'`` would break them, and
+    several templates pull webfonts from Google Fonts. The overlay
+    branch relaxes ``frame-ancestors``, ``style-src``, and ``font-src``
+    only — every other ``script-src`` / ``img-src`` / ``connect-src``
+    policy stays in force.
     """
     csp = _env("SECURITY_CSP", _DEFAULT_CSP)
     if any(path.startswith(prefix) for prefix in _OVERLAY_PREFIXES):
-        # Replace any frame-ancestors directive with the overlay-friendly
-        # value. Falls back to appending if the env override removed it.
         parts = [p.strip() for p in csp.split(";") if p.strip()]
         replaced = False
         for i, p in enumerate(parts):
@@ -98,6 +125,8 @@ def _build_html_csp(path: str) -> str:
                 break
         if not replaced:
             parts.append(_OVERLAY_CSP_FRAME_ANCESTORS)
+        _augment_directive(parts, "style-src", _OVERLAY_CSP_STYLE_HOSTS)
+        _augment_directive(parts, "font-src", _OVERLAY_CSP_FONT_HOSTS)
         csp = "; ".join(parts)
     return csp
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,12 +11,6 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/icon.svg" />
     <title>Volley Scoreboard</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/icon?family=Material+Icons"
-    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "volley-control-ui",
       "version": "0.1.0",
       "dependencies": {
+        "material-icons": "^1.13.14",
         "react": "^19.1.0",
         "react-colorful": "^5.6.1",
         "react-dom": "^19.1.0"
@@ -5582,6 +5583,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/material-icons": {
+      "version": "1.13.14",
+      "resolved": "https://registry.npmjs.org/material-icons/-/material-icons-1.13.14.tgz",
+      "integrity": "sha512-kZOfc7xCC0rAT8Q3DQixYAeT+tBqZnxkseQtp2bxBxz7q5pMAC+wmit7vJn1g/l7wRU+HEPq23gER4iPjGs5Cg==",
+      "license": "Apache-2.0"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "material-icons": "^1.13.14",
     "react": "^19.1.0",
     "react-colorful": "^5.6.1",
     "react-dom": "^19.1.0"

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { I18nProvider } from './i18n';
 import { SettingsProvider } from './hooks/useSettings';
 import { installErrorReporter } from './utils/errorReporter';
+import 'material-icons/iconfont/filled.css';
 import './App.css';
 
 installErrorReporter();

--- a/tests/test_security_enhancements.py
+++ b/tests/test_security_enhancements.py
@@ -102,6 +102,37 @@ def test_overlay_html_relaxes_frame_ancestors(headers_client):
     assert "x-frame-options" not in res.headers
 
 
+def test_overlay_html_allows_google_fonts(headers_client):
+    """Overlay templates pull Google Fonts; the strict default CSP
+    blocks them on every other route, so /overlay/* must allow the two
+    Google Fonts hosts on style-src and font-src."""
+    res = headers_client.get("/overlay/x")
+    csp = res.headers.get("content-security-policy", "")
+    style_directive = next(
+        (p.strip() for p in csp.split(";") if p.strip().startswith("style-src")),
+        "",
+    )
+    font_directive = next(
+        (p.strip() for p in csp.split(";") if p.strip().startswith("font-src")),
+        "",
+    )
+    assert "https://fonts.googleapis.com" in style_directive
+    assert "https://fonts.gstatic.com" in font_directive
+    # Pre-existing tokens must be preserved.
+    assert "'self'" in style_directive
+    assert "'unsafe-inline'" in style_directive
+    assert "'self'" in font_directive
+
+
+def test_non_overlay_html_does_not_allow_google_fonts(headers_client):
+    """The control UI / manage page CSP stays strict — no third-party
+    font hosts leak in from the overlay branch."""
+    res = headers_client.get("/manage")
+    csp = res.headers.get("content-security-policy", "")
+    assert "fonts.googleapis.com" not in csp
+    assert "fonts.gstatic.com" not in csp
+
+
 def test_existing_cache_control_is_preserved(headers_client, monkeypatch):
     app = FastAPI()
 


### PR DESCRIPTION
## Summary

Two regressions caused by the strict CSP shipped in PR #258
(`SecurityHeadersMiddleware`). On fresh page loads (no cached assets)
the browser blocked third-party stylesheet/font requests that the app
relied on, so:

1. The control-UI bottom-bar buttons rendered as ligature names
   (`timeout`, `serve`, `settings`, …) instead of Material Icons.
2. OBS overlays fell back to system sans-serif because their Google
   Fonts (Outfit / Inter / Roboto / Oswald / Montserrat / Rajdhani /
   Barlow Condensed / Chakra Petch / Rubik) were blocked.

Confirmed via the user's HAR — three blocked GETs:

```
GET https://fonts.googleapis.com/icon?family=Material+Icons       (control UI)
GET https://fonts.googleapis.com/css2?family=Outfit:...           (overlay, twice)
```

### Fix 1 — Material Icons (`b212878`)
Self-host via the `material-icons` npm package (filled variant only —
the only class used in `frontend/src/`). Vite emits the woff2 under
`/assets/`, so the request is now same-origin and satisfies the
existing CSP without changes. The control UI keeps its strict
`'self'`-only policy and now works in airgapped / firewalled
deployments. `index.html` drops the Google Fonts `<link>` and the
two `preconnect`s.

### Fix 2 — Overlay templates' Google Fonts (`599b0d4`)
Mirror the existing overlay-scoped `frame-ancestors *` relaxation in
`_build_html_csp()`: on `/overlay/*` paths only, append
`https://fonts.googleapis.com` to `style-src` and
`https://fonts.gstatic.com` to `font-src`. The control UI, `/manage`,
and `/match/{id}/report` keep the strict 'self'-only CSP. New
`_augment_directive()` helper preserves any operator-supplied
`SECURITY_CSP` tokens instead of overwriting them.

### Files

- `frontend/package.json`, `frontend/package-lock.json` — add
  `material-icons@^1.13.14`
- `frontend/src/main.tsx` — `import 'material-icons/iconfont/filled.css'`
- `frontend/index.html` — drop Google Fonts `<link>` + preconnects
- `app/api/middleware/security_headers.py` — overlay-scoped style/font
  relaxation
- `tests/test_security_enhancements.py` — two new tests
- `CHANGELOG.md` — Fixed entries

## Test plan

- [x] `npm run typecheck` (frontend) — clean
- [x] `npm test` — 325/325 pass
- [x] `npm run build` — woff2 emitted at `/assets/material-icons-*.woff2`,
      bundled CSS references it same-origin
- [x] `pytest tests/` — 855/855 pass (including the two new CSP tests)
- [ ] Manual: deploy, hard-reload control UI in a browser that never
      cached the Google Fonts stylesheet — bottom-bar icons should render
- [ ] Manual: hard-reload `/overlay/<id>` for `clear_jersey` (or any
      other Outfit/Inter overlay) — Outfit should render, not system
      sans-serif. Verify in DevTools that `fonts.googleapis.com` and
      `fonts.gstatic.com` requests now succeed under the relaxed CSP

https://claude.ai/code/session_01ViPD1SDrDbR5spBNeLoLT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViPD1SDrDbR5spBNeLoLT8)_