### PR TITLE
build(frontend): support vite-plugin-compression2 v2 options

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -16,8 +16,8 @@ async function maybeCompression() {
     const mod = await import('vite-plugin-compression2');
     const compression = mod.compression || mod.default;
     return [
-      compression({ algorithm: 'gzip', threshold: 1024 }),
-      compression({ algorithm: 'brotliCompress', threshold: 1024 }),
+      compression({ algorithm: 'gzip', algorithms: ['gzip'], threshold: 1024 }),
+      compression({ algorithm: 'brotliCompress', algorithms: ['brotliCompress'], threshold: 1024 }),
     ];
   } catch {
     return [];


### PR DESCRIPTION
## Summary

`vite-plugin-compression2` v2.0.0 renamed the `algorithm` option to `algorithms` (now an array). PR #276 bumps the plugin from 1.4.0 → 2.5.3, and without this change `frontend/vite.config.js` would silently fall back to defaults under v2 (the unknown `algorithm` key is ignored), losing the explicit gzip + brotli outputs.

To stay compatible with both versions during the transition, the call now sets **both** keys — each plugin version reads the one it knows and ignores the other:

```js
compression({ algorithm: 'gzip', algorithms: ['gzip'], threshold: 1024 }),
compression({ algorithm: 'brotliCompress', algorithms: ['brotliCompress'], threshold: 1024 }),
```

After this lands, `@dependabot rebase` on #276 should produce a clean CI run.

## Test plan

- [ ] CI: frontend typecheck + tests pass on this branch (uses currently-installed v1.4.0)
- [ ] After merge, rebase #276 and confirm its frontend build emits both `.gz` and `.br` siblings under v2.5.3


---
_Generated by [Claude Code](https://claude.ai/code/session_01CGX4PcwfR88wrvYxqV177v)_