### PR TITLE
Fase 0+1+4: /manage UX, admin tooling, ops hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,40 @@ once a first tagged release ships.
 
 ### Added
 
+- **WebSocket connection cap + opt-in server heartbeat
+  (Fase 4 / M14).** Two complementary defences against runaway
+  ``WSHub`` registries:
+  * **Connection cap.** ``WSHub.connect`` now refuses upgrades
+    when an OID already has ``WSHUB_MAX_CLIENTS_PER_OID`` (default
+    200) subscribers. The reject path raises a new
+    ``WSHubFull`` exception **before** ``ws.accept()``, and the
+    ``/api/v1/ws`` endpoint translates it into a WebSocket close
+    with code ``1013`` ("Try Again Later") — the conventional
+    server-side back-pressure signal. The cap protects the box
+    from a runaway tab loop or a misconfigured load test eating
+    file descriptors. Configurable via the
+    ``WSHUB_MAX_CLIENTS_PER_OID`` env var.
+  * **Server heartbeat (opt-in).** When the operator sets
+    ``WSHUB_HEARTBEAT_INTERVAL_SECONDS > 0``, a background task
+    started from ``router_lifespan`` sweeps every connection
+    every ``INTERVAL`` seconds, sends an application-level
+    ``{"type":"ping"}`` frame, and evicts any client whose
+    ``mark_active`` timestamp is older than
+    ``WSHUB_CLIENT_TIMEOUT_SECONDS`` (default 60 s) with a 1011
+    close ("server error") and a clean ``disconnect``. Default
+    interval is **0 (disabled)** because the existing browser
+    client does not yet ack application-level pings — turning
+    this on without first updating the frontend would churn live
+    tabs every timeout. A new ``_env_float_nonneg`` helper in
+    ``app.constants`` lets ``KEY=0`` survive the validation as a
+    genuine "off" signal (the strict ``> 0`` filter on
+    ``_env_float`` would otherwise upgrade it to the default).
+  Tests: 6 new cases in ``tests/test_api_routes.py`` covering
+  ``WSHubFull`` raise-before-accept, the endpoint's 1013 close,
+  zombie eviction past the timeout, healthy-client ping
+  dispatch, ``mark_active`` bumping ``_last_seen``, and the
+  ``start_heartbeat`` no-op path. Suite at 934 passing.
+
 - **Audit log rotation + cursor-based pagination
   (Fase 4 / M13).** The per-OID action audit
   (``data/audit_<hash>.jsonl``) used to grow without bound — a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,68 @@ once a first tagged release ships.
 
 ### Added
 
+- **Prometheus ``/metrics`` endpoint + instrumentation
+  (Fase 4 / M15).** A new ``app.metrics`` module wires
+  ``prometheus_client`` (now in ``requirements.txt``) into the
+  hot paths and surfaces the result at ``GET /metrics``. The
+  endpoint speaks the standard Prometheus text-exposition format
+  (``text/plain; version=0.0.4``) and is mounted at the app
+  root rather than under ``/api/v1`` so it lines up with every
+  other Prometheus-instrumented service the operator might be
+  scraping.
+
+  Metrics emitted:
+  * ``voc_http_request_duration_seconds`` — histogram of
+    end-to-end HTTP latency, labelled by ``route`` (the FastAPI
+    route template — bounded by the OpenAPI surface, not the
+    raw path), ``method`` and ``status``. Wired through a new
+    ``MetricsMiddleware`` placed inside ``ExceptionLogging``
+    but outside ``RequestContext`` so the bucket reflects the
+    full handler cost.
+  * ``voc_webhook_delivery_total{event, status}`` — counter
+    with ``status`` ∈ ``success`` / ``client_error`` /
+    ``server_error`` / ``exception`` / ``ssrf_blocked`` /
+    ``dead_letter``. ``dead_letter`` is incremented in
+    addition to the per-attempt status so an alert can fire on
+    "X events landed in the DL" without subtracting other
+    buckets.
+  * ``voc_ws_clients_total`` — total open frontend WebSocket
+    connections across all OIDs (unlabelled).
+  * ``voc_ws_oids_active`` — number of distinct OIDs with at
+    least one open subscriber (unlabelled).
+  * ``voc_active_sessions`` — live ``GameSession`` count
+    tracked by ``SessionManager`` (unlabelled).
+
+  The plan called for ``ws_clients_per_oid`` as a labelled
+  gauge; that label would be unbounded in OID space (textbook
+  Prometheus anti-pattern). The two unlabelled gauges above
+  give the operator the same dashboard story (total fan-out
+  plus breadth) without the cardinality risk.
+
+  Auth ladder mirrors ``/manage``: by default the endpoint is
+  unauthenticated (the exposed values are aggregates, no
+  payloads, no per-OID labels — safe to scrape from the cluster
+  service mesh). Operators that prefer to gate it set
+  ``METRICS_REQUIRE_ADMIN=true``, which checks the same Bearer
+  token as ``/api/v1/admin/*``. The auth check fires *before*
+  the library-availability check so an unauthenticated probe
+  cannot use the 503-vs-200 difference to fingerprint whether
+  the metrics backend is loaded.
+
+  Graceful degradation: if ``prometheus_client`` is missing
+  (older deploys that have not run ``pip install -r
+  requirements.txt``), every helper becomes a no-op, the rest
+  of the app boots normally, and ``/metrics`` returns a 503
+  with a clear "install prometheus-client" message instead of
+  a confusing 404.
+
+  Tests: 7 new in ``tests/test_metrics.py`` covering the
+  exposition format + content, the route-template label, the
+  default-no-auth path, ``METRICS_REQUIRE_ADMIN`` gate,
+  503-when-password-unset, the webhook counter increment, and
+  the WS gauges tracking ``WSHub.connect`` / ``disconnect``.
+  Suite at 953 passing.
+
 - **Webhook retries + dead-letter queue + operator replay
   (Fase 4 / M16).** The outbound webhook dispatcher used to be
   fire-and-forget: a single 503 from a flaky receiver dropped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,52 @@ once a first tagged release ships.
 
 ### Added
 
+- **`/manage` — bulk delete, filter and per-overlay detail drawer
+  (Fase 1 — frontend half).** Three sizeable additions to the
+  custom-overlay manager UI:
+  * **Filter input** above the toolbar: live, case-insensitive
+    substring match against the overlay's name, OID and output
+    key. The result count (`23 of 50`) sits next to the input
+    with `aria-live="polite"` so screen readers announce the
+    new total when the operator types.
+  * **Bulk delete.** A new "Select" column adds a checkbox per
+    row, and a "Select all visible" checkbox in the header. The
+    toolbar gains a "Delete `<N>` selected" button (disabled
+    when nothing is checked); clicking it reuses the existing
+    confirmation modal, which now switches between the original
+    1-overlay layout and a list of up to 10 OIDs (with "… and N
+    more" tail) for multi-deletes. Deletes run sequentially so a
+    401 mid-run bounces back to login instead of fanning out N
+    parallel failures, and the status line summarises partial
+    successes ("`5 of 8 deleted; stopped at error: …`"). Selections
+    that point at OIDs no longer present after a server-side
+    refresh are dropped automatically.
+  * **Detail drawer.** A new "Edit" button on every row opens a
+    right-hand `<aside role="dialog">` that shows: a live
+    preview iframe (`/overlay/<output_key>?style=mosaic`,
+    `sandbox="allow-scripts allow-same-origin"`), a theme
+    dropdown wired to `GET /api/themes` and the new
+    `PATCH /api/v1/admin/custom-overlays/{name}` endpoint, and
+    a "Live usage" panel fed by `GET /usage` with a green/grey
+    dot ("Live" vs "Idle"), OBS viewer count, scoreboard tab
+    count, active-session flag and human-readable
+    "last activity 30s ago / 4m ago / 2h ago" string. The drawer
+    uses `inert` + `aria-hidden` instead of `display: none` so
+    the slide-in transition is meaningful, ESC closes it, and
+    focus returns to the originating button. After a theme is
+    applied, the iframe `src` is bumped with a cache-busting
+    `t=<now>` query so the operator immediately sees the new
+    look.
+
+  ⚠️ Screenshot regeneration: the `/manage` page now shows three
+  buttons in the toolbar (`+ New overlay`, `Refresh`, `Delete N
+  selected`) and a checkbox column. Run
+  `bash scripts/screenshots/run.sh` to refresh
+  `docs/screenshots/05-manage-page.png`. Skipped in this commit
+  because it needs Node + Playwright + a live server.
+
+### Added
+
 - **Admin endpoints for editing and inspecting custom overlays
   (Fase 1 — backend half).** Two new routes under
   ``/api/v1/admin/custom-overlays/{name}``:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ once a first tagged release ships.
 
 ### Changed
 
+- **`/manage` — auth-error handling unified across every admin call.**
+  The custom-overlay manager page previously only bounced the operator
+  back to the login view when ``loadOverlays`` got a 401/403; the
+  delete and create flows logged the raw error inside the dialog and
+  left the now-stale password in memory. A shared ``handleAuthError``
+  helper now clears the cached password, dismisses any open modal,
+  shows the login view and re-focuses the password input from
+  ``loadOverlays``, ``performDelete`` and the ``createForm`` submit
+  alike. Symptom: rotating ``OVERLAY_MANAGER_PASSWORD`` while a
+  manager tab was open used to leave the operator stuck inside a
+  half-broken modal until they refreshed.
+
+### Tests
+
+- **Coverage for the new env-var overrides in ``app.constants``.**
+  ``tests/test_constants.py`` (14 tests) reloads ``app.constants``
+  under each ``monkeypatch.setenv`` and verifies the ``SESSION_TTL_*``
+  / ``WS_*_SECONDS`` overrides honour the env, fall back to defaults
+  on garbage / empty / non-positive input, and that the legacy
+  re-exports in ``app.api.session_manager`` and ``app.ws_client`` see
+  the same value after a matching reload. Without these the only
+  thing protecting the override contract was the implicit "defaults
+  match legacy values" coincidence; a regression in the ``_env_int``
+  / ``_env_float`` parsers would have been silent.
+
+### Changed
+
 - **`/manage` quick wins (Fase 0 del roadmap de mejoras).** Three
   small but operator-visible improvements to the custom-overlay
   manager page (`app/admin/static/overlays.html`):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,43 @@ once a first tagged release ships.
 
 ### Added
 
+- **Audit log rotation + cursor-based pagination
+  (Fase 4 / M13).** The per-OID action audit
+  (``data/audit_<hash>.jsonl``) used to grow without bound — a
+  long tournament could leave a single file with hundreds of
+  thousands of lines, every read of which (``match_archive``,
+  ``GET /audit``, undo) walked the whole thing. Two changes:
+  * **Logrotate-style rotation.** Once the active file exceeds
+    ``AUDIT_LOG_MAX_BYTES`` (default 5 MiB), it rotates to
+    ``audit_<hash>.jsonl.1``, bumping older rotations down by one
+    suffix; anything past ``AUDIT_LOG_MAX_FILES - 1`` rotated
+    slots (default 5 total files counting the active) is dropped.
+    Rotation runs inside the existing per-OID lock so concurrent
+    appends never see a torn rename. ``read_all`` /
+    ``pop_last_forward`` / ``peek_last_forward`` walk the active
+    file plus every rotated file in chronological order, so
+    ``match_archive`` and the undo path keep seeing the full
+    visible history regardless of how many rotations have
+    occurred. ``clear`` and ``delete`` now sweep the whole family
+    (active + rotated) so a match reset starts genuinely empty.
+    Both knobs respect the same env-var override pattern as the
+    other tunables in ``app.constants``.
+  * **Cursor-based pagination on ``GET /audit``.** New optional
+    ``before_ts`` query parameter; the response now carries a
+    ``next_cursor`` field that the caller passes back to walk
+    history one window at a time. Older calls without
+    ``before_ts`` keep returning the most recent ``limit``
+    records, so the existing dashboard contract is preserved —
+    only new clients pay attention to ``next_cursor``. Tombstones
+    are honoured by the cursor so an undo between two pages does
+    not leak the cancelled record.
+  Tests: ``tests/test_action_log.py`` adds 13 new cases covering
+  no-rotation-under-threshold, single-rotation cross-file reads,
+  cap eviction (oldest records dropped), ``clear``/``delete``
+  sweeping the rotated set, undo tombstones spanning rotation,
+  cursor walks across all records, null-cursor on final page,
+  and pagination respecting tombstones. Suite at 928 passing.
+
 - **`/manage` — bulk delete, filter and per-overlay detail drawer
   (Fase 1 — frontend half).** Three sizeable additions to the
   custom-overlay manager UI:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Changed
+
+- **`/manage` quick wins (Fase 0 del roadmap de mejoras).** Three
+  small but operator-visible improvements to the custom-overlay
+  manager page (`app/admin/static/overlays.html`):
+  * **Accessible delete confirmation.** The custom-overlay delete
+    flow no longer uses `window.confirm`. It now opens a
+    `role="dialog" aria-modal="true"` overlay that shows the
+    overlay's name, OID and output key, traps TAB inside the
+    dialog, restores focus to the originating button on close, and
+    dismisses on ESC. The Cancel button is default-focused so a
+    stray ENTER cannot delete by accident. The pre-existing "New
+    custom overlay" modal received the same `aria-modal` /
+    `aria-labelledby` annotations.
+  * **Descriptive ARIA labels on the action buttons.** Screen-reader
+    users now hear "Copy overlay `mybroadcast`" / "Delete overlay
+    `mybroadcast`" instead of bare "Copy" / "Delete".
+  * **Mobile-friendly overlay table.** Below 600 px the overlay
+    list collapses into a stacked card layout (each row labelled
+    via `data-label` `::before` pseudo-elements), so the manager
+    is usable from a phone in a courtside operator workflow.
+
+  No API contract changes; `tests/test_admin.py` keeps passing.
+
+- **Centralised tunable constants in `app.constants`.** The
+  hardcoded `SESSION_TTL_SECONDS` (idle session eviction),
+  `WSHub._BROADCAST_SEND_TIMEOUT` (per-socket broadcast timeout)
+  and the `WSControlClient` reconnect/heartbeat parameters
+  (`_RECONNECT_BASE` / `_RECONNECT_MAX` / `_HEARTBEAT_INTERVAL` /
+  `_ZOMBIE_DEADLINE`) now load from `app.constants` and accept
+  env-var overrides (`SESSION_TTL_SECONDS`,
+  `WS_BROADCAST_SEND_TIMEOUT_SECONDS`, `WS_RECONNECT_BASE_SECONDS`,
+  `WS_RECONNECT_MAX_SECONDS`, `WS_HEARTBEAT_INTERVAL_SECONDS`,
+  `WS_ZOMBIE_DEADLINE_SECONDS`). Non-numeric or non-positive values
+  fall back to the previous defaults so a misconfigured environment
+  degrades gracefully. The legacy module-level names
+  (`app.api.session_manager.SESSION_TTL_SECONDS`,
+  `app.api.ws_hub.WSHub._BROADCAST_SEND_TIMEOUT`,
+  `app.ws_client._ZOMBIE_DEADLINE`…) are preserved as
+  re-exports/initialisers so the existing monkeypatch in
+  `tests/test_api_routes.py` and the deadline read in
+  `tests/test_ws_client.py` keep working untouched.
+
 ## [5.1.4] - 2026-05-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Added
+
+- **Admin endpoints for editing and inspecting custom overlays
+  (Fase 1 — backend half).** Two new routes under
+  ``/api/v1/admin/custom-overlays/{name}``:
+  * **``PATCH``** — partial update of a custom overlay's appearance.
+    The body accepts any combination of ``theme`` (preset name from
+    ``GET /api/themes``), ``colors`` (dict deep-merged into
+    ``overlay_control.colors``) and ``preferred_style`` (validated
+    against the renderable templates plus ``default``). When both
+    ``theme`` and explicit overrides are sent, the theme is applied
+    first so user-supplied values win on the second merge — that's
+    the operator's mental model. Empty patches are rejected with
+    400 to flag accidental form submissions instead of silently
+    no-op'ing. The mutation flows through
+    ``OverlayStateStore.update_state`` so OBS browser sources
+    receive the broadcast in real time (50 ms debounce).
+  * **``GET /usage``** — snapshot of how many live consumers a
+    custom overlay has: ``obs_clients`` (browser-source viewers),
+    ``frontend_ws_clients`` (scoreboard control tabs subscribed via
+    ``WSHub``), ``has_active_session`` (live ``GameSession``) and
+    ``seconds_since_last_activity`` (clamped at the session TTL).
+    The relative duration intentionally avoids confusing
+    ``time.monotonic`` timestamps with epoch wall-clock —
+    ``GameSession.touch`` uses monotonic and the operator's
+    question is "is this still live?", not "when exactly".
+  Both routes require ``OVERLAY_MANAGER_PASSWORD`` and feed the
+  drawer/usage indicator scheduled for the frontend half of Fase 1.
+
+### Refactored
+
+- **``PRESET_THEMES`` extracted to ``app.overlay.themes``.** The
+  static catalogue used to live inside ``app/overlay/routes.py``,
+  which made it inaccessible to ``app/admin/routes.py`` without a
+  circular import (overlay → admin already exists for
+  ``require_admin``). Moving it to a dedicated module breaks the
+  cycle, exposes a stable ``get_theme_names()`` helper to both
+  routers, and prepares the seam M8 (Fase 2) will widen when
+  themes become directory-backed under ``data/themes/``. The
+  ``GET /api/themes`` and ``POST /api/theme/{id}/{name}`` public
+  routes are unchanged on the wire — they now read through
+  ``themes.PRESET_THEMES`` instead of the local dict.
+
 ### Changed
 
 - **`/manage` — auth-error handling unified across every admin call.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,54 @@ once a first tagged release ships.
 
 ### Added
 
+- **Webhook retries + dead-letter queue + operator replay
+  (Fase 4 / M16).** The outbound webhook dispatcher used to be
+  fire-and-forget: a single 503 from a flaky receiver dropped
+  the event on the floor with nothing more than a log warning.
+  Three changes:
+  * **Retries with exponential backoff.** ``_attempt_with_retries``
+    runs the configured ``WEBHOOK_RETRY_ATTEMPTS`` (default 3)
+    additional POSTs after the first failure, sleeping
+    ``WEBHOOK_RETRY_BASE_SECONDS * 2**(attempt-1)`` between them
+    (capped at ``WEBHOOK_RETRY_MAX_SECONDS``). Defaults give the
+    classic 1 / 2 / 4 / 8 progression. Retries fire on 5xx and
+    on ``requests.RequestException`` (timeouts, connect errors);
+    **4xx is treated as permanent client rejection** — no retry,
+    no dead-letter, just a warning, because retrying a "bad
+    request" never converges.
+  * **Dead-letter queue.** When retries are exhausted on a
+    transient failure, the delivery is appended to
+    ``data/webhooks_dead_letter.jsonl`` with the URL, event,
+    OID, body (as a UTF-8 string for human inspection), last
+    error string and attempt count. The HMAC ``secret`` is
+    deliberately **not** persisted — replay re-resolves the
+    target's secret from the live config, so rotating
+    ``WEBHOOKS_SECRET`` does not strand legacy entries with
+    stale signatures and a leaked DL file does not leak signing
+    keys. SSRF blocks and 4xx rejections are also kept out of
+    the DL because they are not replay-recoverable. The DL file
+    is rewritten atomically (tempfile + ``os.replace``) so a
+    crash mid-write cannot leave it half-written.
+  * **Operator replay endpoint.** New
+    ``POST /api/v1/admin/webhooks/replay`` (gated by
+    ``OVERLAY_MANAGER_PASSWORD``) reads the DL, optionally
+    filters by ``since=<unix-seconds>``, redelivers each record
+    against the current target config, and rewrites the file
+    with only the entries that still failed (plus those whose
+    URL no longer matches any configured target — kept so the
+    operator can fix the config and retry). The response carries
+    counts only (``considered`` / ``succeeded`` /
+    ``still_failing`` / ``skipped_unknown_url``); the payloads
+    themselves are never echoed through the admin surface.
+
+  Tests: 8 new in ``tests/test_webhooks.py`` (first-attempt
+  success, 5xx-then-success, 5xx-exhausts-retries, 4xx-no-retry,
+  RequestException retries, ``replay_records`` happy path,
+  unknown-URL preservation, attempts-counter increment) plus
+  4 endpoint-level cases in ``tests/test_admin.py`` (auth,
+  empty-DL no-op, success path pruning, ``since`` filter
+  preserving older entries). Suite at 946 passing.
+
 - **WebSocket connection cap + opt-in server heartbeat
   (Fase 4 / M14).** Two complementary defences against runaway
   ``WSHub`` registries:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Code-review follow-ups on Fase 4 (CR-3, CR-4, M-1).** Three
+  issues surfaced in the post-fase code review:
+  * **Webhook replay was a self-DoS waiting to happen.**
+    ``POST /api/v1/admin/webhooks/replay`` ran synchronously and
+    iterated every dead-letter record with up to ~25 s of blocking
+    retries each — a fully-loaded DL would pin the handler for
+    tens of minutes, well past any sensible HTTP timeout, and tie
+    up an entire FastAPI thread. The endpoint now (a) accepts a
+    ``max_records`` query param (default 50, cap 500) and replays
+    only the oldest-eligible slice, (b) runs the blocking work
+    via ``run_in_threadpool`` so the event loop stays free for
+    other handlers, and (c) reports ``remaining_in_dl`` so the
+    operator can iterate (``while remaining > 0: replay``)
+    without guesswork. Records held back by ``since`` /
+    ``max_records`` are preserved untouched.
+  * **The dead-letter file had no size cap.** A misbehaving
+    target during a multi-day outage could grow
+    ``data/webhooks_dead_letter.jsonl`` without bound — the same
+    anti-pattern Fase 4 just fixed for the audit log. ``append``
+    now enforces ``WEBHOOK_DEAD_LETTER_MAX_RECORDS`` (default
+    1000) by dropping the oldest entries via an atomic rewrite
+    when the cap is breached, so even a runaway producer stays
+    inside a bounded disk footprint. A new
+    ``voc_webhook_dead_letter_size`` Prometheus gauge tracks the
+    current count so dashboards can alert before the cap is
+    reached.
+  * **Heartbeat tick walked clients serially.** With
+    ``WSHUB_HEARTBEAT_INTERVAL_SECONDS > 0`` and a busy OID, a
+    200-client sweep could take 200 × ``BROADCAST_SEND_TIMEOUT``
+    of wall time. ``_heartbeat_tick`` now classifies clients
+    once, fans the zombie closes and healthy pings out via
+    ``asyncio.gather`` (with ``return_exceptions=True`` so a
+    single stuck socket cannot wedge the rest), and applies the
+    bookkeeping after the gather lands — so 200 clients finish
+    in roughly ``BROADCAST_SEND_TIMEOUT``.
+  Tests: 7 new cases — DL ``count``/cap eviction/gauge updates
+  in ``tests/test_webhooks.py``, ``max_records`` paginated
+  replay + ``remaining_in_dl`` in ``tests/test_admin.py``, and
+  the concurrent + mixed-zombie heartbeat sweeps in
+  ``tests/test_api_routes.py``. Full suite: 960 passing.
+
 ### Added
 
 - **Prometheus ``/metrics`` endpoint + instrumentation

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -17,6 +17,7 @@ variable to be set and the request to include a matching
 ``Authorization: Bearer <password>`` header.
 """
 
+import copy
 import logging
 import os
 import re
@@ -355,8 +356,11 @@ async def patch_custom_overlay(name: str, payload: CustomOverlayPatch):
             ),
         )
 
-    # Apply the theme baseline first so user-supplied colors / preferred_style
-    # win on subsequent merges.
+    # Validate first, then build a single merged payload so we hit
+    # ``update_state`` exactly once — every call is one disk write plus
+    # one WebSocket broadcast, so the previous "theme then overrides"
+    # two-step doubled both costs for the common "apply a theme with
+    # one tweak on top" flow.
     if payload.theme is not None:
         # Lazy import to avoid forcing the overlay package onto every test
         # path that imports the admin router.
@@ -369,35 +373,44 @@ async def patch_custom_overlay(name: str, payload: CustomOverlayPatch):
                     f"Available: {get_theme_names()}"
                 ),
             )
-        await store.update_state(name, PRESET_THEMES[payload.theme])
+        # Deep-copy the baseline so we can mutate it freely without
+        # corrupting the shared catalogue entry.
+        to_apply: dict = copy.deepcopy(PRESET_THEMES[payload.theme])
+    else:
+        to_apply = {}
 
-    overrides: dict = {}
-    overlay_control: dict = {}
-    if payload.colors is not None:
-        overlay_control["colors"] = payload.colors
-    if payload.preferred_style is not None:
-        # Validate against the renderable templates so a typo can't park the
-        # overlay on a 404 the next time it's served.
-        renderable = store.get_renderable_styles()
-        # ``default`` maps to ``index.html`` and is always present, but it's
-        # not in get_available_styles_list because it's also the implicit
-        # fallback. Accept it explicitly.
-        if (
-            payload.preferred_style != "default"
-            and payload.preferred_style not in renderable
-        ):
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    f"preferred_style '{payload.preferred_style}' is not a "
-                    f"known overlay style. Available: {renderable}"
-                ),
-            )
-        overlay_control["preferredStyle"] = payload.preferred_style
-    if overlay_control:
-        overrides["overlay_control"] = overlay_control
-    if overrides:
-        await store.update_state(name, overrides)
+    if payload.colors is not None or payload.preferred_style is not None:
+        overlay_control = to_apply.setdefault("overlay_control", {})
+        if payload.colors is not None:
+            # Shallow-merge so explicit color keys override the theme's
+            # values without erasing the ones the operator did not
+            # supply. ``overlay_control["colors"] = payload.colors``
+            # would lose ``set_text`` / ``game_text`` / etc. from the
+            # theme baseline.
+            base_colors = overlay_control.get("colors") or {}
+            overlay_control["colors"] = {**base_colors, **payload.colors}
+        if payload.preferred_style is not None:
+            # Validate against the renderable templates so a typo can't
+            # park the overlay on a 404 the next time it's served.
+            renderable = store.get_renderable_styles()
+            # ``default`` maps to ``index.html`` and is always present,
+            # but it's not in get_available_styles_list because it's
+            # also the implicit fallback. Accept it explicitly.
+            if (
+                payload.preferred_style != "default"
+                and payload.preferred_style not in renderable
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"preferred_style '{payload.preferred_style}' is not a "
+                        f"known overlay style. Available: {renderable}"
+                    ),
+                )
+            overlay_control["preferredStyle"] = payload.preferred_style
+
+    if to_apply:
+        await store.update_state(name, to_apply)
 
     logger.info(
         "Patched custom overlay '%s' (theme=%s, colors=%s, preferred_style=%s)",

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -58,6 +58,64 @@ class CustomOverlayCreate(BaseModel):
     )
 
 
+class CustomOverlayPatch(BaseModel):
+    """Partial update for a custom overlay's appearance.
+
+    Every field is optional — the patch is a thin admin-side wrapper around
+    ``OverlayStateStore.update_state``. When ``theme`` is set, the matching
+    preset from ``app.overlay.themes`` is applied first; ``colors`` and
+    ``preferred_style`` are then merged on top so explicit overrides win
+    over the theme defaults.
+    """
+
+    theme: str | None = Field(
+        None,
+        description=(
+            "Apply a preset theme (e.g. 'dark', 'esports'). "
+            "Available themes are listed by GET /api/themes."
+        ),
+    )
+    colors: dict[str, str] | None = Field(
+        None,
+        description=(
+            "Color overrides merged into overlay_control.colors. "
+            "Common keys: set_bg, set_text, game_bg, game_text."
+        ),
+    )
+    preferred_style: str | None = Field(
+        None,
+        description=(
+            "Switch the Jinja template served at /overlay/{output_key}. "
+            "Must match an entry in GET /api/config/{id}.availableStyles."
+        ),
+    )
+
+
+class CustomOverlayUsage(BaseModel):
+    """Snapshot of how many live consumers a custom overlay has."""
+
+    obs_clients: int = Field(
+        ..., description="Connected OBS / browser-source viewers."
+    )
+    frontend_ws_clients: int = Field(
+        ...,
+        description=(
+            "Connected scoreboard control tabs (frontend WebSocket "
+            "subscribers)."
+        ),
+    )
+    has_active_session: bool = Field(
+        ..., description="True when SessionManager has a live GameSession."
+    )
+    seconds_since_last_activity: int | None = Field(
+        None,
+        description=(
+            "Seconds elapsed since the session was last touched; "
+            "null when no session is active."
+        ),
+    )
+
+
 class MatchSignUrlRequest(BaseModel):
     ttl_seconds: int | None = Field(
         default=None,
@@ -263,6 +321,147 @@ def sign_match_report_url(
         url=url,
         expires_at=signed["expires_at"],
         expires_in=max(0, signed["expires_at"] - int(time.time())),
+    )
+
+
+@admin_router.patch(
+    "/custom-overlays/{name}",
+    dependencies=[Depends(require_admin)],
+    summary="Edit a custom overlay's theme / colors / preferred style",
+)
+async def patch_custom_overlay(name: str, payload: CustomOverlayPatch):
+    """Apply a preset theme and/or merge colors / preferredStyle.
+
+    Layering order matches the operator's mental model: the theme acts
+    as a baseline, then explicit ``colors`` and ``preferred_style`` are
+    merged on top. Empty patches are rejected with 400 so the operator
+    sees a clear error rather than a silent no-op (which would mask
+    accidental empty form submissions from the manager UI).
+    """
+    name = _validate_overlay_id(name)
+    store = _overlay_store()
+
+    if not store.overlay_exists(name):
+        raise HTTPException(
+            status_code=404, detail=f"Overlay '{name}' not found.",
+        )
+
+    if payload.theme is None and payload.colors is None and payload.preferred_style is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Patch must specify at least one of: theme, colors, "
+                "preferred_style."
+            ),
+        )
+
+    # Apply the theme baseline first so user-supplied colors / preferred_style
+    # win on subsequent merges.
+    if payload.theme is not None:
+        # Lazy import to avoid forcing the overlay package onto every test
+        # path that imports the admin router.
+        from app.overlay.themes import PRESET_THEMES, get_theme_names
+        if payload.theme not in PRESET_THEMES:
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    f"Theme '{payload.theme}' not found. "
+                    f"Available: {get_theme_names()}"
+                ),
+            )
+        await store.update_state(name, PRESET_THEMES[payload.theme])
+
+    overrides: dict = {}
+    overlay_control: dict = {}
+    if payload.colors is not None:
+        overlay_control["colors"] = payload.colors
+    if payload.preferred_style is not None:
+        # Validate against the renderable templates so a typo can't park the
+        # overlay on a 404 the next time it's served.
+        renderable = store.get_renderable_styles()
+        # ``default`` maps to ``index.html`` and is always present, but it's
+        # not in get_available_styles_list because it's also the implicit
+        # fallback. Accept it explicitly.
+        if (
+            payload.preferred_style != "default"
+            and payload.preferred_style not in renderable
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"preferred_style '{payload.preferred_style}' is not a "
+                    f"known overlay style. Available: {renderable}"
+                ),
+            )
+        overlay_control["preferredStyle"] = payload.preferred_style
+    if overlay_control:
+        overrides["overlay_control"] = overlay_control
+    if overrides:
+        await store.update_state(name, overrides)
+
+    logger.info(
+        "Patched custom overlay '%s' (theme=%s, colors=%s, preferred_style=%s)",
+        name,
+        payload.theme,
+        "yes" if payload.colors else "no",
+        payload.preferred_style,
+    )
+    return {
+        "id": name,
+        "oid": name,
+        "output_key": store.get_output_key(name),
+    }
+
+
+@admin_router.get(
+    "/custom-overlays/{name}/usage",
+    response_model=CustomOverlayUsage,
+    dependencies=[Depends(require_admin)],
+    summary="Inspect how many live consumers a custom overlay has",
+)
+def get_custom_overlay_usage(name: str):
+    """Report live OBS / scoreboard / session counts for *name*.
+
+    The response gives the operator enough information to decide whether
+    deleting (or re-theming) the overlay will disrupt an in-progress
+    broadcast — currently surfaced in the ``/manage`` UI as a dot next to
+    each row.
+    """
+    name = _validate_overlay_id(name)
+    store = _overlay_store()
+    if not store.overlay_exists(name):
+        raise HTTPException(
+            status_code=404, detail=f"Overlay '{name}' not found.",
+        )
+
+    # Lazy imports — these modules carry heavy dependencies (asyncio task
+    # registries, Backend) that we don't want loaded for every test that
+    # imports admin.routes.
+    from app.api.session_manager import SESSION_TTL_SECONDS, SessionManager
+    from app.api.ws_hub import WSHub
+    from app.overlay import obs_broadcast_hub
+
+    obs_count = obs_broadcast_hub.get_client_count(name)
+    frontend_count = len(WSHub._connections.get(name, set()))
+
+    session = SessionManager._sessions.get(name)
+    has_session = session is not None
+    seconds_since: int | None = None
+    if session is not None:
+        # ``last_accessed`` uses ``time.monotonic`` (see GameSession.touch)
+        # so we report a relative duration rather than a wall-clock
+        # timestamp — matches the operator's question ("is this still
+        # live?") and avoids the epoch-vs-monotonic confusion.
+        elapsed = time.monotonic() - session.last_accessed
+        # Clamp at the eviction TTL — anything older is considered stale
+        # and should be GC'd by the next ``SessionManager.cleanup_expired``.
+        seconds_since = max(0, min(int(elapsed), SESSION_TTL_SECONDS))
+
+    return CustomOverlayUsage(
+        obs_clients=obs_count,
+        frontend_ws_clients=frontend_count,
+        has_active_session=has_session,
+        seconds_since_last_activity=seconds_since,
     )
 
 

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -22,7 +22,7 @@ import os
 import re
 import time
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 from starlette.concurrency import run_in_threadpool
@@ -463,6 +463,61 @@ def get_custom_overlay_usage(name: str):
         has_active_session=has_session,
         seconds_since_last_activity=seconds_since,
     )
+
+
+@admin_router.post(
+    "/webhooks/replay",
+    dependencies=[Depends(require_admin)],
+    summary="Re-deliver dead-lettered webhook records",
+)
+def replay_dead_letter_webhooks(
+    since: float | None = Query(
+        None,
+        description=(
+            "Only replay records whose ``ts`` is >= this Unix-seconds "
+            "value. Useful for restricting replay to entries that "
+            "landed after the receiving service came back online."
+        ),
+    ),
+):
+    """Replay every record currently in the webhook dead-letter file.
+
+    Each record is matched to a configured ``WebhookTarget`` by URL,
+    re-signed with the *current* HMAC secret (so rotating
+    ``WEBHOOKS_SECRET`` doesn't strand legacy records with stale
+    signatures), and re-attempted with the standard retry policy.
+
+    * Successful redeliveries are removed from the file.
+    * Records whose URL no longer matches any configured target are
+      kept on disk so the operator can fix the config and retry.
+    * Records that fail again are kept with their ``attempts``
+      counter bumped and the latest ``last_error`` recorded.
+
+    Returns counts only — the body itself is never echoed back to
+    avoid leaking match payloads through the admin surface.
+    """
+    # Lazy imports keep ``app.admin.routes`` light for tests that just
+    # exercise overlay CRUD; pulling in ``requests`` (via webhooks)
+    # eagerly would tax those test paths.
+    from app.api import webhook_dead_letter, webhooks
+    records = webhook_dead_letter.read_all()
+    if since is not None:
+        # Anything older than ``since`` stays in the file untouched.
+        replay_set = [r for r in records if r.get("ts", 0) >= since]
+        keep_set = [r for r in records if r.get("ts", 0) < since]
+    else:
+        replay_set = list(records)
+        keep_set = []
+    succeeded, still_failing, skipped = (
+        webhooks.webhook_dispatcher.replay_records(replay_set)
+    )
+    webhook_dead_letter.replace_all(keep_set + still_failing)
+    return {
+        "considered": len(replay_set),
+        "succeeded": succeeded,
+        "still_failing": len(still_failing),
+        "skipped_unknown_url": skipped,
+    }
 
 
 @admin_router.delete("/custom-overlays/{name}", dependencies=[Depends(require_admin)])

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -470,7 +470,7 @@ def get_custom_overlay_usage(name: str):
     dependencies=[Depends(require_admin)],
     summary="Re-deliver dead-lettered webhook records",
 )
-def replay_dead_letter_webhooks(
+async def replay_dead_letter_webhooks(
     since: float | None = Query(
         None,
         description=(
@@ -479,8 +479,21 @@ def replay_dead_letter_webhooks(
             "landed after the receiving service came back online."
         ),
     ),
+    max_records: int = Query(
+        50,
+        ge=1,
+        le=500,
+        description=(
+            "Cap the number of records redelivered in this call. "
+            "``replay_records`` blocks on per-record retries with "
+            "exponential backoff (~25 s worst case per record), so a "
+            "fully-loaded dead-letter would otherwise pin the handler "
+            "for tens of minutes. Use the ``remaining_in_dl`` field in "
+            "the response to decide whether to call again."
+        ),
+    ),
 ):
-    """Replay every record currently in the webhook dead-letter file.
+    """Replay (a slice of) the webhook dead-letter file.
 
     Each record is matched to a configured ``WebhookTarget`` by URL,
     re-signed with the *current* HMAC secret (so rotating
@@ -493,8 +506,18 @@ def replay_dead_letter_webhooks(
     * Records that fail again are kept with their ``attempts``
       counter bumped and the latest ``last_error`` recorded.
 
-    Returns counts only — the body itself is never echoed back to
-    avoid leaking match payloads through the admin surface.
+    Selection order: oldest records (lowest ``ts``) within the
+    eligible window go first, so iterative calls drain the file
+    front-to-back. The blocking work runs on the FastAPI threadpool
+    via ``run_in_threadpool`` so the event loop stays free for other
+    handlers while a long replay is in flight.
+
+    Returns counts only — the bodies are never echoed back so the
+    admin surface cannot leak match payloads. ``remaining_in_dl``
+    is the count of records still on disk after the call (ones held
+    back by ``since`` / ``max_records`` plus the ``still_failing``
+    bucket that just got re-written) so the operator knows whether
+    to call again.
     """
     # Lazy imports keep ``app.admin.routes`` light for tests that just
     # exercise overlay CRUD; pulling in ``requests`` (via webhooks)
@@ -502,21 +525,28 @@ def replay_dead_letter_webhooks(
     from app.api import webhook_dead_letter, webhooks
     records = webhook_dead_letter.read_all()
     if since is not None:
-        # Anything older than ``since`` stays in the file untouched.
-        replay_set = [r for r in records if r.get("ts", 0) >= since]
-        keep_set = [r for r in records if r.get("ts", 0) < since]
+        eligible = [r for r in records if r.get("ts", 0) >= since]
+        held_back = [r for r in records if r.get("ts", 0) < since]
     else:
-        replay_set = list(records)
-        keep_set = []
-    succeeded, still_failing, skipped = (
-        webhooks.webhook_dispatcher.replay_records(replay_set)
+        eligible = list(records)
+        held_back = []
+    # Replay the oldest-eligible slice so successive calls drain the
+    # file front-to-back; what doesn't fit in this call stays in the
+    # DL (``deferred``) and shows up in ``remaining_in_dl``.
+    replay_set = eligible[:max_records]
+    deferred = eligible[max_records:]
+    dispatcher = webhooks.webhook_dispatcher
+    succeeded, still_failing, skipped = await run_in_threadpool(
+        dispatcher.replay_records, replay_set,
     )
-    webhook_dead_letter.replace_all(keep_set + still_failing)
+    new_dl = held_back + deferred + still_failing
+    webhook_dead_letter.replace_all(new_dl)
     return {
         "considered": len(replay_set),
         "succeeded": succeeded,
         "still_failing": len(still_failing),
         "skipped_unknown_url": skipped,
+        "remaining_in_dl": len(new_dl),
     }
 
 

--- a/app/admin/static/overlays.html
+++ b/app/admin/static/overlays.html
@@ -146,6 +146,139 @@
   }
   .modal h2 { margin-top: 0; }
   .modal p.muted { margin: 0.4rem 0 1rem; }
+  .manage-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 1rem;
+    margin-bottom: 0.25rem;
+    flex-wrap: wrap;
+  }
+  .manage-controls input[type="search"] {
+    flex: 1;
+    min-width: 220px;
+    max-width: 360px;
+  }
+  #resultCount { font-size: 0.85rem; }
+  #bulkCount { font-variant-numeric: tabular-nums; }
+  th.select-col, td.select-col { width: 36px; padding-right: 0; }
+  .bulk-list {
+    margin: 0.5rem 0 1rem;
+    padding-left: 1.25rem;
+    max-height: 240px;
+    overflow-y: auto;
+  }
+  .bulk-list li { font-family: monospace; font-size: 0.85rem; }
+  .link-btn {
+    background: transparent;
+    color: var(--accent);
+    padding: 0.25rem 0.5rem;
+    text-align: left;
+    font-weight: inherit;
+  }
+  .link-btn:hover { background: var(--surface-alt); }
+  .row-name-btn {
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  /* Drawer (overlay detail panel) */
+  .drawer {
+    position: fixed;
+    top: 0; right: 0;
+    width: 100%;
+    max-width: 480px;
+    height: 100dvh;
+    background: var(--surface);
+    border-left: 1px solid var(--border);
+    box-shadow: -10px 0 30px rgba(0, 0, 0, 0.2);
+    display: flex;
+    flex-direction: column;
+    z-index: 8;
+    transform: translateX(100%);
+    transition: transform 0.18s ease-out;
+    visibility: hidden;
+  }
+  .drawer.open {
+    transform: translateX(0);
+    visibility: visible;
+  }
+  .drawer-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .drawer-header h2 {
+    margin: 0;
+    font-size: 1.05rem;
+    word-break: break-all;
+  }
+  .drawer-close {
+    font-size: 1.4rem;
+    line-height: 1;
+    padding: 0.1rem 0.55rem;
+  }
+  .drawer-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1rem 1.25rem;
+  }
+  .drawer-section { margin-bottom: 1.5rem; }
+  .drawer-section h3 {
+    margin: 0 0 0.5rem;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--muted);
+  }
+  .drawer-preview {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    background: #000;
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .drawer-preview iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+  #drawerUsage dl.usage-grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.3rem 0.75rem;
+    margin: 0;
+    font-size: 0.9rem;
+  }
+  #drawerUsage dt { color: var(--muted); }
+  #drawerUsage dd {
+    margin: 0;
+    font-variant-numeric: tabular-nums;
+  }
+  .dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--muted);
+    margin-right: 0.4rem;
+    vertical-align: middle;
+  }
+  .dot.live { background: #2e7d32; }
+  .row-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.8rem;
+    color: var(--muted);
+  }
   .modal dl.meta {
     display: grid;
     grid-template-columns: auto 1fr;
@@ -200,6 +333,9 @@
     }
     table td.actions { justify-content: flex-end; padding-top: 0.5rem; }
     table td.actions::before { display: none; }
+    table td.select-col { justify-content: flex-end; padding: 0.2rem 0; }
+    table td.select-col::before { display: none; }
+    .manage-controls input[type="search"] { max-width: 100%; }
   }
 </style>
 </head>
@@ -246,9 +382,19 @@
         <code>/overlay/&lt;output_key&gt;</code>. Use the OID shown below when
         pointing the scoreboard controller at an overlay.
       </p>
+      <div class="manage-controls">
+        <input type="search" id="filterInput"
+               placeholder="Filter by name or OID…"
+               aria-label="Filter overlays" />
+        <span id="resultCount" class="muted" aria-live="polite"></span>
+      </div>
       <div class="toolbar" style="justify-content: flex-start;">
         <button id="newBtn">+ New overlay</button>
         <button id="refreshBtn" class="secondary">Refresh</button>
+        <button id="bulkDeleteBtn" class="danger" disabled
+                aria-label="Delete selected overlays">
+          Delete <span id="bulkCount">0</span> selected
+        </button>
       </div>
       <div id="overlayList"></div>
     </div>
@@ -287,6 +433,55 @@
     </div>
   </div>
 
+  <!-- Detail drawer (M5): live preview, theme apply, usage indicator -->
+  <aside id="overlayDrawer" class="drawer" aria-hidden="true" inert
+         aria-labelledby="drawerTitle">
+    <header class="drawer-header">
+      <h2 id="drawerTitle">Overlay</h2>
+      <button id="drawerCloseBtn" class="secondary drawer-close"
+              aria-label="Close overlay drawer" type="button">×</button>
+    </header>
+    <div class="drawer-body">
+      <section class="drawer-section">
+        <h3>Preview</h3>
+        <div class="drawer-preview">
+          <iframe id="drawerPreview"
+                  title="Overlay live preview"
+                  sandbox="allow-scripts allow-same-origin"
+                  referrerpolicy="same-origin"></iframe>
+        </div>
+        <p class="muted" style="margin: 0.5rem 0 0;">
+          <a id="drawerOpenInTab" href="#" target="_blank" rel="noopener">
+            Open preview in new tab ↗
+          </a>
+        </p>
+      </section>
+
+      <section class="drawer-section">
+        <h3>Theme</h3>
+        <p class="muted" style="margin: 0 0 0.5rem;">
+          Applies a preset theme to the overlay. The change reaches OBS
+          browser sources in real time via the broadcast hub.
+        </p>
+        <div class="field">
+          <label for="drawerTheme">Preset</label>
+          <select id="drawerTheme">
+            <option value="">— Keep current —</option>
+          </select>
+        </div>
+        <div id="drawerError" class="status error hidden"></div>
+        <div class="toolbar">
+          <button id="drawerApplyBtn" type="button">Apply theme</button>
+        </div>
+      </section>
+
+      <section class="drawer-section">
+        <h3>Live usage</h3>
+        <div id="drawerUsage" class="muted">Loading…</div>
+      </section>
+    </div>
+  </aside>
+
   <!-- Delete confirmation modal -->
   <div id="deleteModal" class="modal-backdrop hidden"
        role="dialog" aria-modal="true"
@@ -296,13 +491,9 @@
       <p id="deleteDesc" class="muted">
         This permanently removes the overlay's persisted state, disconnects
         any broadcast clients, and deletes the saved match archive entries
-        for this OID. This action cannot be undone.
+        for the affected OIDs. This action cannot be undone.
       </p>
-      <dl class="meta">
-        <dt>Name</dt><dd><strong id="deleteName"></strong></dd>
-        <dt>OID</dt><dd><code id="deleteOid"></code></dd>
-        <dt>Output key</dt><dd><code id="deleteOutputKey"></code></dd>
-      </dl>
+      <div id="deleteSummary"></div>
       <div id="deleteError" class="status error hidden"></div>
       <div class="toolbar">
         <button type="button" id="deleteCancelBtn" class="secondary">Cancel</button>
@@ -343,12 +534,28 @@
   const fieldName = $('field-name');
   const fieldCopy = $('field-copy');
   const deleteModal = $('deleteModal');
-  const deleteName = $('deleteName');
-  const deleteOid = $('deleteOid');
-  const deleteOutputKey = $('deleteOutputKey');
+  const deleteSummary = $('deleteSummary');
   const deleteError = $('deleteError');
   const deleteCancelBtn = $('deleteCancelBtn');
   const deleteConfirmBtn = $('deleteConfirmBtn');
+  const filterInput = $('filterInput');
+  const resultCount = $('resultCount');
+  const bulkDeleteBtn = $('bulkDeleteBtn');
+  const bulkCount = $('bulkCount');
+  const drawer = $('overlayDrawer');
+  const drawerTitle = $('drawerTitle');
+  const drawerCloseBtn = $('drawerCloseBtn');
+  const drawerPreview = $('drawerPreview');
+  const drawerOpenInTab = $('drawerOpenInTab');
+  const drawerTheme = $('drawerTheme');
+  const drawerError = $('drawerError');
+  const drawerApplyBtn = $('drawerApplyBtn');
+  const drawerUsage = $('drawerUsage');
+
+  let _filterText = '';
+  const _selectedIds = new Set();
+  let _drawerOverlay = null;
+  let _themesCache = null;
 
   function showStatus(text, kind) {
     statusMsg.textContent = text;
@@ -410,6 +617,7 @@
     if (err.status !== 401 && err.status !== 403) return false;
     setPassword('');
     if (_activeModal) closeModal(_activeModal);
+    if (drawer && drawer.classList.contains('open')) closeDrawer();
     showView('login');
     setTimeout(() => passwordInput.focus(), 30);
     return true;
@@ -503,6 +711,8 @@
 
   logoutBtn.addEventListener('click', () => {
     setPassword('');
+    if (_activeModal) closeModal(_activeModal);
+    if (drawer && drawer.classList.contains('open')) closeDrawer();
     showView('login');
     passwordInput.value = '';
     passwordInput.focus();
@@ -513,24 +723,75 @@
     try {
       const overlays = await apiCall('GET', '/custom-overlays');
       cachedOverlays = Array.isArray(overlays) ? overlays : [];
-      renderOverlays(cachedOverlays);
+      // Drop selections that point at overlays which no longer exist —
+      // otherwise a stale id from before a server-side delete would
+      // re-appear in the next bulk delete.
+      for (const id of [..._selectedIds]) {
+        if (!cachedOverlays.some((o) => o.id === id)) _selectedIds.delete(id);
+      }
+      applyFilter();
     } catch (err) {
       if (handleAuthError(err)) return;
       overlayList.innerHTML = '<p class="status error">' + escapeHtml(err.message) + '</p>';
     }
   }
 
-  function renderOverlays(overlays) {
-    if (!overlays || overlays.length === 0) {
-      overlayList.innerHTML = '<p class="empty">No custom overlays yet. Click “New overlay” to add one.</p>';
+  function applyFilter() {
+    if (!_filterText) {
+      renderOverlays(cachedOverlays);
       return;
     }
+    const needle = _filterText.toLowerCase();
+    const filtered = cachedOverlays.filter((o) =>
+      o.id.toLowerCase().includes(needle)
+      || o.oid.toLowerCase().includes(needle)
+      || o.output_key.toLowerCase().includes(needle));
+    renderOverlays(filtered);
+  }
+
+  function updateResultCount(visibleCount) {
+    if (cachedOverlays.length === 0) {
+      resultCount.textContent = '';
+    } else if (visibleCount === cachedOverlays.length) {
+      resultCount.textContent = cachedOverlays.length === 1
+        ? '1 overlay'
+        : `${cachedOverlays.length} overlays`;
+    } else {
+      resultCount.textContent = `${visibleCount} of ${cachedOverlays.length}`;
+    }
+  }
+
+  function updateBulkButton() {
+    bulkCount.textContent = String(_selectedIds.size);
+    bulkDeleteBtn.disabled = _selectedIds.size === 0;
+  }
+
+  function renderOverlays(overlays) {
+    updateResultCount(overlays.length);
+    if (cachedOverlays.length === 0) {
+      overlayList.innerHTML = '<p class="empty">No custom overlays yet. Click “New overlay” to add one.</p>';
+      updateBulkButton();
+      return;
+    }
+    if (overlays.length === 0) {
+      overlayList.innerHTML = '<p class="empty">No overlays match the current filter.</p>';
+      updateBulkButton();
+      return;
+    }
+    const allVisibleSelected = overlays.every((o) => _selectedIds.has(o.id));
     const rows = overlays.map((o) => `
         <tr data-id="${escapeAttr(o.id)}">
+          <td class="select-col">
+            <input type="checkbox" class="row-select"
+                   aria-label="Select overlay ${escapeAttr(o.id)}"
+                   ${_selectedIds.has(o.id) ? 'checked' : ''} />
+          </td>
           <td data-label="Name"><strong>${escapeHtml(o.id)}</strong></td>
           <td data-label="OID"><code>${escapeHtml(o.oid)}</code></td>
           <td data-label="Output key"><code>${escapeHtml(o.output_key)}</code></td>
           <td class="actions">
+            <button class="secondary" data-action="edit"
+                    aria-label="Edit overlay ${escapeAttr(o.id)}">Edit</button>
             <button class="secondary" data-action="copy"
                     aria-label="Copy overlay ${escapeAttr(o.id)}">Copy</button>
             <button class="danger" data-action="delete"
@@ -541,22 +802,51 @@
     overlayList.innerHTML = `
       <table>
         <thead>
-          <tr><th>Name</th><th>OID</th><th>Output key</th><th></th></tr>
+          <tr>
+            <th class="select-col">
+              <input type="checkbox" id="selectAll"
+                     aria-label="Select all visible overlays"
+                     ${allVisibleSelected ? 'checked' : ''} />
+            </th>
+            <th>Name</th><th>OID</th><th>Output key</th><th></th>
+          </tr>
         </thead>
         <tbody>${rows}</tbody>
       </table>
     `;
+    overlayList.querySelectorAll('input.row-select').forEach((cb) => {
+      cb.addEventListener('change', () => {
+        const id = cb.closest('tr').getAttribute('data-id');
+        if (cb.checked) _selectedIds.add(id); else _selectedIds.delete(id);
+        // Keep the select-all checkbox in sync with the actual visible set.
+        const sa = overlayList.querySelector('#selectAll');
+        if (sa) sa.checked = overlays.every((o) => _selectedIds.has(o.id));
+        updateBulkButton();
+      });
+    });
+    const selectAll = overlayList.querySelector('#selectAll');
+    if (selectAll) {
+      selectAll.addEventListener('change', () => {
+        const visibleIds = overlays.map((o) => o.id);
+        if (selectAll.checked) {
+          visibleIds.forEach((id) => _selectedIds.add(id));
+        } else {
+          visibleIds.forEach((id) => _selectedIds.delete(id));
+        }
+        applyFilter();
+      });
+    }
     overlayList.querySelectorAll('button[data-action]').forEach((btn) => {
       btn.addEventListener('click', () => {
         const tr = btn.closest('tr');
         const id = tr.getAttribute('data-id');
+        const overlay = cachedOverlays.find((o) => o.id === id);
+        if (btn.dataset.action === 'edit' && overlay) openDrawer(overlay, btn);
         if (btn.dataset.action === 'copy') openCreate(id, btn);
-        if (btn.dataset.action === 'delete') {
-          const overlay = cachedOverlays.find((o) => o.id === id);
-          if (overlay) openDelete(overlay, btn);
-        }
+        if (btn.dataset.action === 'delete' && overlay) openDelete([overlay], btn);
       });
     });
+    updateBulkButton();
   }
 
   newBtn.addEventListener('click', () => openCreate(null, newBtn));
@@ -570,6 +860,14 @@
     if (e.target === deleteModal) closeDelete();
   });
   deleteConfirmBtn.addEventListener('click', performDelete);
+  filterInput.addEventListener('input', () => {
+    _filterText = filterInput.value.trim();
+    applyFilter();
+  });
+  bulkDeleteBtn.addEventListener('click', () => {
+    const targets = cachedOverlays.filter((o) => _selectedIds.has(o.id));
+    if (targets.length) openDelete(targets, bulkDeleteBtn);
+  });
 
   function openCreate(copyFromId, opener) {
     clearError(createError);
@@ -590,12 +888,35 @@
     closeModal(createModal);
   }
 
-  let _pendingDelete = null;
-  function openDelete(overlay, opener) {
-    _pendingDelete = overlay;
-    deleteName.textContent = overlay.id;
-    deleteOid.textContent = overlay.oid;
-    deleteOutputKey.textContent = overlay.output_key;
+  let _pendingDelete = [];
+
+  function openDelete(overlays, opener) {
+    if (!overlays || overlays.length === 0) return;
+    _pendingDelete = overlays.slice();
+    if (overlays.length === 1) {
+      const o = overlays[0];
+      deleteSummary.innerHTML = `
+        <dl class="meta">
+          <dt>Name</dt><dd><strong>${escapeHtml(o.id)}</strong></dd>
+          <dt>OID</dt><dd><code>${escapeHtml(o.oid)}</code></dd>
+          <dt>Output key</dt><dd><code>${escapeHtml(o.output_key)}</code></dd>
+        </dl>`;
+      deleteConfirmBtn.textContent = 'Delete overlay';
+    } else {
+      // Cap the visible list at 10 entries so the modal does not run off
+      // the viewport for a "delete everything" selection. The total count
+      // sits in the heading line so the operator still sees the impact.
+      const head = overlays.slice(0, 10);
+      const tail = overlays.length - head.length;
+      const items = head.map((o) =>
+        `<li>${escapeHtml(o.id)}</li>`).join('');
+      const more = tail > 0
+        ? `<li class="muted">… and ${tail} more</li>` : '';
+      deleteSummary.innerHTML = `
+        <p><strong>${overlays.length}</strong> overlays will be permanently deleted:</p>
+        <ul class="bulk-list">${items}${more}</ul>`;
+      deleteConfirmBtn.textContent = `Delete ${overlays.length} overlays`;
+    }
     clearError(deleteError);
     deleteConfirmBtn.disabled = false;
     // Cancel is default-focused so ENTER does not delete by accident.
@@ -603,24 +924,46 @@
   }
 
   function closeDelete() {
-    _pendingDelete = null;
+    _pendingDelete = [];
     closeModal(deleteModal);
   }
 
   async function performDelete() {
-    const overlay = _pendingDelete;
-    if (!overlay) return;
+    const targets = _pendingDelete;
+    if (!targets.length) return;
     deleteConfirmBtn.disabled = true;
-    try {
-      await apiCall('DELETE', '/custom-overlays/' + encodeURIComponent(overlay.id));
-      closeDelete();
-      showStatus('Overlay deleted.', 'success');
-      await loadOverlays();
-    } catch (err) {
-      if (handleAuthError(err)) return;
-      showError(deleteError, err.message || 'Could not delete overlay.');
-      deleteConfirmBtn.disabled = false;
+    let succeeded = 0;
+    let lastError = null;
+    // Sequential rather than concurrent: a 401 on the first call
+    // (password rotated) should bounce immediately to login instead
+    // of fanning out N parallel failures.
+    for (const overlay of targets) {
+      try {
+        await apiCall(
+          'DELETE',
+          '/custom-overlays/' + encodeURIComponent(overlay.id));
+        _selectedIds.delete(overlay.id);
+        succeeded++;
+      } catch (err) {
+        if (handleAuthError(err)) return;
+        lastError = err;
+        break;
+      }
     }
+    closeDelete();
+    if (lastError && succeeded === 0) {
+      showStatus(lastError.message || 'Could not delete overlay.', 'error');
+    } else if (lastError) {
+      showStatus(
+        `${succeeded} of ${targets.length} deleted; stopped at error: `
+        + (lastError.message || 'unknown error'),
+        'error');
+    } else if (succeeded === 1) {
+      showStatus('Overlay deleted.', 'success');
+    } else {
+      showStatus(`${succeeded} overlays deleted.`, 'success');
+    }
+    await loadOverlays();
   }
 
   createForm.addEventListener('submit', async (e) => {
@@ -644,6 +987,139 @@
       showError(createError, err.message || 'Could not create overlay.');
     }
   });
+
+  // ---- Drawer (M5) -------------------------------------------------------
+
+  drawerCloseBtn.addEventListener('click', closeDrawer);
+  drawerApplyBtn.addEventListener('click', applyDrawerTheme);
+  // ESC also closes the drawer when no modal is on top of it.
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape') return;
+    if (_activeModal) return;  // modal handler above already deals with it
+    if (drawer.classList.contains('open')) {
+      e.stopPropagation();
+      closeDrawer();
+    }
+  });
+
+  async function openDrawer(overlay, opener) {
+    _drawerOverlay = overlay;
+    drawerTitle.textContent = overlay.id;
+    // Re-point the iframe even when reopening on the same overlay so the
+    // operator sees a fresh state (and so a previously closed drawer
+    // releases the about:blank loaded by closeDrawer).
+    const previewUrl = '/overlay/' + encodeURIComponent(overlay.output_key)
+      + '?style=mosaic';
+    drawerPreview.src = previewUrl;
+    drawerOpenInTab.href = '/overlay/' + encodeURIComponent(overlay.output_key);
+    clearError(drawerError);
+    drawer.classList.add('open');
+    drawer.removeAttribute('inert');
+    drawer.setAttribute('aria-hidden', 'false');
+    drawer._opener = opener || null;
+    setTimeout(() => drawerCloseBtn.focus(), 30);
+    await loadDrawerThemes();
+    drawerTheme.value = '';  // start at "keep current" each time
+    loadDrawerUsage(overlay.id);
+  }
+
+  function closeDrawer() {
+    drawer.classList.remove('open');
+    drawer.setAttribute('aria-hidden', 'true');
+    drawer.setAttribute('inert', '');
+    // Release the live preview so the WS in the iframe disconnects.
+    drawerPreview.src = 'about:blank';
+    const opener = drawer._opener;
+    drawer._opener = null;
+    _drawerOverlay = null;
+    if (opener && typeof opener.focus === 'function') opener.focus();
+  }
+
+  async function loadDrawerThemes() {
+    if (_themesCache) return _themesCache;
+    try {
+      // /api/themes is unauthenticated and returns {themes: [...]}.
+      const res = await fetch('/api/themes', { method: 'GET' });
+      if (!res.ok) throw new Error('Could not list themes (' + res.status + ').');
+      const body = await res.json();
+      _themesCache = Array.isArray(body && body.themes) ? body.themes : [];
+    } catch (err) {
+      _themesCache = [];
+      showError(drawerError, err.message || 'Could not load themes.');
+    }
+    // Rebuild the dropdown.
+    const opts = ['<option value="">— Keep current —</option>']
+      .concat(_themesCache.map((t) =>
+        `<option value="${escapeAttr(t)}">${escapeHtml(t)}</option>`));
+    drawerTheme.innerHTML = opts.join('');
+    return _themesCache;
+  }
+
+  async function loadDrawerUsage(overlayId) {
+    drawerUsage.textContent = 'Loading…';
+    try {
+      const u = await apiCall(
+        'GET', '/custom-overlays/' + encodeURIComponent(overlayId) + '/usage');
+      const live = (u.has_active_session
+        || u.obs_clients > 0
+        || u.frontend_ws_clients > 0);
+      const elapsed = u.seconds_since_last_activity;
+      const elapsedLabel = (elapsed === null || elapsed === undefined)
+        ? '—'
+        : (elapsed < 60 ? `${elapsed}s ago`
+           : elapsed < 3600 ? `${Math.floor(elapsed / 60)}m ago`
+           : `${Math.floor(elapsed / 3600)}h ago`);
+      drawerUsage.innerHTML = `
+        <p style="margin: 0 0 0.5rem;">
+          <span class="dot${live ? ' live' : ''}" aria-hidden="true"></span>
+          <strong>${live ? 'Live' : 'Idle'}</strong>
+        </p>
+        <dl class="usage-grid">
+          <dt>OBS viewers</dt><dd>${u.obs_clients}</dd>
+          <dt>Scoreboard tabs</dt><dd>${u.frontend_ws_clients}</dd>
+          <dt>Active session</dt><dd>${u.has_active_session ? 'yes' : 'no'}</dd>
+          <dt>Last activity</dt><dd>${escapeHtml(elapsedLabel)}</dd>
+        </dl>`;
+    } catch (err) {
+      if (handleAuthError(err)) return;
+      drawerUsage.innerHTML =
+        '<p class="status error">'
+        + escapeHtml(err.message || 'Could not load usage.')
+        + '</p>';
+    }
+  }
+
+  async function applyDrawerTheme() {
+    const overlay = _drawerOverlay;
+    if (!overlay) return;
+    const theme = drawerTheme.value;
+    if (!theme) {
+      showError(drawerError, 'Pick a theme to apply, or close the drawer.');
+      return;
+    }
+    clearError(drawerError);
+    drawerApplyBtn.disabled = true;
+    try {
+      await apiCall(
+        'PATCH',
+        '/custom-overlays/' + encodeURIComponent(overlay.id),
+        { theme });
+      showStatus(`Theme “${theme}” applied.`, 'success');
+      // Bust the iframe cache so the operator sees the new theme right
+      // away — without this, the same URL would be served from cache and
+      // only the WebSocket-pushed state would refresh.
+      const u = new URL(drawerPreview.src, window.location.origin);
+      u.searchParams.set('t', String(Date.now()));
+      drawerPreview.src = u.pathname + u.search;
+      // Refresh the usage panel — the apply broadcast bumps last_activity.
+      loadDrawerUsage(overlay.id);
+    } catch (err) {
+      if (handleAuthError(err)) return;
+      showError(drawerError, err.message || 'Could not apply theme.');
+    } finally {
+      drawerApplyBtn.disabled = false;
+    }
+  }
 
   function escapeHtml(s) {
     return String(s == null ? '' : s).replace(/[&<>"']/g, (c) => ({

--- a/app/admin/static/overlays.html
+++ b/app/admin/static/overlays.html
@@ -145,6 +145,62 @@
     box-shadow: 0 10px 30px rgba(0,0,0,0.3);
   }
   .modal h2 { margin-top: 0; }
+  .modal p.muted { margin: 0.4rem 0 1rem; }
+  .modal dl.meta {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.35rem 0.75rem;
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+  }
+  .modal dl.meta dt { color: var(--muted); }
+  .modal dl.meta dd { margin: 0; word-break: break-all; }
+  .modal dl.meta dd code {
+    background: var(--surface-alt);
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+    font-size: 0.85rem;
+  }
+
+  @media (max-width: 600px) {
+    main { padding: 1rem 0.5rem; }
+    header { padding: 0.75rem 1rem; }
+    header h1 { font-size: 1.1rem; }
+    .card { padding: 1rem; }
+    .toolbar { flex-wrap: wrap; }
+    table thead { display: none; }
+    table, table tbody { display: block; width: 100%; }
+    table tr {
+      display: block;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      margin-bottom: 0.75rem;
+      padding: 0.5rem 0.75rem;
+      background: var(--surface-alt);
+    }
+    table td {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 0.75rem;
+      border-bottom: none;
+      padding: 0.3rem 0;
+      text-align: right;
+      word-break: break-all;
+    }
+    table td::before {
+      content: attr(data-label);
+      font-weight: 600;
+      color: var(--muted);
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      flex-shrink: 0;
+      text-align: left;
+    }
+    table td.actions { justify-content: flex-end; padding-top: 0.5rem; }
+    table td.actions::before { display: none; }
+  }
 </style>
 </head>
 <body>
@@ -199,9 +255,10 @@
   </div>
 
   <!-- Create modal -->
-  <div id="createModal" class="modal-backdrop hidden">
+  <div id="createModal" class="modal-backdrop hidden"
+       role="dialog" aria-modal="true" aria-labelledby="createTitle">
     <div class="modal">
-      <h2>New custom overlay</h2>
+      <h2 id="createTitle">New custom overlay</h2>
       <form id="createForm">
         <div class="field">
           <label for="field-name">Name *</label>
@@ -227,6 +284,30 @@
           <button type="submit" id="saveBtn">Create</button>
         </div>
       </form>
+    </div>
+  </div>
+
+  <!-- Delete confirmation modal -->
+  <div id="deleteModal" class="modal-backdrop hidden"
+       role="dialog" aria-modal="true"
+       aria-labelledby="deleteTitle" aria-describedby="deleteDesc">
+    <div class="modal">
+      <h2 id="deleteTitle">Delete custom overlay?</h2>
+      <p id="deleteDesc" class="muted">
+        This permanently removes the overlay's persisted state, disconnects
+        any broadcast clients, and deletes the saved match archive entries
+        for this OID. This action cannot be undone.
+      </p>
+      <dl class="meta">
+        <dt>Name</dt><dd><strong id="deleteName"></strong></dd>
+        <dt>OID</dt><dd><code id="deleteOid"></code></dd>
+        <dt>Output key</dt><dd><code id="deleteOutputKey"></code></dd>
+      </dl>
+      <div id="deleteError" class="status error hidden"></div>
+      <div class="toolbar">
+        <button type="button" id="deleteCancelBtn" class="secondary">Cancel</button>
+        <button type="button" id="deleteConfirmBtn" class="danger">Delete overlay</button>
+      </div>
     </div>
   </div>
 </main>
@@ -261,6 +342,13 @@
   const cancelBtn = $('cancelBtn');
   const fieldName = $('field-name');
   const fieldCopy = $('field-copy');
+  const deleteModal = $('deleteModal');
+  const deleteName = $('deleteName');
+  const deleteOid = $('deleteOid');
+  const deleteOutputKey = $('deleteOutputKey');
+  const deleteError = $('deleteError');
+  const deleteCancelBtn = $('deleteCancelBtn');
+  const deleteConfirmBtn = $('deleteConfirmBtn');
 
   function showStatus(text, kind) {
     statusMsg.textContent = text;
@@ -314,6 +402,52 @@
     logoutBtn.classList.toggle('hidden', which !== 'admin');
     loggedInHint.classList.toggle('hidden', which !== 'admin');
   }
+
+  // Lightweight modal a11y: restore focus to the opener on close, trap
+  // TAB inside the dialog, and let ESC dismiss it.
+  let _activeModal = null;
+  let _modalReturnFocus = null;
+  function openModal(modal, opener, focusEl) {
+    _modalReturnFocus = opener || document.activeElement;
+    _activeModal = modal;
+    modal.classList.remove('hidden');
+    setTimeout(() => {
+      const target = focusEl
+        || modal.querySelector('input, select, button, textarea, [tabindex]:not([tabindex="-1"])');
+      if (target && typeof target.focus === 'function') target.focus();
+    }, 30);
+  }
+  function closeModal(modal) {
+    if (modal !== _activeModal) return;
+    modal.classList.add('hidden');
+    _activeModal = null;
+    const ret = _modalReturnFocus;
+    _modalReturnFocus = null;
+    if (ret && typeof ret.focus === 'function') ret.focus();
+  }
+  document.addEventListener('keydown', (e) => {
+    if (!_activeModal) return;
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      closeModal(_activeModal);
+      return;
+    }
+    if (e.key !== 'Tab') return;
+    const focusables = Array.from(_activeModal.querySelectorAll(
+      'input:not([disabled]), select:not([disabled]), '
+      + 'button:not([disabled]), textarea:not([disabled]), '
+      + '[tabindex]:not([tabindex="-1"])'));
+    if (!focusables.length) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  });
 
   async function bootstrap() {
     let statusInfo;
@@ -385,12 +519,14 @@
     }
     const rows = overlays.map((o) => `
         <tr data-id="${escapeAttr(o.id)}">
-          <td><strong>${escapeHtml(o.id)}</strong></td>
-          <td><code>${escapeHtml(o.oid)}</code></td>
-          <td><code>${escapeHtml(o.output_key)}</code></td>
+          <td data-label="Name"><strong>${escapeHtml(o.id)}</strong></td>
+          <td data-label="OID"><code>${escapeHtml(o.oid)}</code></td>
+          <td data-label="Output key"><code>${escapeHtml(o.output_key)}</code></td>
           <td class="actions">
-            <button class="secondary" data-action="copy">Copy</button>
-            <button class="danger" data-action="delete">Delete</button>
+            <button class="secondary" data-action="copy"
+                    aria-label="Copy overlay ${escapeAttr(o.id)}">Copy</button>
+            <button class="danger" data-action="delete"
+                    aria-label="Delete overlay ${escapeAttr(o.id)}">Delete</button>
           </td>
         </tr>
       `).join('');
@@ -406,20 +542,28 @@
       btn.addEventListener('click', () => {
         const tr = btn.closest('tr');
         const id = tr.getAttribute('data-id');
-        if (btn.dataset.action === 'copy') openCreate(id);
-        if (btn.dataset.action === 'delete') confirmDelete(id);
+        if (btn.dataset.action === 'copy') openCreate(id, btn);
+        if (btn.dataset.action === 'delete') {
+          const overlay = cachedOverlays.find((o) => o.id === id);
+          if (overlay) openDelete(overlay, btn);
+        }
       });
     });
   }
 
-  newBtn.addEventListener('click', () => openCreate(null));
+  newBtn.addEventListener('click', () => openCreate(null, newBtn));
   refreshBtn.addEventListener('click', loadOverlays);
   cancelBtn.addEventListener('click', closeCreate);
   createModal.addEventListener('click', (e) => {
     if (e.target === createModal) closeCreate();
   });
+  deleteCancelBtn.addEventListener('click', closeDelete);
+  deleteModal.addEventListener('click', (e) => {
+    if (e.target === deleteModal) closeDelete();
+  });
+  deleteConfirmBtn.addEventListener('click', performDelete);
 
-  function openCreate(copyFromId) {
+  function openCreate(copyFromId, opener) {
     clearError(createError);
     fieldName.value = '';
     // Rebuild the copy-from dropdown from the current list.
@@ -431,12 +575,43 @@
       fieldCopy.appendChild(opt);
     });
     fieldCopy.value = copyFromId || '';
-    createModal.classList.remove('hidden');
-    setTimeout(() => fieldName.focus(), 50);
+    openModal(createModal, opener, fieldName);
   }
 
   function closeCreate() {
-    createModal.classList.add('hidden');
+    closeModal(createModal);
+  }
+
+  let _pendingDelete = null;
+  function openDelete(overlay, opener) {
+    _pendingDelete = overlay;
+    deleteName.textContent = overlay.id;
+    deleteOid.textContent = overlay.oid;
+    deleteOutputKey.textContent = overlay.output_key;
+    clearError(deleteError);
+    deleteConfirmBtn.disabled = false;
+    // Cancel is default-focused so ENTER does not delete by accident.
+    openModal(deleteModal, opener, deleteCancelBtn);
+  }
+
+  function closeDelete() {
+    _pendingDelete = null;
+    closeModal(deleteModal);
+  }
+
+  async function performDelete() {
+    const overlay = _pendingDelete;
+    if (!overlay) return;
+    deleteConfirmBtn.disabled = true;
+    try {
+      await apiCall('DELETE', '/custom-overlays/' + encodeURIComponent(overlay.id));
+      closeDelete();
+      showStatus('Overlay deleted.', 'success');
+      await loadOverlays();
+    } catch (err) {
+      showError(deleteError, err.message || 'Could not delete overlay.');
+      deleteConfirmBtn.disabled = false;
+    }
   }
 
   createForm.addEventListener('submit', async (e) => {
@@ -459,17 +634,6 @@
       showError(createError, err.message || 'Could not create overlay.');
     }
   });
-
-  async function confirmDelete(id) {
-    if (!window.confirm(`Delete overlay “${id}”? This removes its persisted state.`)) return;
-    try {
-      await apiCall('DELETE', '/custom-overlays/' + encodeURIComponent(id));
-      showStatus('Overlay deleted.', 'success');
-      await loadOverlays();
-    } catch (err) {
-      showStatus(err.message || 'Could not delete overlay.', 'error');
-    }
-  }
 
   function escapeHtml(s) {
     return String(s == null ? '' : s).replace(/[&<>"']/g, (c) => ({

--- a/app/admin/static/overlays.html
+++ b/app/admin/static/overlays.html
@@ -403,6 +403,18 @@
     loggedInHint.classList.toggle('hidden', which !== 'admin');
   }
 
+  // 401/403 from any admin call means the password rotated (or expired).
+  // Clear it from memory and bounce the operator back to the login view —
+  // every entry point that calls ``apiCall`` should reuse this helper.
+  function handleAuthError(err) {
+    if (err.status !== 401 && err.status !== 403) return false;
+    setPassword('');
+    if (_activeModal) closeModal(_activeModal);
+    showView('login');
+    setTimeout(() => passwordInput.focus(), 30);
+    return true;
+  }
+
   // Lightweight modal a11y: restore focus to the opener on close, trap
   // TAB inside the dialog, and let ESC dismiss it.
   let _activeModal = null;
@@ -503,11 +515,7 @@
       cachedOverlays = Array.isArray(overlays) ? overlays : [];
       renderOverlays(cachedOverlays);
     } catch (err) {
-      if (err.status === 401 || err.status === 403) {
-        setPassword('');
-        showView('login');
-        return;
-      }
+      if (handleAuthError(err)) return;
       overlayList.innerHTML = '<p class="status error">' + escapeHtml(err.message) + '</p>';
     }
   }
@@ -609,6 +617,7 @@
       showStatus('Overlay deleted.', 'success');
       await loadOverlays();
     } catch (err) {
+      if (handleAuthError(err)) return;
       showError(deleteError, err.message || 'Could not delete overlay.');
       deleteConfirmBtn.disabled = false;
     }
@@ -631,6 +640,7 @@
       closeCreate();
       await loadOverlays();
     } catch (err) {
+      if (handleAuthError(err)) return;
       showError(createError, err.message || 'Could not create overlay.');
     }
   });

--- a/app/api/action_log.py
+++ b/app/api/action_log.py
@@ -45,6 +45,7 @@ import time
 from collections.abc import Set as AbstractSet
 
 from app.api.oid_validation import OID_PATTERN
+from app.constants import AUDIT_LOG_MAX_BYTES, AUDIT_LOG_MAX_FILES
 
 logger = logging.getLogger(__name__)
 
@@ -128,6 +129,108 @@ def _lock_for(oid: str) -> threading.Lock:
     return _locks_pool[idx]
 
 
+# ---------------------------------------------------------------------------
+# Log rotation
+# ---------------------------------------------------------------------------
+#
+# The active file lives at ``audit_<hash>.jsonl``. When ``append`` finds it
+# above ``AUDIT_LOG_MAX_BYTES``, the file is rotated logrotate-style:
+# ``.{N-1} -> .N`` (oldest first to avoid clobbering), then active -> .1,
+# and anything that would land beyond ``.MAX_FILES-1`` is deleted.
+# ``MAX_FILES`` counts the active file plus the rotated set, matching the
+# operator's "keep N audit files per OID" mental model.
+#
+# Rotation runs inside the per-OID lock (same lock that serializes
+# appends / pops / clears) so a concurrent reader never sees a torn rename.
+
+
+def _rotated_path(path: str, index: int) -> str:
+    """Return the on-disk path of the *index*-th rotated file (1-based)."""
+    return f"{path}.{index}"
+
+
+def _existing_rotated_indices(path: str) -> list[int]:
+    """Return rotated-file indices that exist on disk, ascending order.
+
+    1 is the most recently rotated; higher indices are older. Used by
+    ``_iter_log_paths_oldest_first`` to walk the full per-OID log without
+    forcing every caller to ``os.path.exists`` the same set of files.
+    """
+    indices = []
+    for i in range(1, AUDIT_LOG_MAX_FILES):
+        if os.path.exists(_rotated_path(path, i)):
+            indices.append(i)
+    return indices
+
+
+def _iter_log_paths_oldest_first(path: str) -> list[str]:
+    """Return [oldest_rotated, ..., active] for the OID at *path*.
+
+    Active appears last so callers (``read_all``) can concatenate
+    records in chronological order without a separate sort pass.
+    """
+    paths: list[str] = []
+    # Rotated files: the largest index is the oldest.
+    for i in reversed(_existing_rotated_indices(path)):
+        paths.append(_rotated_path(path, i))
+    if os.path.exists(path):
+        paths.append(path)
+    return paths
+
+
+def _rotate_if_needed_locked(path: str) -> None:
+    """Rotate ``path`` when it exceeds ``AUDIT_LOG_MAX_BYTES``.
+
+    Caller must hold ``_lock_for(oid)``. No-op when the file is missing
+    or under the threshold, or when ``AUDIT_LOG_MAX_FILES <= 1`` (in
+    which case the operator has effectively disabled rotation history
+    and we just truncate by deletion on overflow).
+    """
+    if AUDIT_LOG_MAX_FILES <= 1:
+        # No rotated slots configured — fall back to truncating the
+        # active file when it overflows so it cannot grow without bound.
+        if os.path.exists(path) and os.path.getsize(path) > AUDIT_LOG_MAX_BYTES:
+            try:
+                os.remove(path)
+            except OSError as exc:
+                logger.warning("Failed to truncate oversized audit '%s': %s", path, exc)
+        return
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return
+    if size <= AUDIT_LOG_MAX_BYTES:
+        return
+    # Drop the oldest slot if it would exceed the cap after the shift.
+    oldest = _rotated_path(path, AUDIT_LOG_MAX_FILES - 1)
+    try:
+        os.remove(oldest)
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning("Failed to drop oldest rotated audit '%s': %s", oldest, exc)
+    # Shift .{i} -> .{i+1} from oldest survivor down so renames never
+    # overwrite an existing file (.replace would, but the explicit walk
+    # makes the intent obvious in the dominator code path).
+    for i in range(AUDIT_LOG_MAX_FILES - 2, 0, -1):
+        src = _rotated_path(path, i)
+        dst = _rotated_path(path, i + 1)
+        if os.path.exists(src):
+            try:
+                os.replace(src, dst)
+            except OSError as exc:
+                logger.warning(
+                    "Failed to shift rotated audit '%s' -> '%s': %s",
+                    src, dst, exc,
+                )
+                return
+    # Active -> .1.
+    try:
+        os.replace(path, _rotated_path(path, 1))
+    except OSError as exc:
+        logger.warning("Failed to rotate active audit '%s': %s", path, exc)
+
+
 def append(oid: str, action: str, params: dict, result: dict) -> None:
     """Atomically append one record. Best-effort: never raises."""
     path = _path(oid)
@@ -136,6 +239,7 @@ def append(oid: str, action: str, params: dict, result: dict) -> None:
     try:
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with _lock_for(oid):
+            _rotate_if_needed_locked(path)
             record = {
                 "ts": _next_ts(oid),
                 "action": action,
@@ -151,13 +255,8 @@ def append(oid: str, action: str, params: dict, result: dict) -> None:
         logger.warning("Failed to append audit log for %r: %s", oid, exc)
 
 
-def _read_raw_locked(path: str, oid: str) -> list[dict]:
-    """Read every JSON line at *path*, skipping malformed ones.
-
-    Caller must already hold ``_lock_for(oid)``. Tombstone records and
-    the records they reference are returned as-is — filtering happens
-    in :func:`_apply_tombstones`.
-    """
+def _read_one_file_locked(path: str, oid: str) -> list[dict]:
+    """Read every JSON line at *path*, skipping malformed ones."""
     records: list[dict] = []
     with open(path, encoding="utf-8") as f:
         for line in f:
@@ -171,6 +270,22 @@ def _read_raw_locked(path: str, oid: str) -> list[dict]:
                     "Skipping malformed audit line for %r: %s",
                     oid, exc,
                 )
+    return records
+
+
+def _read_raw_locked(path: str, oid: str) -> list[dict]:
+    """Read every JSON line in the OID's full log, oldest first.
+
+    Walks ``audit_<hash>.jsonl.{N-1}`` down to ``.1`` and finally the
+    active ``audit_<hash>.jsonl`` so chronological order is preserved
+    across rotation boundaries. Caller must already hold
+    ``_lock_for(oid)``. Tombstone records and the records they
+    reference are returned as-is — filtering happens in
+    :func:`_apply_tombstones`.
+    """
+    records: list[dict] = []
+    for p in _iter_log_paths_oldest_first(path):
+        records.extend(_read_one_file_locked(p, oid))
     return records
 
 
@@ -199,15 +314,30 @@ def _apply_tombstones(raw: list[dict]) -> list[dict]:
     ]
 
 
+def _has_any_log_file(path: str) -> bool:
+    """True when the active file or any rotated file exists for *path*."""
+    if os.path.exists(path):
+        return True
+    return any(
+        os.path.exists(_rotated_path(path, i))
+        for i in range(1, AUDIT_LOG_MAX_FILES)
+    )
+
+
 def read_all(oid: str) -> list[dict]:
     """Return every record for *oid* in append order. Empty list if absent.
+
+    Walks the active file plus every rotated file so consumers
+    (``match_archive``, the ``/audit`` endpoint, the undo path) see
+    the full per-OID history regardless of how many rotations have
+    occurred since the match started.
 
     Pop tombstones (and the forward records they cancel) are filtered
     out so callers see the same logical view a full rewrite would
     produce.
     """
     path = _path(oid)
-    if path is None or not os.path.exists(path):
+    if path is None or not _has_any_log_file(path):
         return []
     try:
         with _lock_for(oid):
@@ -218,6 +348,46 @@ def read_all(oid: str) -> list[dict]:
     return _apply_tombstones(raw)
 
 
+def read_page(
+    oid: str,
+    limit: int,
+    before_ts: float | None = None,
+) -> tuple[list[dict], float | None]:
+    """Return up to *limit* records older than *before_ts*, plus a cursor.
+
+    Cursor-based pagination over the per-OID audit log, walking forward
+    from the newest entry and serving fixed-size pages so a long-running
+    match (50 K+ records) does not force the operator to ship the whole
+    history on every dashboard refresh.
+
+    Parameters:
+      * ``limit`` — max number of records to return; clamped to >= 1.
+      * ``before_ts`` — when set, only records with ``ts < before_ts``
+        are considered. Use ``None`` for the first page (newest
+        ``limit`` records).
+
+    Returns ``(records, next_cursor)``:
+      * ``records`` is in chronological order (oldest first within the
+        returned window — same convention as ``read_recent``).
+      * ``next_cursor`` is the ``ts`` of the **oldest** returned record
+        when more pages remain (caller passes it as ``before_ts`` for
+        the next call), or ``None`` when the page is the final one.
+
+    Tombstoned records are invisible to the cursor so paging never
+    skips past visible records because of an undo that happened
+    between calls.
+    """
+    if limit <= 0:
+        return [], None
+    records = read_all(oid)
+    if before_ts is not None:
+        records = [r for r in records if r.get("ts", 0) < before_ts]
+    page = records[-limit:]
+    has_more = len(records) > len(page)
+    next_cursor = page[0].get("ts") if (page and has_more) else None
+    return page, next_cursor
+
+
 def read_recent(oid: str, limit: int = 100) -> list[dict]:
     """Return up to *limit* most-recent records (chronological order)."""
     if limit <= 0:
@@ -226,33 +396,61 @@ def read_recent(oid: str, limit: int = 100) -> list[dict]:
     return records[-limit:]
 
 
+def _remove_all_log_files_locked(path: str) -> bool:
+    """Delete the active log and every rotated file for *path*.
+
+    Returns True when at least one file was removed. Caller must hold
+    the per-OID lock.
+    """
+    removed = False
+    if os.path.exists(path):
+        try:
+            os.remove(path)
+            removed = True
+        except OSError as exc:
+            logger.warning("Failed to remove active audit '%s': %s", path, exc)
+    for i in range(1, AUDIT_LOG_MAX_FILES):
+        rp = _rotated_path(path, i)
+        if os.path.exists(rp):
+            try:
+                os.remove(rp)
+                removed = True
+            except OSError as exc:
+                logger.warning("Failed to remove rotated audit '%s': %s", rp, exc)
+    return removed
+
+
 def clear(oid: str) -> None:
-    """Truncate the audit log for *oid* if it exists. No-op otherwise."""
+    """Truncate the audit log for *oid* if it exists. No-op otherwise.
+
+    Removes both the active file and every rotated file so a match
+    reset starts from a genuinely empty log even if rotation happened
+    earlier in the same process.
+    """
     path = _path(oid)
     if path is None:
         return
     try:
         with _lock_for(oid):
-            if os.path.exists(path):
-                os.remove(path)
+            _remove_all_log_files_locked(path)
             _last_ts_per_oid.pop(oid, None)
     except Exception as exc:
         logger.warning("Failed to clear audit log for %r: %s", oid, exc)
 
 
 def delete(oid: str) -> bool:
-    """Remove the audit file. Returns True if a file was removed."""
+    """Remove every audit file for *oid* (active + rotated).
+
+    Returns True when at least one file existed and was removed.
+    """
     path = _path(oid)
     if path is None:
         return False
     try:
         with _lock_for(oid):
-            os.remove(path)
+            removed = _remove_all_log_files_locked(path)
             _last_ts_per_oid.pop(oid, None)
-        return True
-    except FileNotFoundError:
-        _last_ts_per_oid.pop(oid, None)
-        return False
+        return removed
     except OSError as exc:
         logger.warning("Failed to delete audit log for %r: %s", oid, exc)
         return False
@@ -304,7 +502,7 @@ def pop_last_forward(
     Returns ``None`` when no matching forward record exists.
     """
     path = _path(oid)
-    if path is None or not os.path.exists(path):
+    if path is None or not _has_any_log_file(path):
         return None
     try:
         with _lock_for(oid):
@@ -328,6 +526,11 @@ def pop_last_forward(
             line = json.dumps(
                 tombstone, separators=(",", ":"), ensure_ascii=False,
             ) + "\n"
+            # The tombstone always lands on the active file; even when
+            # the target lives in a rotated archive the read paths
+            # (``read_all`` / ``_apply_tombstones``) walk the whole
+            # set together, so a forward record in ``.3`` can be
+            # cancelled by a tombstone in the active file.
             with open(path, "a", encoding="utf-8") as f:
                 f.write(line)
             return target
@@ -348,7 +551,7 @@ def peek_last_forward(
     dispatch — the dispatched call performs the actual pop.
     """
     path = _path(oid)
-    if path is None or not os.path.exists(path):
+    if path is None or not _has_any_log_file(path):
         return None
     try:
         with _lock_for(oid):

--- a/app/api/middleware/metrics.py
+++ b/app/api/middleware/metrics.py
@@ -1,0 +1,57 @@
+"""ASGI middleware that records HTTP request latency in Prometheus.
+
+Observes one entry per request into ``http_request_duration_seconds``
+labelled by ``route`` (the FastAPI route template — bounded by the
+OpenAPI surface, never the raw path), ``method`` and ``status``.
+
+WebSocket scopes are skipped: their lifetime is open-ended and does
+not map cleanly onto a histogram bucket.
+
+Designed to be cheap when ``prometheus_client`` is missing — every
+``observe`` call falls through to a no-op stub in :mod:`app.metrics`
+so the middleware can stay wired in unconditionally.
+"""
+from __future__ import annotations
+
+import time
+
+from app.metrics import http_request_duration_seconds
+
+
+class MetricsMiddleware:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        start = time.monotonic()
+        status_code_holder = {"code": 0}
+
+        async def _send(message):
+            if message["type"] == "http.response.start":
+                status_code_holder["code"] = int(message.get("status", 0))
+            await send(message)
+
+        try:
+            await self.app(scope, receive, _send)
+        finally:
+            elapsed = time.monotonic() - start
+            # Resolve the route template so cardinality stays bounded.
+            # ``scope['route']`` is set by Starlette once routing has run.
+            # When it's missing (404 before routing, lifespan hooks…) we
+            # bucket under ``unmatched`` to keep the label cardinality
+            # bounded even on a hostile probe storm.
+            route_obj = scope.get("route")
+            route = (
+                getattr(route_obj, "path", None)
+                or scope.get("path", "unmatched")
+            )
+            method = scope.get("method", "UNKNOWN")
+            http_request_duration_seconds.labels(
+                route=route,
+                method=method,
+                status=str(status_code_holder["code"] or "0"),
+            ).observe(elapsed)

--- a/app/api/routes/audit.py
+++ b/app/api/routes/audit.py
@@ -12,21 +12,48 @@ router = APIRouter()
 @router.get(
     "/audit",
     dependencies=[Depends(verify_api_key)],
-    summary="Recent action audit log",
+    summary="Recent action audit log (cursor-paginated)",
 )
 async def get_audit_log(
     session: GameSession = Depends(get_session),
     limit: int = Query(100, ge=1, le=1000),
+    before_ts: float | None = Query(
+        None,
+        description=(
+            "Pagination cursor: only return records strictly older "
+            "than this timestamp. Use the ``next_cursor`` value from "
+            "the previous response. Omit for the first page."
+        ),
+    ),
 ):
-    """Return up to *limit* most-recent records from the action log.
+    """Return one page of audit records, newest page first.
 
-    Records are ordered chronologically (oldest first within the
-    returned window). Each entry has the shape::
+    First call (``before_ts`` omitted) returns the most recent
+    ``limit`` records. Subsequent calls pass the previous response's
+    ``next_cursor`` to walk back through history one window at a time.
+
+    Records are ordered chronologically (oldest first **within** the
+    returned window — same convention as ``read_recent``). Each entry
+    has the shape::
 
         {"ts": 1714508400.123,
          "action": "add_point",
          "params": {"team": 1, "undo": false},
          "result": {"current_set": 2, "team_1": {...}, ...}}
+
+    The response carries:
+
+    * ``records`` — the page itself.
+    * ``count`` — ``len(records)``.
+    * ``next_cursor`` — the ``ts`` to pass as ``before_ts`` for the
+      next page, or ``null`` when this is the last page.
     """
-    records = action_log.read_recent(session.oid, limit=limit)
-    return {"oid": session.oid, "count": len(records), "records": records}
+    records, next_cursor = action_log.read_page(
+        session.oid, limit=limit, before_ts=before_ts,
+    )
+    return {
+        "oid": session.oid,
+        "count": len(records),
+        "records": records,
+        "next_cursor": next_cursor,
+    }

--- a/app/api/routes/lifespan.py
+++ b/app/api/routes/lifespan.py
@@ -7,6 +7,7 @@ from weakref import WeakValueDictionary
 
 from app.api.session_manager import SessionManager
 from app.api.webhooks import webhook_dispatcher
+from app.api.ws_hub import WSHub
 
 logger = logging.getLogger(__name__)
 
@@ -44,9 +45,12 @@ async def _session_cleanup_loop():
 async def router_lifespan(app):
     global _cleanup_task
     _cleanup_task = asyncio.create_task(_session_cleanup_loop())
+    # No-op when WSHUB_HEARTBEAT_INTERVAL_SECONDS == 0 (the default).
+    WSHub.start_heartbeat()
     yield
     if _cleanup_task:
         _cleanup_task.cancel()
+    WSHub.stop_heartbeat()
     SessionManager.clear()
     # Drain in-flight deliveries with cancel_futures=True so a hung
     # outbound webhook can't keep the process alive past shutdown.

--- a/app/api/routes/metrics.py
+++ b/app/api/routes/metrics.py
@@ -1,0 +1,78 @@
+"""GET /metrics — Prometheus exposition.
+
+Mounted at the FastAPI app root (not under ``/api/v1``) so the path
+matches every other Prometheus-instrumented service the operator is
+likely to scrape.
+
+Auth ladder:
+
+* Default: **unauthenticated**. The exported metrics expose
+  aggregates (request latency, webhook delivery counts, total open
+  WebSocket connections, active session count) — no payloads, no
+  per-OID labels — so the surface is safe to scrape from the
+  Kubernetes service mesh / Prometheus operator without provisioning
+  another secret.
+* Opt-in: setting ``METRICS_REQUIRE_ADMIN=true`` gates the route
+  behind the same Bearer token as ``/api/v1/admin/*`` for operators
+  who would rather not expose anything to the LAN.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Header, HTTPException, Response
+
+from app.auth_utils import require_admin_token
+from app.env_vars_manager import EnvVarsManager
+from app.metrics import (
+    CONTENT_TYPE_LATEST,
+    PROMETHEUS_AVAILABLE,
+    REGISTRY,
+    generate_latest,
+)
+
+router = APIRouter()
+
+
+_TRUTHY = ("1", "true", "t", "yes", "on")
+
+
+def _require_admin_when_configured() -> bool:
+    raw = EnvVarsManager.get_env_var("METRICS_REQUIRE_ADMIN", "false")
+    return str(raw).strip().lower() in _TRUTHY
+
+
+@router.get(
+    "/metrics",
+    summary="Prometheus exposition",
+    response_class=Response,
+)
+def metrics_endpoint(authorization: str = Header(None)):
+    """Return the registry's current exposition in Prometheus text format.
+
+    ``METRICS_REQUIRE_ADMIN=true`` opts into Bearer auth at the same
+    ladder as ``/api/v1/admin/*``. The check fires *before* the
+    library-availability check so an unauthenticated probe cannot use
+    the 503-vs-200 difference to fingerprint whether the metrics
+    backend is loaded.
+    """
+    if _require_admin_when_configured():
+        require_admin_token(
+            authorization,
+            token=None,
+            missing_password_detail=(  # nosec B106
+                "Metrics auth requested but OVERLAY_MANAGER_PASSWORD is unset."
+            ),
+            missing_token_detail=(  # nosec B106
+                "Missing admin password. Use 'Authorization: Bearer <password>'."
+            ),
+            invalid_token_detail="Invalid admin password.",  # nosec B106
+        )
+    if not PROMETHEUS_AVAILABLE:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Metrics disabled: prometheus_client is not installed. "
+                "Run 'pip install -r requirements.txt' to enable."
+            ),
+        )
+    body = generate_latest(REGISTRY)
+    return Response(content=body, media_type=CONTENT_TYPE_LATEST)

--- a/app/api/routes/websocket.py
+++ b/app/api/routes/websocket.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, Query, WebSocket, WebSocketDisconn
 from app.api.dependencies import check_oid_access
 from app.api.game_service import GameService
 from app.api.session_manager import SessionManager
-from app.api.ws_hub import WSHub
+from app.api.ws_hub import WSHub, WSHubFull
 from app.logging_utils import redact_oid
 
 logger = logging.getLogger(__name__)
@@ -84,13 +84,25 @@ async def websocket_endpoint(
         await ws.close(code=4004, reason="No active session for this OID.")
         return
 
-    await WSHub.connect(ws, resolved, subprotocol=selected_subprotocol)
+    try:
+        await WSHub.connect(ws, resolved, subprotocol=selected_subprotocol)
+    except WSHubFull as exc:
+        # 1013 = Try Again Later. Reason stays generic so a probing
+        # client cannot use the close text to enumerate which OIDs are
+        # at the cap.
+        logger.warning(
+            "Refused WS connect for OID %s — at cap %d",
+            redact_oid(resolved), exc.cap,
+        )
+        await ws.close(code=1013, reason="Too many clients for this OID.")
+        return
     try:
         state_data = GameService.get_state(session).model_dump()
         await ws.send_json({"type": "state_update", "data": state_data})
 
         while True:
             data = await ws.receive_text()
+            WSHub.mark_active(ws)
             # Actions go through REST; WS is state-stream + ping/pong only.
             if data == "ping":
                 await ws.send_text("pong")

--- a/app/api/session_manager.py
+++ b/app/api/session_manager.py
@@ -11,13 +11,11 @@ from app.api.session_persistence import (
 )
 from app.backend import Backend
 from app.conf import Conf
+from app.constants import SESSION_TTL_SECONDS  # re-exported
 from app.customization import Customization
 from app.game_manager import GameManager
 
 logger = logging.getLogger(__name__)
-
-# Sessions expire after 24 hours of inactivity
-SESSION_TTL_SECONDS = 24 * 60 * 60
 
 
 class GameSession:

--- a/app/api/session_manager.py
+++ b/app/api/session_manager.py
@@ -14,6 +14,7 @@ from app.conf import Conf
 from app.constants import SESSION_TTL_SECONDS  # re-exported
 from app.customization import Customization
 from app.game_manager import GameManager
+from app.metrics import set_active_sessions
 
 logger = logging.getLogger(__name__)
 
@@ -224,6 +225,7 @@ class SessionManager:
             # rehydrate without requiring any mutation in between.
             new_session.persist_meta()
             cls._sessions[oid] = new_session
+            set_active_sessions(len(cls._sessions))
             return new_session
 
     @classmethod
@@ -242,6 +244,7 @@ class SessionManager:
             session = cls._sessions.pop(oid, None)
             if session:
                 session.shutdown()
+            set_active_sessions(len(cls._sessions))
 
     @classmethod
     def clear(cls):
@@ -250,6 +253,7 @@ class SessionManager:
             for session in cls._sessions.values():
                 session.shutdown()
             cls._sessions.clear()
+            set_active_sessions(0)
 
     @classmethod
     def cleanup_expired(cls):
@@ -264,4 +268,6 @@ class SessionManager:
                 session = cls._sessions.pop(oid)
                 session.shutdown()
                 logger.info("Expired session for OID=%s", oid)
+            if expired:
+                set_active_sessions(len(cls._sessions))
         return len(expired)

--- a/app/api/webhook_dead_letter.py
+++ b/app/api/webhook_dead_letter.py
@@ -1,0 +1,134 @@
+"""Dead-letter queue for webhook deliveries that exhausted every retry.
+
+Persists one JSON record per failed delivery to
+``data/webhooks_dead_letter.jsonl``. The operator replays it on demand
+once the receiving service is healthy again via
+``POST /api/v1/admin/webhooks/replay``.
+
+Record schema (one JSON object per line)::
+
+    {"ts": 1714508400.123,
+     "url": "https://hooks.example.com/scoreboard",
+     "event": "set_end",
+     "oid": "abc",
+     "body": "{...}",
+     "last_error": "HTTP 503",
+     "attempts": 4}
+
+The ``body`` is stored as a UTF-8 string (the JSON payload that would
+have been sent), so the file is human-inspectable. The HMAC ``secret``
+is **not** persisted: replay re-resolves the matching ``WebhookTarget``
+from the live config and re-signs with the current secret. That way
+rotating ``WEBHOOKS_SECRET`` does not strand legacy DL entries with
+stale signatures, and a leaked DL file does not leak signing keys.
+
+I/O is protected by a module-level lock so a producer thread (the
+webhook ThreadPoolExecutor) and a consumer (the admin replay
+handler) cannot interleave half-written records.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+
+_FILENAME = "webhooks_dead_letter.jsonl"
+
+
+def _data_dir() -> str:
+    base = os.path.dirname(os.path.abspath(__file__))
+    return os.path.normpath(os.path.join(base, "..", "..", "data"))
+
+
+def _path() -> str:
+    return os.path.join(_data_dir(), _FILENAME)
+
+
+def append(record: dict) -> None:
+    """Append a JSON record to the dead-letter file. Best-effort."""
+    record = dict(record)
+    record.setdefault("ts", time.time())
+    path = _path()
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        line = json.dumps(record, ensure_ascii=False) + "\n"
+        with _lock, open(path, "a", encoding="utf-8") as f:
+            f.write(line)
+    except OSError as exc:
+        logger.warning("Failed to append webhook dead-letter: %s", exc)
+
+
+def read_all() -> list[dict]:
+    """Return every record in append order. Empty list when the file is missing."""
+    path = _path()
+    if not os.path.exists(path):
+        return []
+    records: list[dict] = []
+    try:
+        with _lock, open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError as exc:
+                    logger.debug("Skipping malformed DL line: %s", exc)
+    except OSError as exc:
+        logger.warning("Failed to read webhook dead-letter: %s", exc)
+    return records
+
+
+def replace_all(records: list[dict]) -> None:
+    """Atomically rewrite the dead-letter to contain only *records*.
+
+    Tempfile + ``os.replace`` so a crash mid-write cannot leave the
+    file half-written; either the new content or the old one survives.
+    Used by the admin replay handler after pruning successfully
+    re-delivered entries.
+    """
+    path = _path()
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with _lock:
+            fd, tmp_path = tempfile.mkstemp(
+                dir=os.path.dirname(path), suffix=".tmp",
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    for r in records:
+                        f.write(json.dumps(r, ensure_ascii=False) + "\n")
+                os.replace(tmp_path, path)
+            except BaseException:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+    except OSError as exc:
+        logger.warning("Failed to rewrite webhook dead-letter: %s", exc)
+
+
+def clear() -> None:
+    """Remove the dead-letter file entirely. No-op if missing."""
+    path = _path()
+    try:
+        with _lock:
+            if os.path.exists(path):
+                os.remove(path)
+    except OSError as exc:
+        logger.warning("Failed to clear webhook dead-letter: %s", exc)
+
+
+def filter_since(records: list[dict], since: float | None) -> list[dict]:
+    """Return only records whose ``ts`` is >= *since* (or all when None)."""
+    if since is None:
+        return list(records)
+    return [r for r in records if r.get("ts", 0) >= since]

--- a/app/api/webhook_dead_letter.py
+++ b/app/api/webhook_dead_letter.py
@@ -35,6 +35,9 @@ import tempfile
 import threading
 import time
 
+from app.constants import WEBHOOK_DEAD_LETTER_MAX_RECORDS
+from app.metrics import set_dead_letter_size
+
 logger = logging.getLogger(__name__)
 
 _lock = threading.Lock()
@@ -51,28 +54,78 @@ def _path() -> str:
     return os.path.join(_data_dir(), _FILENAME)
 
 
+def _count_lines_locked(path: str) -> int:
+    """Return the current record count in *path* (caller holds ``_lock``).
+
+    Counts non-empty lines so partially-written tails (the writer crashed
+    between ``write`` and ``\n``) are forgiven. Used by ``append`` to
+    decide whether to evict and by ``set_dead_letter_size`` callers.
+    """
+    if not os.path.exists(path):
+        return 0
+    n = 0
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    n += 1
+    except OSError as exc:
+        logger.warning("Failed to count webhook DL records: %s", exc)
+    return n
+
+
 def append(record: dict) -> None:
-    """Append a JSON record to the dead-letter file. Best-effort."""
+    """Append a JSON record to the dead-letter file.
+
+    When the resulting record count would exceed
+    ``WEBHOOK_DEAD_LETTER_MAX_RECORDS``, the oldest entries are dropped
+    so the file stays bounded. Eviction is FIFO (preserving the most
+    recent failures, which are most likely to still be relevant for a
+    replay) and runs under the same lock that serialises every other
+    mutation, so a concurrent ``read_all`` or ``replay_records`` can
+    never observe a torn rewrite.
+
+    Best-effort: filesystem errors are logged but never raised so a
+    write failure here cannot kill the GameService action that fired
+    the webhook.
+    """
     record = dict(record)
     record.setdefault("ts", time.time())
     path = _path()
     try:
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        line = json.dumps(record, ensure_ascii=False) + "\n"
-        with _lock, open(path, "a", encoding="utf-8") as f:
-            f.write(line)
+        with _lock:
+            current = _count_lines_locked(path)
+            cap = max(1, WEBHOOK_DEAD_LETTER_MAX_RECORDS)
+            if current + 1 > cap:
+                # Need to drop ``overflow`` of the oldest records to make
+                # room for the new one. Read everything, slice the tail,
+                # and rewrite atomically (tempfile + os.replace).
+                overflow = current + 1 - cap
+                kept = _read_records_locked(path)[overflow:]
+                kept.append(record)
+                _write_records_atomic_locked(path, kept)
+                logger.warning(
+                    "Webhook DL evicted %d oldest records (cap=%d)",
+                    overflow, cap,
+                )
+                set_dead_letter_size(len(kept))
+                return
+            line = json.dumps(record, ensure_ascii=False) + "\n"
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(line)
+            set_dead_letter_size(current + 1)
     except OSError as exc:
         logger.warning("Failed to append webhook dead-letter: %s", exc)
 
 
-def read_all() -> list[dict]:
-    """Return every record in append order. Empty list when the file is missing."""
-    path = _path()
-    if not os.path.exists(path):
-        return []
+def _read_records_locked(path: str) -> list[dict]:
+    """Read every JSON record at *path* (caller holds ``_lock``)."""
     records: list[dict] = []
+    if not os.path.exists(path):
+        return records
     try:
-        with _lock, open(path, encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line:
@@ -82,8 +135,40 @@ def read_all() -> list[dict]:
                 except json.JSONDecodeError as exc:
                     logger.debug("Skipping malformed DL line: %s", exc)
     except OSError as exc:
-        logger.warning("Failed to read webhook dead-letter: %s", exc)
+        logger.warning("Failed to read webhook DL: %s", exc)
     return records
+
+
+def _write_records_atomic_locked(path: str, records: list[dict]) -> None:
+    """Tempfile + ``os.replace`` rewrite (caller holds ``_lock``)."""
+    fd, tmp_path = tempfile.mkstemp(
+        dir=os.path.dirname(path), suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            for r in records:
+                f.write(json.dumps(r, ensure_ascii=False) + "\n")
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def read_all() -> list[dict]:
+    """Return every record in append order. Empty list when the file is missing."""
+    path = _path()
+    with _lock:
+        return _read_records_locked(path)
+
+
+def count() -> int:
+    """Return the current record count without parsing every line."""
+    path = _path()
+    with _lock:
+        return _count_lines_locked(path)
 
 
 def replace_all(records: list[dict]) -> None:
@@ -98,20 +183,8 @@ def replace_all(records: list[dict]) -> None:
     try:
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with _lock:
-            fd, tmp_path = tempfile.mkstemp(
-                dir=os.path.dirname(path), suffix=".tmp",
-            )
-            try:
-                with os.fdopen(fd, "w", encoding="utf-8") as f:
-                    for r in records:
-                        f.write(json.dumps(r, ensure_ascii=False) + "\n")
-                os.replace(tmp_path, path)
-            except BaseException:
-                try:
-                    os.unlink(tmp_path)
-                except OSError:
-                    pass
-                raise
+            _write_records_atomic_locked(path, records)
+        set_dead_letter_size(len(records))
     except OSError as exc:
         logger.warning("Failed to rewrite webhook dead-letter: %s", exc)
 
@@ -123,6 +196,7 @@ def clear() -> None:
         with _lock:
             if os.path.exists(path):
                 os.remove(path)
+        set_dead_letter_size(0)
     except OSError as exc:
         logger.warning("Failed to clear webhook dead-letter: %s", exc)
 

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -43,6 +43,12 @@ from urllib.parse import urlparse
 
 import requests
 
+from app.api import webhook_dead_letter
+from app.constants import (
+    WEBHOOK_RETRY_ATTEMPTS,
+    WEBHOOK_RETRY_BASE_SECONDS,
+    WEBHOOK_RETRY_MAX_SECONDS,
+)
 from app.env_vars_manager import EnvVarsManager
 
 logger = logging.getLogger(__name__)
@@ -296,9 +302,12 @@ class WebhookDispatcher:
             if executor is None:
                 # Synchronous fallback (used by tests when the executor
                 # is mocked away). Keeps semantics identical.
-                self._deliver(target, body_bytes)
+                self._deliver(target, body_bytes, event=event, oid=oid)
             else:
-                executor.submit(self._deliver, target, body_bytes)
+                executor.submit(
+                    self._deliver, target, body_bytes,
+                    event=event, oid=oid,
+                )
         return queued
 
     @staticmethod
@@ -308,45 +317,167 @@ class WebhookDispatcher:
         ).hexdigest()
         return f"sha256={digest}"
 
-    def _deliver(self, target: WebhookTarget, body: bytes) -> None:
-        # SSRF guard: refuse to call URLs that resolve to private,
-        # loopback, link-local, or otherwise non-public IPs unless
-        # the operator explicitly opted in. Resolution happens here
-        # rather than at config time so a target whose DNS rotates
-        # between deliveries is still vetted on every send. This
-        # does not fully mitigate DNS rebinding (the IP at delivery
-        # could differ from the one ``requests.post`` ultimately
-        # connects to), but it stops the most common foot-guns:
-        # accidental ``http://localhost/...`` typos and cloud
-        # metadata endpoints (``http://169.254.169.254``).
-        if not _allow_private_targets():
-            safe, reason = _is_target_safe(target.url)
-            if not safe:
-                logger.warning(
-                    "Webhook %s blocked by SSRF guard: %s. Set "
-                    "WEBHOOKS_ALLOW_PRIVATE_IPS=true to opt into "
-                    "private-network targets.",
-                    target.url, reason,
-                )
-                return
+    @staticmethod
+    def _ssrf_check(target: WebhookTarget) -> bool:
+        """Return True if *target* passes the SSRF allow-list.
 
+        Mirrors the original guard in ``_deliver``: refuses URLs whose
+        host resolves to a private/loopback/link-local/multicast/
+        reserved IP unless the operator opted into private targets.
+        """
+        if _allow_private_targets():
+            return True
+        safe, reason = _is_target_safe(target.url)
+        if not safe:
+            logger.warning(
+                "Webhook %s blocked by SSRF guard: %s. Set "
+                "WEBHOOKS_ALLOW_PRIVATE_IPS=true to opt into "
+                "private-network targets.",
+                target.url, reason,
+            )
+            return False
+        return True
+
+    def _attempt_with_retries(
+        self, target: WebhookTarget, body: bytes,
+    ) -> tuple[bool, str]:
+        """Try delivery with up to ``WEBHOOK_RETRY_ATTEMPTS`` retries.
+
+        Retries on 5xx and ``requests.RequestException`` (timeouts,
+        connect errors). 4xx is treated as a permanent client
+        rejection — no retry, no dead-letter, just a warning.
+
+        Backoff: ``WEBHOOK_RETRY_BASE_SECONDS * 2**(attempt-1)``,
+        capped at ``WEBHOOK_RETRY_MAX_SECONDS``. Default is
+        1 / 2 / 4 seconds between attempts (then capped at 8).
+
+        Returns ``(success, last_error_string)``. ``last_error`` is
+        empty when ``success`` is True or when the failure was a 4xx
+        (the 4xx body is logged but not re-surfaced).
+        """
+        if not self._ssrf_check(target):
+            # SSRF block is permanent: do not retry, do not DL, do not
+            # leak the URL in the error string returned to the caller.
+            return False, ""
         headers = {"Content-Type": "application/json"}
         if target.secret:
             headers["X-Webhook-Signature"] = self._sign(target.secret, body)
-        try:
-            response = requests.post(
-                target.url,
-                data=body,
-                headers=headers,
-                timeout=target.timeout_s,
-            )
-            if response.status_code >= 400:
+        last_err = ""
+        total_attempts = WEBHOOK_RETRY_ATTEMPTS + 1
+        for attempt in range(total_attempts):
+            if attempt > 0:
+                delay = min(
+                    WEBHOOK_RETRY_BASE_SECONDS * (2 ** (attempt - 1)),
+                    WEBHOOK_RETRY_MAX_SECONDS,
+                )
+                time.sleep(delay)
+            try:
+                response = requests.post(
+                    target.url,
+                    data=body,
+                    headers=headers,
+                    timeout=target.timeout_s,
+                )
+            except requests.RequestException as exc:
+                last_err = f"{type(exc).__name__}: {exc}"
                 logger.warning(
-                    "Webhook %s returned %s",
+                    "Webhook %s failed on attempt %d/%d: %s",
+                    target.url, attempt + 1, total_attempts, exc,
+                )
+                continue
+            if response.status_code < 400:
+                return True, ""
+            if 400 <= response.status_code < 500:
+                # Client-side rejection: not retriable, not dead-letter
+                # material — the receiver will keep saying no.
+                logger.warning(
+                    "Webhook %s returned %d (not retried)",
                     target.url, response.status_code,
                 )
-        except requests.RequestException as exc:
-            logger.warning("Webhook %s failed: %s", target.url, exc)
+                return False, ""
+            last_err = f"HTTP {response.status_code}"
+            logger.warning(
+                "Webhook %s returned %d on attempt %d/%d",
+                target.url, response.status_code, attempt + 1, total_attempts,
+            )
+        return False, last_err
+
+    def _deliver(
+        self,
+        target: WebhookTarget,
+        body: bytes,
+        event: str = "",
+        oid: str = "",
+    ) -> None:
+        """Deliver *body* with retries; dead-letter on terminal failure.
+
+        Called from the dispatch thread pool. Successes return
+        silently; permanent 4xx / SSRF rejections also return silently
+        (their warnings live in the logger). Only retriable failures
+        that exhaust ``WEBHOOK_RETRY_ATTEMPTS`` end up in the
+        dead-letter file for operator-initiated replay.
+        """
+        ok, last_err = self._attempt_with_retries(target, body)
+        if ok or not last_err:
+            return
+        try:
+            body_str = body.decode("utf-8")
+        except UnicodeDecodeError:
+            body_str = body.decode("utf-8", errors="replace")
+        webhook_dead_letter.append({
+            "url": target.url,
+            "event": event,
+            "oid": oid,
+            "body": body_str,
+            "last_error": last_err,
+            "attempts": WEBHOOK_RETRY_ATTEMPTS + 1,
+        })
+
+    def replay_records(
+        self, records: list[dict],
+    ) -> tuple[int, list[dict], int]:
+        """Re-attempt *records* against the current target config.
+
+        Used by the admin replay endpoint. Each record is matched to a
+        configured ``WebhookTarget`` by URL; missing matches mean the
+        operator changed the config since the entry landed in the DL,
+        and those records are kept in the DL for manual triage.
+
+        Returns ``(succeeded, still_failing, skipped_unknown_url)``:
+
+        * ``succeeded`` — count of records re-delivered cleanly.
+        * ``still_failing`` — records to write back to the DL (failed
+          deliveries plus skipped ones, so the operator does not lose
+          them on replay).
+        * ``skipped_unknown_url`` — count of records whose URL no
+          longer matches any configured target. They're included in
+          ``still_failing`` so the operator can rewrite their config
+          and retry.
+        """
+        targets = self._ensure_loaded()
+        targets_by_url = {t.url: t for t in targets}
+        succeeded = 0
+        still_failing: list[dict] = []
+        skipped = 0
+        for r in records:
+            target = targets_by_url.get(r.get("url"))
+            if target is None:
+                skipped += 1
+                still_failing.append(r)
+                continue
+            body_str = r.get("body") or ""
+            body = body_str.encode("utf-8")
+            ok, last_err = self._attempt_with_retries(target, body)
+            if ok:
+                succeeded += 1
+                continue
+            updated = dict(r)
+            updated["last_error"] = last_err or r.get("last_error", "")
+            updated["attempts"] = (
+                int(r.get("attempts", 0)) + WEBHOOK_RETRY_ATTEMPTS + 1
+            )
+            still_failing.append(updated)
+        return succeeded, still_failing, skipped
 
 
 # Module-level singleton — mirrors the overlay/store/hub pattern.

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -50,6 +50,7 @@ from app.constants import (
     WEBHOOK_RETRY_MAX_SECONDS,
 )
 from app.env_vars_manager import EnvVarsManager
+from app.metrics import record_webhook_outcome
 
 logger = logging.getLogger(__name__)
 
@@ -340,7 +341,7 @@ class WebhookDispatcher:
 
     def _attempt_with_retries(
         self, target: WebhookTarget, body: bytes,
-    ) -> tuple[bool, str]:
+    ) -> tuple[bool, str, str]:
         """Try delivery with up to ``WEBHOOK_RETRY_ATTEMPTS`` retries.
 
         Retries on 5xx and ``requests.RequestException`` (timeouts,
@@ -351,14 +352,16 @@ class WebhookDispatcher:
         capped at ``WEBHOOK_RETRY_MAX_SECONDS``. Default is
         1 / 2 / 4 seconds between attempts (then capped at 8).
 
-        Returns ``(success, last_error_string)``. ``last_error`` is
-        empty when ``success`` is True or when the failure was a 4xx
-        (the 4xx body is logged but not re-surfaced).
+        Returns ``(success, last_error_string, status_kind)``.
+        ``status_kind`` is one of ``success`` / ``client_error`` /
+        ``server_error`` / ``exception`` / ``ssrf_blocked`` so the
+        caller can drive the Prometheus counter without re-deriving
+        the bucket from a string match on ``last_error``.
         """
         if not self._ssrf_check(target):
             # SSRF block is permanent: do not retry, do not DL, do not
             # leak the URL in the error string returned to the caller.
-            return False, ""
+            return False, "", "ssrf_blocked"
         headers = {"Content-Type": "application/json"}
         if target.secret:
             headers["X-Webhook-Signature"] = self._sign(target.secret, body)
@@ -386,7 +389,7 @@ class WebhookDispatcher:
                 )
                 continue
             if response.status_code < 400:
-                return True, ""
+                return True, "", "success"
             if 400 <= response.status_code < 500:
                 # Client-side rejection: not retriable, not dead-letter
                 # material — the receiver will keep saying no.
@@ -394,13 +397,16 @@ class WebhookDispatcher:
                     "Webhook %s returned %d (not retried)",
                     target.url, response.status_code,
                 )
-                return False, ""
+                return False, "", "client_error"
             last_err = f"HTTP {response.status_code}"
             logger.warning(
                 "Webhook %s returned %d on attempt %d/%d",
                 target.url, response.status_code, attempt + 1, total_attempts,
             )
-        return False, last_err
+        # Exhausted retries on a transient failure. ``last_err`` differentiates
+        # exception vs HTTP 5xx via its ``HTTP `` prefix.
+        kind = "server_error" if last_err.startswith("HTTP ") else "exception"
+        return False, last_err, kind
 
     def _deliver(
         self,
@@ -417,7 +423,8 @@ class WebhookDispatcher:
         that exhaust ``WEBHOOK_RETRY_ATTEMPTS`` end up in the
         dead-letter file for operator-initiated replay.
         """
-        ok, last_err = self._attempt_with_retries(target, body)
+        ok, last_err, status_kind = self._attempt_with_retries(target, body)
+        record_webhook_outcome(event, status_kind)
         if ok or not last_err:
             return
         try:
@@ -432,6 +439,10 @@ class WebhookDispatcher:
             "last_error": last_err,
             "attempts": WEBHOOK_RETRY_ATTEMPTS + 1,
         })
+        # Counted in addition to the per-attempt status above so the
+        # operator can alert on "X events landed in the DL" without
+        # subtracting success/4xx/etc. from the total.
+        record_webhook_outcome(event, "dead_letter")
 
     def replay_records(
         self, records: list[dict],
@@ -467,7 +478,8 @@ class WebhookDispatcher:
                 continue
             body_str = r.get("body") or ""
             body = body_str.encode("utf-8")
-            ok, last_err = self._attempt_with_retries(target, body)
+            ok, last_err, status_kind = self._attempt_with_retries(target, body)
+            record_webhook_outcome(r.get("event", ""), status_kind)
             if ok:
                 succeeded += 1
                 continue

--- a/app/api/ws_hub.py
+++ b/app/api/ws_hub.py
@@ -11,6 +11,7 @@ from app.constants import (
     WSHUB_HEARTBEAT_INTERVAL_SECONDS,
     WSHUB_MAX_CLIENTS_PER_OID,
 )
+from app.metrics import set_ws_gauges
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,7 @@ class WSHub:
             await ws.accept()
         cls._connections.setdefault(oid, set()).add(ws)
         cls._last_seen[ws] = time.monotonic()
+        cls._refresh_gauges()
         logger.info(
             "WS client connected for OID=%s (total=%d)",
             oid, len(cls._connections[oid]))
@@ -103,6 +105,17 @@ class WSHub:
             cls._last_seen[ws] = time.monotonic()
 
     @classmethod
+    def _refresh_gauges(cls) -> None:
+        """Publish the current ``_connections`` snapshot to the Prometheus gauges.
+
+        Cheap (one ``sum`` over a small dict). Centralises the metric
+        update so the cardinality story stays in one place — neither
+        gauge takes per-OID labels by design.
+        """
+        total = sum(len(s) for s in cls._connections.values())
+        set_ws_gauges(total, len(cls._connections))
+
+    @classmethod
     def disconnect(cls, ws: WebSocket, oid: str):
         conns = cls._connections.get(oid)
         if conns:
@@ -110,6 +123,7 @@ class WSHub:
             if not conns:
                 del cls._connections[oid]
         cls._last_seen.pop(ws, None)
+        cls._refresh_gauges()
         logger.info("WS client disconnected for OID=%s", oid)
 
     # Per-socket send timeout. A slow/hung client must not stall broadcasts
@@ -146,15 +160,21 @@ class WSHub:
             return_exceptions=False,
         )
 
+        evicted_any = False
         for ws in results:
             if ws is not None:
                 conns.discard(ws)
+                cls._last_seen.pop(ws, None)
+                evicted_any = True
         # Only drop the OID entry if the registry still holds *our* set.
         # A concurrent ``disconnect`` could have removed it and a concurrent
         # ``connect`` could have installed a new set in the meantime; popping
         # in that case would silently lose the new client.
         if not conns and cls._connections.get(oid) is conns:
             cls._connections.pop(oid, None)
+            evicted_any = True
+        if evicted_any:
+            cls._refresh_gauges()
 
     @classmethod
     async def broadcast(cls, oid: str, data: dict):
@@ -208,6 +228,7 @@ class WSHub:
         """Remove all connections (for testing)."""
         cls._connections.clear()
         cls._last_seen.clear()
+        cls._refresh_gauges()
 
     # ----- Heartbeat (opt-in via WSHUB_HEARTBEAT_INTERVAL_SECONDS > 0) ---
 

--- a/app/api/ws_hub.py
+++ b/app/api/ws_hub.py
@@ -1,12 +1,35 @@
 import asyncio
 import json
 import logging
+import time
 
 from fastapi import WebSocket
 
-from app.constants import WS_BROADCAST_SEND_TIMEOUT_SECONDS
+from app.constants import (
+    WS_BROADCAST_SEND_TIMEOUT_SECONDS,
+    WSHUB_CLIENT_TIMEOUT_SECONDS,
+    WSHUB_HEARTBEAT_INTERVAL_SECONDS,
+    WSHUB_MAX_CLIENTS_PER_OID,
+)
 
 logger = logging.getLogger(__name__)
+
+
+class WSHubFull(Exception):
+    """Raised by :meth:`WSHub.connect` when an OID is at its connection cap.
+
+    The endpoint catches this and closes the upgrade with WebSocket
+    code 1013 ("Try Again Later"), which is the conventional
+    server-side back-pressure signal. The OID is preserved on the
+    exception so the caller can include it in the close reason for
+    log correlation.
+    """
+
+    def __init__(self, oid: str, cap: int):
+        super().__init__(
+            f"OID {oid!r} is at the {cap}-client cap.")
+        self.oid = oid
+        self.cap = cap
 
 
 class WSHub:
@@ -23,11 +46,26 @@ class WSHub:
     # this, the asyncio event loop may garbage-collect a task created via
     # ``loop.create_task(...)`` before it finishes, dropping the broadcast.
     _pending_tasks: set = set()
+    # {WebSocket: monotonic timestamp of last client activity}. Populated
+    # by ``connect`` and bumped by the endpoint on every received frame
+    # so the heartbeat loop can tell zombies from healthy idle clients.
+    _last_seen: dict = {}
+    # Background heartbeat task (created by ``start_heartbeat``).
+    _heartbeat_task = None
+
+    # Runtime-tunable copy of the cap so tests can ``monkeypatch.setattr``
+    # without reaching into ``app.constants``.
+    _MAX_CLIENTS_PER_OID = WSHUB_MAX_CLIENTS_PER_OID
 
     @classmethod
     async def connect(cls, ws: WebSocket, oid: str, *,
                       subprotocol: str | None = None):
         """Accept *ws* and register it under *oid*.
+
+        Raises :class:`WSHubFull` (without ``accept``-ing) when the OID
+        already has ``_MAX_CLIENTS_PER_OID`` subscribers. The caller is
+        expected to ``await ws.close(code=1013, reason=...)`` after
+        catching the exception.
 
         ``subprotocol`` is echoed back to the client during the
         WebSocket handshake. The Bearer-token-as-subprotocol pattern
@@ -36,14 +74,33 @@ class WSHub:
         with a protocol-mismatch error. Callers that authenticated
         via subprotocol must pass the same value here.
         """
+        existing = len(cls._connections.get(oid, ()))
+        if existing >= cls._MAX_CLIENTS_PER_OID:
+            logger.warning(
+                "Rejecting WS connect for OID=%s: %d/%d clients (cap reached)",
+                oid, existing, cls._MAX_CLIENTS_PER_OID,
+            )
+            raise WSHubFull(oid, cls._MAX_CLIENTS_PER_OID)
         if subprotocol is not None:
             await ws.accept(subprotocol=subprotocol)
         else:
             await ws.accept()
         cls._connections.setdefault(oid, set()).add(ws)
+        cls._last_seen[ws] = time.monotonic()
         logger.info(
             "WS client connected for OID=%s (total=%d)",
             oid, len(cls._connections[oid]))
+
+    @classmethod
+    def mark_active(cls, ws: WebSocket) -> None:
+        """Record that *ws* sent or received traffic just now.
+
+        Called from the endpoint on every successful ``receive_text`` so
+        the heartbeat loop can distinguish a zombie (no traffic for
+        ``WSHUB_CLIENT_TIMEOUT_SECONDS``) from an idle-but-healthy tab.
+        """
+        if ws in cls._last_seen:
+            cls._last_seen[ws] = time.monotonic()
 
     @classmethod
     def disconnect(cls, ws: WebSocket, oid: str):
@@ -52,6 +109,7 @@ class WSHub:
             conns.discard(ws)
             if not conns:
                 del cls._connections[oid]
+        cls._last_seen.pop(ws, None)
         logger.info("WS client disconnected for OID=%s", oid)
 
     # Per-socket send timeout. A slow/hung client must not stall broadcasts
@@ -149,3 +207,107 @@ class WSHub:
     def clear(cls):
         """Remove all connections (for testing)."""
         cls._connections.clear()
+        cls._last_seen.clear()
+
+    # ----- Heartbeat (opt-in via WSHUB_HEARTBEAT_INTERVAL_SECONDS > 0) ---
+
+    @classmethod
+    async def _heartbeat_tick(cls) -> None:
+        """One pass: ping every client and evict the stale ones.
+
+        Stale = no inbound traffic recorded for more than
+        ``WSHUB_CLIENT_TIMEOUT_SECONDS``. Eviction sends an explicit
+        close so the client receives a proper handshake termination
+        instead of a TCP reset; the disconnect bookkeeping then runs
+        from the endpoint's ``finally`` clause when ``receive_text``
+        raises.
+
+        Errors per-client are caught individually so one stuck socket
+        cannot wedge the whole heartbeat sweep.
+        """
+        now = time.monotonic()
+        # Snapshot to avoid mutating the registry mid-iteration.
+        targets: list[tuple[str, WebSocket]] = []
+        for oid, conns in list(cls._connections.items()):
+            for ws in list(conns):
+                targets.append((oid, ws))
+        if not targets:
+            return
+        ping_msg = '{"type":"ping"}'
+        for oid, ws in targets:
+            last_seen = cls._last_seen.get(ws, now)
+            if (now - last_seen) > WSHUB_CLIENT_TIMEOUT_SECONDS:
+                logger.info(
+                    "Evicting WS zombie for OID=%s (idle %.0fs)",
+                    oid, now - last_seen,
+                )
+                try:
+                    await ws.close(
+                        code=1011, reason="heartbeat timeout")
+                except Exception:  # nosec B110 — best-effort close
+                    pass
+                cls.disconnect(ws, oid)
+                continue
+            try:
+                await asyncio.wait_for(
+                    ws.send_text(ping_msg),
+                    timeout=cls._BROADCAST_SEND_TIMEOUT,
+                )
+            except Exception:
+                # The send raised — treat as the same evict path so we
+                # do not keep retrying a doomed socket. The client may
+                # already be gone; just log at debug.
+                logger.debug(
+                    "Heartbeat send failed for OID=%s; evicting", oid)
+                try:
+                    await ws.close(code=1011, reason="ping failed")
+                except Exception:  # nosec B110
+                    pass
+                cls.disconnect(ws, oid)
+
+    @classmethod
+    async def _heartbeat_loop(cls, interval: float) -> None:
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                await cls._heartbeat_tick()
+        except asyncio.CancelledError:
+            raise
+
+    @classmethod
+    def start_heartbeat(cls, interval: float | None = None) -> None:
+        """Schedule the heartbeat loop on the running event loop.
+
+        No-op when *interval* (or the configured default) is 0 — the
+        operator has explicitly disabled the feature, which matches the
+        out-of-the-box default. Idempotent: a second call replaces the
+        previous task.
+        """
+        effective = (
+            interval if interval is not None
+            else WSHUB_HEARTBEAT_INTERVAL_SECONDS
+        )
+        if effective <= 0:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            logger.debug("No running loop — heartbeat not started")
+            return
+        cls.stop_heartbeat()
+        cls._heartbeat_task = loop.create_task(
+            cls._heartbeat_loop(effective))
+        logger.info(
+            "WS heartbeat started (every %.1fs, timeout %.1fs)",
+            effective, WSHUB_CLIENT_TIMEOUT_SECONDS,
+        )
+
+    @classmethod
+    def stop_heartbeat(cls) -> None:
+        """Cancel the heartbeat task if one is running. Idempotent."""
+        task = cls._heartbeat_task
+        if task is None:
+            return
+        cls._heartbeat_task = None
+        if not task.done():
+            task.cancel()

--- a/app/api/ws_hub.py
+++ b/app/api/ws_hub.py
@@ -4,6 +4,8 @@ import logging
 
 from fastapi import WebSocket
 
+from app.constants import WS_BROADCAST_SEND_TIMEOUT_SECONDS
+
 logger = logging.getLogger(__name__)
 
 
@@ -54,7 +56,8 @@ class WSHub:
 
     # Per-socket send timeout. A slow/hung client must not stall broadcasts
     # to the rest of the subscribers (nor the main state-update path).
-    _BROADCAST_SEND_TIMEOUT = 2.0
+    # Configure via ``WS_BROADCAST_SEND_TIMEOUT_SECONDS``.
+    _BROADCAST_SEND_TIMEOUT = WS_BROADCAST_SEND_TIMEOUT_SECONDS
 
     @classmethod
     async def _broadcast_text(cls, oid: str, message: str):

--- a/app/api/ws_hub.py
+++ b/app/api/ws_hub.py
@@ -234,17 +234,31 @@ class WSHub:
 
     @classmethod
     async def _heartbeat_tick(cls) -> None:
-        """One pass: ping every client and evict the stale ones.
+        """One pass: ping every healthy client and evict the stale ones.
 
         Stale = no inbound traffic recorded for more than
         ``WSHUB_CLIENT_TIMEOUT_SECONDS``. Eviction sends an explicit
         close so the client receives a proper handshake termination
         instead of a TCP reset; the disconnect bookkeeping then runs
-        from the endpoint's ``finally`` clause when ``receive_text``
-        raises.
+        either inline here or from the endpoint's ``finally`` clause
+        when ``receive_text`` raises.
 
-        Errors per-client are caught individually so one stuck socket
-        cannot wedge the whole heartbeat sweep.
+        Phases:
+
+        1. Snapshot ``_connections`` and classify each client into
+           "zombie" or "healthy" using a single ``time.monotonic()``
+           reading.
+        2. Run zombie ``close`` calls and healthy ``send_text(ping)``
+           calls concurrently via ``asyncio.gather`` so a 200-client
+           OID does not turn into 200 × ``BROADCAST_SEND_TIMEOUT`` of
+           wall time. Each task is wrapped in
+           ``return_exceptions=True`` so one stuck socket cannot wedge
+           the rest of the sweep — and the per-task timeout still
+           fires per-socket via ``asyncio.wait_for``.
+        3. Apply the bookkeeping (``disconnect`` for zombies and for
+           healthy sockets that failed the ping send) after the
+           gather, so the registry is mutated under predictable
+           conditions rather than mid-iteration.
         """
         now = time.monotonic()
         # Snapshot to avoid mutating the registry mid-iteration.
@@ -254,37 +268,67 @@ class WSHub:
                 targets.append((oid, ws))
         if not targets:
             return
-        ping_msg = '{"type":"ping"}'
+
+        zombies: list[tuple[str, WebSocket]] = []
+        healthy: list[tuple[str, WebSocket]] = []
         for oid, ws in targets:
             last_seen = cls._last_seen.get(ws, now)
             if (now - last_seen) > WSHUB_CLIENT_TIMEOUT_SECONDS:
-                logger.info(
-                    "Evicting WS zombie for OID=%s (idle %.0fs)",
-                    oid, now - last_seen,
-                )
-                try:
-                    await ws.close(
-                        code=1011, reason="heartbeat timeout")
-                except Exception:  # nosec B110 — best-effort close
-                    pass
-                cls.disconnect(ws, oid)
-                continue
+                zombies.append((oid, ws))
+            else:
+                healthy.append((oid, ws))
+
+        ping_msg = '{"type":"ping"}'
+
+        async def _close_zombie(oid: str, ws: WebSocket) -> None:
+            logger.info(
+                "Evicting WS zombie for OID=%s (idle %.0fs)",
+                oid, now - cls._last_seen.get(ws, now),
+            )
+            try:
+                await ws.close(code=1011, reason="heartbeat timeout")
+            except Exception:  # nosec B110 — best-effort close
+                pass
+
+        async def _ping_healthy(_oid: str, ws: WebSocket) -> bool:
+            """Return True iff the ping was delivered cleanly."""
             try:
                 await asyncio.wait_for(
                     ws.send_text(ping_msg),
                     timeout=cls._BROADCAST_SEND_TIMEOUT,
                 )
             except Exception:
-                # The send raised — treat as the same evict path so we
-                # do not keep retrying a doomed socket. The client may
-                # already be gone; just log at debug.
-                logger.debug(
-                    "Heartbeat send failed for OID=%s; evicting", oid)
-                try:
-                    await ws.close(code=1011, reason="ping failed")
-                except Exception:  # nosec B110
-                    pass
-                cls.disconnect(ws, oid)
+                return False
+            return True
+
+        # Fan out: zombie closes and healthy pings run concurrently.
+        # Capturing ``return_exceptions`` defends against an awaitable
+        # that raises despite the inner try/except (e.g. a future
+        # cancelled out from under us during shutdown).
+        zombie_coros = [_close_zombie(oid, ws) for oid, ws in zombies]
+        healthy_coros = [_ping_healthy(oid, ws) for oid, ws in healthy]
+        if zombie_coros:
+            await asyncio.gather(*zombie_coros, return_exceptions=True)
+        ping_results: list = []
+        if healthy_coros:
+            ping_results = await asyncio.gather(
+                *healthy_coros, return_exceptions=True,
+            )
+
+        # Apply bookkeeping: every zombie disconnects, every healthy
+        # client that failed the ping is also evicted.
+        for oid, ws in zombies:
+            cls.disconnect(ws, oid)
+        for (oid, ws), ok in zip(healthy, ping_results, strict=False):
+            if ok is True:
+                continue
+            logger.debug(
+                "Heartbeat send failed for OID=%s; evicting", oid)
+            try:
+                await ws.close(code=1011, reason="ping failed")
+            except Exception:  # nosec B110
+                pass
+            cls.disconnect(ws, oid)
 
     @classmethod
     async def _heartbeat_loop(cls, interval: float) -> None:

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -28,7 +28,9 @@ from app.api import api_router
 from app.api.middleware.auth_rate_limit import AuthRateLimitMiddleware
 from app.api.middleware.errors import ExceptionLoggingMiddleware
 from app.api.middleware.logging import RequestContextMiddleware
+from app.api.middleware.metrics import MetricsMiddleware
 from app.api.middleware.security_headers import SecurityHeadersMiddleware
+from app.api.routes.metrics import router as metrics_router
 from app.app_config import get_app_title
 from app.authentication import PasswordAuthenticator
 from app.match_report import match_report_router
@@ -467,7 +469,13 @@ def create_app() -> FastAPI:
     #           GZip           (compresses after headers are decided)
     #             RequestContext (populates contextvars for logging)
     #               ExceptionLogging (innermost — sees raw handler exceptions)
+    application.include_router(metrics_router)
     application.add_middleware(ExceptionLoggingMiddleware)
+    # Metrics observes every HTTP request — keep it inside ExceptionLogging
+    # (so handler exceptions still surface as 500 + log) but outside
+    # RequestContext so the latency reflects the full handler cost
+    # including contextvar setup.
+    application.add_middleware(MetricsMiddleware)
     application.add_middleware(RequestContextMiddleware)
     application.add_middleware(GZipMiddleware, minimum_size=1024)
     application.add_middleware(SecurityHeadersMiddleware)

--- a/app/constants.py
+++ b/app/constants.py
@@ -36,6 +36,24 @@ def _env_int(key: str, default: int) -> int:
     return value if value > 0 else default
 
 
+def _env_float_nonneg(key: str, default: float) -> float:
+    """Like :func:`_env_float` but accepts 0 as a valid disable signal.
+
+    Used by knobs where ``0`` has a meaningful "off" interpretation
+    (heartbeat interval, optional rate-limit window) — the strict
+    ``> 0`` filter on :func:`_env_float` would otherwise silently
+    upgrade ``KEY=0`` to the default and confuse the operator.
+    """
+    raw = os.environ.get(key)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value >= 0 else default
+
+
 # Idle game sessions are evicted after this many seconds. Override with
 # the ``SESSION_TTL_SECONDS`` env var.
 SESSION_TTL_SECONDS = _env_int("SESSION_TTL_SECONDS", 24 * 60 * 60)
@@ -55,6 +73,29 @@ WS_BROADCAST_SEND_TIMEOUT_SECONDS = _env_float(
 # letting ``read_all`` / ``read_page`` walk the rotated set transparently.
 AUDIT_LOG_MAX_BYTES = _env_int("AUDIT_LOG_MAX_BYTES", 5 * 1024 * 1024)
 AUDIT_LOG_MAX_FILES = _env_int("AUDIT_LOG_MAX_FILES", 5)
+
+# Maximum number of concurrent WebSocket subscribers per OID. Once an
+# OID hits this cap, ``WSHub.connect`` rejects further upgrades with a
+# 1013 ("Try Again Later") close so a runaway tab loop or scripted
+# attacker cannot exhaust file descriptors on the box. Override with
+# ``WSHUB_MAX_CLIENTS_PER_OID``.
+WSHUB_MAX_CLIENTS_PER_OID = _env_int("WSHUB_MAX_CLIENTS_PER_OID", 200)
+
+# Server-side WebSocket heartbeat. ``WSHUB_HEARTBEAT_INTERVAL_SECONDS``
+# defaults to 0 (disabled) because the existing browser client does not
+# yet respond to application-level pings — enabling without first
+# updating the frontend would churn live tabs every
+# ``WSHUB_CLIENT_TIMEOUT_SECONDS``. Operators that have a heartbeat-
+# aware client (e.g. a custom OBS bridge) can opt in by setting
+# ``WSHUB_HEARTBEAT_INTERVAL_SECONDS=30`` and tuning the timeout.
+# Constraint: ``CLIENT_TIMEOUT > 2 * INTERVAL`` so a single dropped
+# pong does not churn the connection (mirrors the WSControlClient rule).
+WSHUB_HEARTBEAT_INTERVAL_SECONDS = _env_float_nonneg(
+    "WSHUB_HEARTBEAT_INTERVAL_SECONDS", 0.0,
+)
+WSHUB_CLIENT_TIMEOUT_SECONDS = _env_float(
+    "WSHUB_CLIENT_TIMEOUT_SECONDS", 60.0,
+)
 
 # ``WSControlClient`` reconnect/heartbeat tuning. ``WS_ZOMBIE_DEADLINE``
 # must stay > 2 * ``WS_HEARTBEAT_INTERVAL`` so a single dropped pong

--- a/app/constants.py
+++ b/app/constants.py
@@ -97,6 +97,18 @@ WSHUB_CLIENT_TIMEOUT_SECONDS = _env_float(
     "WSHUB_CLIENT_TIMEOUT_SECONDS", 60.0,
 )
 
+# Outbound webhook retry policy. Exponential backoff between attempts:
+# ``RETRY_BASE * 2**attempt`` capped at ``RETRY_MAX``. Only 5xx
+# responses and ``requests.RequestException`` (timeouts, connect
+# errors) trigger a retry — 4xx is treated as a permanent client
+# rejection and goes straight to the dead-letter (well, it does not:
+# 4xx is logged and dropped, see ``app/api/webhooks.py``).
+# ``RETRY_ATTEMPTS`` counts retries *after* the first attempt, so
+# the default of 3 means up to 4 total POSTs per delivery.
+WEBHOOK_RETRY_ATTEMPTS = _env_int("WEBHOOK_RETRY_ATTEMPTS", 3)
+WEBHOOK_RETRY_BASE_SECONDS = _env_float("WEBHOOK_RETRY_BASE_SECONDS", 1.0)
+WEBHOOK_RETRY_MAX_SECONDS = _env_float("WEBHOOK_RETRY_MAX_SECONDS", 8.0)
+
 # ``WSControlClient`` reconnect/heartbeat tuning. ``WS_ZOMBIE_DEADLINE``
 # must stay > 2 * ``WS_HEARTBEAT_INTERVAL`` so a single dropped pong
 # does not churn the connection.

--- a/app/constants.py
+++ b/app/constants.py
@@ -109,6 +109,15 @@ WEBHOOK_RETRY_ATTEMPTS = _env_int("WEBHOOK_RETRY_ATTEMPTS", 3)
 WEBHOOK_RETRY_BASE_SECONDS = _env_float("WEBHOOK_RETRY_BASE_SECONDS", 1.0)
 WEBHOOK_RETRY_MAX_SECONDS = _env_float("WEBHOOK_RETRY_MAX_SECONDS", 8.0)
 
+# Hard cap on the dead-letter file. ``append`` evicts the oldest
+# records once the file would exceed this many entries, so a
+# misbehaving target / runaway producer cannot grow ``data/
+# webhooks_dead_letter.jsonl`` without bound between operator
+# replays. Override with ``WEBHOOK_DEAD_LETTER_MAX_RECORDS``.
+WEBHOOK_DEAD_LETTER_MAX_RECORDS = _env_int(
+    "WEBHOOK_DEAD_LETTER_MAX_RECORDS", 1000,
+)
+
 # ``WSControlClient`` reconnect/heartbeat tuning. ``WS_ZOMBIE_DEADLINE``
 # must stay > 2 * ``WS_HEARTBEAT_INTERVAL`` so a single dropped pong
 # does not churn the connection.

--- a/app/constants.py
+++ b/app/constants.py
@@ -1,3 +1,6 @@
+import os
+
+
 class Constants:
     """
     Centralized location for hardcoded strings, configuration constants, and URLs.
@@ -9,3 +12,49 @@ class Constants:
 
     # Base URL for the overlays.uno API
     API_BASE_URL = 'https://app.overlays.uno/apiv2/controlapps'
+
+
+def _env_float(key: str, default: float) -> float:
+    raw = os.environ.get(key)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _env_int(key: str, default: int) -> int:
+    raw = os.environ.get(key)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+# Idle game sessions are evicted after this many seconds. Override with
+# the ``SESSION_TTL_SECONDS`` env var.
+SESSION_TTL_SECONDS = _env_int("SESSION_TTL_SECONDS", 24 * 60 * 60)
+
+# Per-socket WebSocket broadcast timeout used by ``WSHub``. A slow
+# subscriber must not stall delivery to the rest. Override with
+# ``WS_BROADCAST_SEND_TIMEOUT_SECONDS``.
+WS_BROADCAST_SEND_TIMEOUT_SECONDS = _env_float(
+    "WS_BROADCAST_SEND_TIMEOUT_SECONDS", 2.0,
+)
+
+# ``WSControlClient`` reconnect/heartbeat tuning. ``WS_ZOMBIE_DEADLINE``
+# must stay > 2 * ``WS_HEARTBEAT_INTERVAL`` so a single dropped pong
+# does not churn the connection.
+WS_RECONNECT_BASE_SECONDS = _env_float("WS_RECONNECT_BASE_SECONDS", 1.0)
+WS_RECONNECT_MAX_SECONDS = _env_float("WS_RECONNECT_MAX_SECONDS", 30.0)
+WS_HEARTBEAT_INTERVAL_SECONDS = _env_float(
+    "WS_HEARTBEAT_INTERVAL_SECONDS", 25.0,
+)
+WS_ZOMBIE_DEADLINE_SECONDS = _env_float(
+    "WS_ZOMBIE_DEADLINE_SECONDS", 55.0,
+)

--- a/app/constants.py
+++ b/app/constants.py
@@ -47,6 +47,15 @@ WS_BROADCAST_SEND_TIMEOUT_SECONDS = _env_float(
     "WS_BROADCAST_SEND_TIMEOUT_SECONDS", 2.0,
 )
 
+# Per-OID audit log file rotation. The active log rotates to
+# ``audit_<hash>.jsonl.1`` once it exceeds ``AUDIT_LOG_MAX_BYTES``,
+# bumping older rotations down by one suffix; anything above
+# ``AUDIT_LOG_MAX_FILES`` (counting the active file) is dropped.
+# Keeps long-running per-OID logs from growing unbounded while still
+# letting ``read_all`` / ``read_page`` walk the rotated set transparently.
+AUDIT_LOG_MAX_BYTES = _env_int("AUDIT_LOG_MAX_BYTES", 5 * 1024 * 1024)
+AUDIT_LOG_MAX_FILES = _env_int("AUDIT_LOG_MAX_FILES", 5)
+
 # ``WSControlClient`` reconnect/heartbeat tuning. ``WS_ZOMBIE_DEADLINE``
 # must stay > 2 * ``WS_HEARTBEAT_INTERVAL`` so a single dropped pong
 # does not churn the connection.

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -127,6 +127,11 @@ active_sessions = Gauge(
     "Number of live GameSession instances tracked by SessionManager.",
 )
 
+webhook_dead_letter_size = Gauge(
+    "voc_webhook_dead_letter_size",
+    "Records currently parked in data/webhooks_dead_letter.jsonl.",
+)
+
 
 # ---------------------------------------------------------------------------
 # Helpers used from hot paths (kept tiny so the bookkeeping cost stays
@@ -154,3 +159,8 @@ def set_ws_gauges(total_clients: int, oid_count: int) -> None:
 
 def set_active_sessions(count: int) -> None:
     active_sessions.set(count)
+
+
+def set_dead_letter_size(count: int) -> None:
+    """Refresh the webhook dead-letter gauge after a write/clear."""
+    webhook_dead_letter_size.set(count)

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,0 +1,156 @@
+"""Prometheus metrics surface.
+
+Exposes a single ``/metrics`` HTTP endpoint plus a small handful of
+counters and gauges that the rest of the codebase bumps from its hot
+paths. Designed to degrade gracefully:
+
+* If ``prometheus_client`` is missing (``pip install -r requirements.txt``
+  is the canonical fix), ``PROMETHEUS_AVAILABLE`` flips to False and
+  every helper becomes a no-op so the operator can still boot the app.
+* The ``/metrics`` endpoint stays mounted in either case — when the
+  library is missing it returns a 503 with a clear "install
+  prometheus-client" message rather than a confusing 404.
+
+Cardinality budget:
+
+* ``http_request_duration_seconds`` — labels ``route``, ``method``,
+  ``status``. ``route`` is the FastAPI route template
+  (``/api/v1/admin/custom-overlays/{name}``) rather than the raw path,
+  so the label set stays bounded by the OpenAPI surface.
+* ``webhook_delivery_total`` — labels ``event`` (4 known values)
+  and ``status`` (``success`` / ``client_error`` / ``server_error`` /
+  ``exception`` / ``dead_letter`` / ``ssrf_blocked``).
+* ``ws_clients_total`` and ``ws_oids_active`` — unlabelled gauges so
+  a tournament with thousands of OIDs cannot blow up the metric set.
+* ``active_sessions`` — unlabelled gauge.
+
+The plan called for ``ws_clients_per_oid``; that label would be
+unbounded in OID space and is the textbook anti-pattern. Two
+unlabelled gauges (``ws_clients_total`` plus ``ws_oids_active``) give
+the operator the same dashboard story (total fan-out + breadth)
+without the cardinality risk.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    from prometheus_client import (
+        CONTENT_TYPE_LATEST,
+        REGISTRY,
+        Counter,
+        Gauge,
+        Histogram,
+        generate_latest,
+    )
+    PROMETHEUS_AVAILABLE = True
+except ImportError:  # pragma: no cover — handled at runtime
+    logger.warning(
+        "prometheus_client not installed; /metrics will return 503. "
+        "Run 'pip install -r requirements.txt' to enable.",
+    )
+    PROMETHEUS_AVAILABLE = False
+    CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
+    REGISTRY = None  # type: ignore[assignment]
+
+    class _NoOp:
+        """Stand-in for missing Counter/Gauge/Histogram/etc.
+
+        Mimics the chainable ``labels(...)`` API so call sites can
+        unconditionally do ``METRIC.labels(foo='bar').inc()`` regardless
+        of whether the library is present.
+        """
+
+        def labels(self, **_kwargs):
+            return self
+
+        def inc(self, *_a, **_kw):
+            return None
+
+        def dec(self, *_a, **_kw):
+            return None
+
+        def set(self, *_a, **_kw):
+            return None
+
+        def observe(self, *_a, **_kw):
+            return None
+
+        def time(self):  # context manager fallback
+            return _NoOpTimer()
+
+    class _NoOpTimer:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    Counter = Gauge = Histogram = _NoOp  # type: ignore[assignment]
+
+    def generate_latest(*_a, **_kw):  # type: ignore[misc]
+        return b""
+
+
+# ---------------------------------------------------------------------------
+# Metric definitions
+# ---------------------------------------------------------------------------
+
+
+http_request_duration_seconds = Histogram(
+    "voc_http_request_duration_seconds",
+    "End-to-end HTTP request latency in seconds.",
+    labelnames=("route", "method", "status"),
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+)
+
+webhook_delivery_total = Counter(
+    "voc_webhook_delivery_total",
+    "Webhook delivery outcomes per event and status bucket.",
+    labelnames=("event", "status"),
+)
+
+ws_clients_total = Gauge(
+    "voc_ws_clients_total",
+    "Total open frontend WebSocket connections across all OIDs.",
+)
+
+ws_oids_active = Gauge(
+    "voc_ws_oids_active",
+    "Number of distinct OIDs with at least one open WebSocket subscriber.",
+)
+
+active_sessions = Gauge(
+    "voc_active_sessions",
+    "Number of live GameSession instances tracked by SessionManager.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers used from hot paths (kept tiny so the bookkeeping cost stays
+# under a microsecond when prometheus_client is present and exactly
+# zero when it is not).
+# ---------------------------------------------------------------------------
+
+
+def record_webhook_outcome(event: str, status: str) -> None:
+    """Increment ``webhook_delivery_total{event, status}`` by 1.
+
+    *status* is one of: ``success``, ``client_error``, ``server_error``,
+    ``exception``, ``dead_letter``, ``ssrf_blocked``. Unknown values
+    flow through unchanged so a future refinement does not need a
+    coordinated metrics change.
+    """
+    webhook_delivery_total.labels(event=event or "unknown", status=status).inc()
+
+
+def set_ws_gauges(total_clients: int, oid_count: int) -> None:
+    """Refresh the two WebSocket gauges from a single observation."""
+    ws_clients_total.set(total_clients)
+    ws_oids_active.set(oid_count)
+
+
+def set_active_sessions(count: int) -> None:
+    active_sessions.set(count)

--- a/app/overlay/routes.py
+++ b/app/overlay/routes.py
@@ -22,6 +22,7 @@ from starlette.concurrency import run_in_threadpool
 from app.admin.routes import require_admin
 from app.env_vars_manager import EnvVarsManager
 from app.overlay.state_store import OverlayStateStore
+from app.overlay.themes import PRESET_THEMES, get_theme_names
 from app.password_hash import verify_password
 
 logger = logging.getLogger(__name__)
@@ -138,54 +139,6 @@ class RawConfigPayload(BaseModel):
     model_config = ConfigDict(extra="allow")
     model: Any | None = None
     customization: Any | None = None
-
-
-# ---------------------------------------------------------------------------
-# Preset themes
-# ---------------------------------------------------------------------------
-
-PRESET_THEMES: dict[str, dict] = {
-    "dark": {
-        "overlay_control": {
-            "colors": {
-                "set_bg": "#222222", "set_text": "#FFFFFF",
-                "game_bg": "#111111", "game_text": "#FFFFFF",
-            }
-        }
-    },
-    "light": {
-        "overlay_control": {
-            "colors": {
-                "set_bg": "#EEEEEE", "set_text": "#222222",
-                "game_bg": "#F5F5F5", "game_text": "#111111",
-            }
-        }
-    },
-    "esports": {
-        "overlay_control": {
-            "preferredStyle": "esports",
-            "colors": {
-                "set_bg": "#0d0d1a", "set_text": "#00FFFF",
-                "game_bg": "#0a0a0f", "game_text": "#00FFFF",
-            },
-        }
-    },
-    "neo_jersey": {
-        "overlay_control": {
-            "preferredStyle": "neo_jersey",
-        }
-    },
-    "split_jersey": {
-        "overlay_control": {
-            "preferredStyle": "split_jersey",
-        }
-    },
-    "clear_jersey": {
-        "overlay_control": {
-            "preferredStyle": "clear_jersey",
-        }
-    },
-}
 
 
 # ---------------------------------------------------------------------------
@@ -397,7 +350,7 @@ def create_overlay_router(
 
     @router.get("/api/themes")
     async def list_themes():
-        return {"themes": list(PRESET_THEMES.keys())}
+        return {"themes": get_theme_names()}
 
     @router.post(
         "/api/theme/{overlay_id}/{theme_name}",
@@ -409,7 +362,7 @@ def create_overlay_router(
                 status_code=404,
                 detail=(
                     f"Theme '{theme_name}' not found. "
-                    f"Available: {list(PRESET_THEMES.keys())}"
+                    f"Available: {get_theme_names()}"
                 ),
             )
         if not store.overlay_exists(overlay_id):

--- a/app/overlay/themes.py
+++ b/app/overlay/themes.py
@@ -1,0 +1,64 @@
+"""Catalogue of preset overlay themes.
+
+A theme is a partial state payload — a dict that ``OverlayStateStore.update_state``
+deep-merges into ``data/overlay_state_<hash>.json``. Every theme either flips
+``overlay_control.preferredStyle`` (which switches the Jinja template served at
+``/overlay/{output_key}``), tweaks ``overlay_control.colors`` (consumed by the
+``original``, ``compact``, ``glass``… templates) or both.
+
+Lives in its own module so both the public overlay router (``apply_theme``)
+and the admin router (``PATCH /api/v1/admin/custom-overlays/{name}``) can
+import it without creating a circular dependency between
+``app.overlay.routes`` and ``app.admin.routes``. Fase 2 / M8 will replace
+this static dict with a directory-backed catalogue under ``data/themes/``;
+keeping the import surface stable now means M8 only has to swap the
+implementation.
+"""
+
+PRESET_THEMES: dict[str, dict] = {
+    "dark": {
+        "overlay_control": {
+            "colors": {
+                "set_bg": "#222222", "set_text": "#FFFFFF",
+                "game_bg": "#111111", "game_text": "#FFFFFF",
+            }
+        }
+    },
+    "light": {
+        "overlay_control": {
+            "colors": {
+                "set_bg": "#EEEEEE", "set_text": "#222222",
+                "game_bg": "#F5F5F5", "game_text": "#111111",
+            }
+        }
+    },
+    "esports": {
+        "overlay_control": {
+            "preferredStyle": "esports",
+            "colors": {
+                "set_bg": "#0d0d1a", "set_text": "#00FFFF",
+                "game_bg": "#0a0a0f", "game_text": "#00FFFF",
+            },
+        }
+    },
+    "neo_jersey": {
+        "overlay_control": {
+            "preferredStyle": "neo_jersey",
+        }
+    },
+    "split_jersey": {
+        "overlay_control": {
+            "preferredStyle": "split_jersey",
+        }
+    },
+    "clear_jersey": {
+        "overlay_control": {
+            "preferredStyle": "clear_jersey",
+        }
+    },
+}
+
+
+def get_theme_names() -> list[str]:
+    """Return the list of available theme names in catalogue order."""
+    return list(PRESET_THEMES.keys())

--- a/app/ws_client.py
+++ b/app/ws_client.py
@@ -10,19 +10,26 @@ import threading
 import time
 from collections.abc import Callable
 
+from app.constants import (
+    WS_HEARTBEAT_INTERVAL_SECONDS,
+    WS_RECONNECT_BASE_SECONDS,
+    WS_RECONNECT_MAX_SECONDS,
+    WS_ZOMBIE_DEADLINE_SECONDS,
+)
+
 logger = logging.getLogger(__name__)
 
 # Protocol version this client supports
 WS_CONTROL_PROTOCOL_VERSION = 1
 
-# Reconnection parameters
-_RECONNECT_BASE = 1.0      # seconds
-_RECONNECT_MAX = 30.0       # seconds
-_HEARTBEAT_INTERVAL = 25.0  # seconds (inside the server's 30s timeout)
-# If no inbound traffic (pong or otherwise) lands within this many seconds,
-# assume the socket is a zombie and force a reconnect. Must be > 2 *
-# _HEARTBEAT_INTERVAL so a single dropped pong does not churn the connection.
-_ZOMBIE_DEADLINE = 55.0
+# Reconnection / heartbeat parameters. Defaults can be overridden via the
+# matching ``WS_*_SECONDS`` env vars (see ``app.constants``).
+_RECONNECT_BASE = WS_RECONNECT_BASE_SECONDS
+_RECONNECT_MAX = WS_RECONNECT_MAX_SECONDS
+_HEARTBEAT_INTERVAL = WS_HEARTBEAT_INTERVAL_SECONDS
+# Zombie deadline must stay > 2 * _HEARTBEAT_INTERVAL so a single dropped
+# pong does not churn the connection.
+_ZOMBIE_DEADLINE = WS_ZOMBIE_DEADLINE_SECONDS
 
 
 class WSControlClient:

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -181,6 +181,91 @@
         "title": "CustomOverlayCreate",
         "type": "object"
       },
+      "CustomOverlayPatch": {
+        "description": "Partial update for a custom overlay's appearance.\n\nEvery field is optional \u2014 the patch is a thin admin-side wrapper around\n``OverlayStateStore.update_state``. When ``theme`` is set, the matching\npreset from ``app.overlay.themes`` is applied first; ``colors`` and\n``preferred_style`` are then merged on top so explicit overrides win\nover the theme defaults.",
+        "properties": {
+          "colors": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Color overrides merged into overlay_control.colors. Common keys: set_bg, set_text, game_bg, game_text.",
+            "title": "Colors"
+          },
+          "preferred_style": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Switch the Jinja template served at /overlay/{output_key}. Must match an entry in GET /api/config/{id}.availableStyles.",
+            "title": "Preferred Style"
+          },
+          "theme": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Apply a preset theme (e.g. 'dark', 'esports'). Available themes are listed by GET /api/themes.",
+            "title": "Theme"
+          }
+        },
+        "title": "CustomOverlayPatch",
+        "type": "object"
+      },
+      "CustomOverlayUsage": {
+        "description": "Snapshot of how many live consumers a custom overlay has.",
+        "properties": {
+          "frontend_ws_clients": {
+            "description": "Connected scoreboard control tabs (frontend WebSocket subscribers).",
+            "title": "Frontend Ws Clients",
+            "type": "integer"
+          },
+          "has_active_session": {
+            "description": "True when SessionManager has a live GameSession.",
+            "title": "Has Active Session",
+            "type": "boolean"
+          },
+          "obs_clients": {
+            "description": "Connected OBS / browser-source viewers.",
+            "title": "Obs Clients",
+            "type": "integer"
+          },
+          "seconds_since_last_activity": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Seconds elapsed since the session was last touched; null when no session is active.",
+            "title": "Seconds Since Last Activity"
+          }
+        },
+        "required": [
+          "obs_clients",
+          "frontend_ws_clients",
+          "has_active_session"
+        ],
+        "title": "CustomOverlayUsage",
+        "type": "object"
+      },
       "GameStateResponse": {
         "properties": {
           "beach_side_switch": {
@@ -1527,6 +1612,116 @@
         "tags": [
           "Admin"
         ]
+      },
+      "patch": {
+        "description": "Apply a preset theme and/or merge colors / preferredStyle.\n\nLayering order matches the operator's mental model: the theme acts\nas a baseline, then explicit ``colors`` and ``preferred_style`` are\nmerged on top. Empty patches are rejected with 400 so the operator\nsees a clear error rather than a silent no-op (which would mask\naccidental empty form submissions from the manager UI).",
+        "operationId": "patch_custom_overlay_api_v1_admin_custom_overlays__name__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomOverlayPatch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Edit a custom overlay's theme / colors / preferred style",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/v1/admin/custom-overlays/{name}/usage": {
+      "get": {
+        "description": "Report live OBS / scoreboard / session counts for *name*.\n\nThe response gives the operator enough information to decide whether\ndeleting (or re-theming) the overlay will disrupt an in-progress\nbroadcast \u2014 currently surfaced in the ``/manage`` UI as a dot next to\neach row.",
+        "operationId": "get_custom_overlay_usage_api_v1_admin_custom_overlays__name__usage_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomOverlayUsage"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Inspect how many live consumers a custom overlay has",
+        "tags": [
+          "Admin"
+        ]
       }
     },
     "/api/v1/admin/login": {
@@ -1652,6 +1847,79 @@
         ]
       }
     },
+    "/api/v1/admin/webhooks/replay": {
+      "post": {
+        "description": "Replay (a slice of) the webhook dead-letter file.\n\nEach record is matched to a configured ``WebhookTarget`` by URL,\nre-signed with the *current* HMAC secret (so rotating\n``WEBHOOKS_SECRET`` doesn't strand legacy records with stale\nsignatures), and re-attempted with the standard retry policy.\n\n* Successful redeliveries are removed from the file.\n* Records whose URL no longer matches any configured target are\n  kept on disk so the operator can fix the config and retry.\n* Records that fail again are kept with their ``attempts``\n  counter bumped and the latest ``last_error`` recorded.\n\nSelection order: oldest records (lowest ``ts``) within the\neligible window go first, so iterative calls drain the file\nfront-to-back. The blocking work runs on the FastAPI threadpool\nvia ``run_in_threadpool`` so the event loop stays free for other\nhandlers while a long replay is in flight.\n\nReturns counts only \u2014 the bodies are never echoed back so the\nadmin surface cannot leak match payloads. ``remaining_in_dl``\nis the count of records still on disk after the call (ones held\nback by ``since`` / ``max_records`` plus the ``still_failing``\nbucket that just got re-written) so the operator knows whether\nto call again.",
+        "operationId": "replay_dead_letter_webhooks_api_v1_admin_webhooks_replay_post",
+        "parameters": [
+          {
+            "description": "Only replay records whose ``ts`` is >= this Unix-seconds value. Useful for restricting replay to entries that landed after the receiving service came back online.",
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only replay records whose ``ts`` is >= this Unix-seconds value. Useful for restricting replay to entries that landed after the receiving service came back online.",
+              "title": "Since"
+            }
+          },
+          {
+            "description": "Cap the number of records redelivered in this call. ``replay_records`` blocks on per-record retries with exponential backoff (~25 s worst case per record), so a fully-loaded dead-letter would otherwise pin the handler for tens of minutes. Use the ``remaining_in_dl`` field in the response to decide whether to call again.",
+            "in": "query",
+            "name": "max_records",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Cap the number of records redelivered in this call. ``replay_records`` blocks on per-record retries with exponential backoff (~25 s worst case per record), so a fully-loaded dead-letter would otherwise pin the handler for tens of minutes. Use the ``remaining_in_dl`` field in the response to decide whether to call again.",
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Max Records",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Re-deliver dead-lettered webhook records",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
     "/api/v1/app-config": {
       "get": {
         "description": "Return runtime app configuration consumed by the SPA on boot.",
@@ -1676,7 +1944,7 @@
     },
     "/api/v1/audit": {
       "get": {
-        "description": "Return up to *limit* most-recent records from the action log.\n\nRecords are ordered chronologically (oldest first within the\nreturned window). Each entry has the shape::\n\n    {\"ts\": 1714508400.123,\n     \"action\": \"add_point\",\n     \"params\": {\"team\": 1, \"undo\": false},\n     \"result\": {\"current_set\": 2, \"team_1\": {...}, ...}}",
+        "description": "Return one page of audit records, newest page first.\n\nFirst call (``before_ts`` omitted) returns the most recent\n``limit`` records. Subsequent calls pass the previous response's\n``next_cursor`` to walk back through history one window at a time.\n\nRecords are ordered chronologically (oldest first **within** the\nreturned window \u2014 same convention as ``read_recent``). Each entry\nhas the shape::\n\n    {\"ts\": 1714508400.123,\n     \"action\": \"add_point\",\n     \"params\": {\"team\": 1, \"undo\": false},\n     \"result\": {\"current_set\": 2, \"team_1\": {...}, ...}}\n\nThe response carries:\n\n* ``records`` \u2014 the page itself.\n* ``count`` \u2014 ``len(records)``.\n* ``next_cursor`` \u2014 the ``ts`` to pass as ``before_ts`` for the\n  next page, or ``null`` when this is the last page.",
         "operationId": "get_audit_log_api_v1_audit_get",
         "parameters": [
           {
@@ -1689,6 +1957,24 @@
               "minimum": 1,
               "title": "Limit",
               "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination cursor: only return records strictly older than this timestamp. Use the ``next_cursor`` value from the previous response. Omit for the first page.",
+            "in": "query",
+            "name": "before_ts",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Pagination cursor: only return records strictly older than this timestamp. Use the ``next_cursor`` value from the previous response. Omit for the first page.",
+              "title": "Before Ts"
             }
           },
           {
@@ -1757,7 +2043,7 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Recent action audit log",
+        "summary": "Recent action audit log (cursor-paginated)",
         "tags": [
           "Scoreboard API v1"
         ]
@@ -4164,6 +4450,39 @@
           }
         },
         "summary": "Delete an archived match snapshot"
+      }
+    },
+    "/metrics": {
+      "get": {
+        "description": "Return the registry's current exposition in Prometheus text format.\n\n``METRICS_REQUIRE_ADMIN=true`` opts into Bearer auth at the same\nladder as ``/api/v1/admin/*``. The check fires *before* the\nlibrary-availability check so an unauthenticated probe cannot use\nthe 503-vs-200 difference to fingerprint whether the metrics\nbackend is loaded.",
+        "operationId": "metrics_endpoint_metrics_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Prometheus exposition"
       }
     },
     "/overlay/{overlay_id}": {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -156,6 +156,41 @@ export interface paths {
         delete: operations["delete_custom_overlay_api_v1_admin_custom_overlays__name__delete"];
         options?: never;
         head?: never;
+        /**
+         * Edit a custom overlay's theme / colors / preferred style
+         * @description Apply a preset theme and/or merge colors / preferredStyle.
+         *
+         *     Layering order matches the operator's mental model: the theme acts
+         *     as a baseline, then explicit ``colors`` and ``preferred_style`` are
+         *     merged on top. Empty patches are rejected with 400 so the operator
+         *     sees a clear error rather than a silent no-op (which would mask
+         *     accidental empty form submissions from the manager UI).
+         */
+        patch: operations["patch_custom_overlay_api_v1_admin_custom_overlays__name__patch"];
+        trace?: never;
+    };
+    "/api/v1/admin/custom-overlays/{name}/usage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Inspect how many live consumers a custom overlay has
+         * @description Report live OBS / scoreboard / session counts for *name*.
+         *
+         *     The response gives the operator enough information to decide whether
+         *     deleting (or re-theming) the overlay will disrupt an in-progress
+         *     broadcast — currently surfaced in the ``/manage`` UI as a dot next to
+         *     each row.
+         */
+        get: operations["get_custom_overlay_usage_api_v1_admin_custom_overlays__name__usage_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
         patch?: never;
         trace?: never;
     };
@@ -237,6 +272,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/webhooks/replay": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Re-deliver dead-lettered webhook records
+         * @description Replay (a slice of) the webhook dead-letter file.
+         *
+         *     Each record is matched to a configured ``WebhookTarget`` by URL,
+         *     re-signed with the *current* HMAC secret (so rotating
+         *     ``WEBHOOKS_SECRET`` doesn't strand legacy records with stale
+         *     signatures), and re-attempted with the standard retry policy.
+         *
+         *     * Successful redeliveries are removed from the file.
+         *     * Records whose URL no longer matches any configured target are
+         *       kept on disk so the operator can fix the config and retry.
+         *     * Records that fail again are kept with their ``attempts``
+         *       counter bumped and the latest ``last_error`` recorded.
+         *
+         *     Selection order: oldest records (lowest ``ts``) within the
+         *     eligible window go first, so iterative calls drain the file
+         *     front-to-back. The blocking work runs on the FastAPI threadpool
+         *     via ``run_in_threadpool`` so the event loop stays free for other
+         *     handlers while a long replay is in flight.
+         *
+         *     Returns counts only — the bodies are never echoed back so the
+         *     admin surface cannot leak match payloads. ``remaining_in_dl``
+         *     is the count of records still on disk after the call (ones held
+         *     back by ``since`` / ``max_records`` plus the ``still_failing``
+         *     bucket that just got re-written) so the operator knows whether
+         *     to call again.
+         */
+        post: operations["replay_dead_letter_webhooks_api_v1_admin_webhooks_replay_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/app-config": {
         parameters: {
             query?: never;
@@ -265,16 +344,28 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Recent action audit log
-         * @description Return up to *limit* most-recent records from the action log.
+         * Recent action audit log (cursor-paginated)
+         * @description Return one page of audit records, newest page first.
          *
-         *     Records are ordered chronologically (oldest first within the
-         *     returned window). Each entry has the shape::
+         *     First call (``before_ts`` omitted) returns the most recent
+         *     ``limit`` records. Subsequent calls pass the previous response's
+         *     ``next_cursor`` to walk back through history one window at a time.
+         *
+         *     Records are ordered chronologically (oldest first **within** the
+         *     returned window — same convention as ``read_recent``). Each entry
+         *     has the shape::
          *
          *         {"ts": 1714508400.123,
          *          "action": "add_point",
          *          "params": {"team": 1, "undo": false},
          *          "result": {"current_set": 2, "team_1": {...}, ...}}
+         *
+         *     The response carries:
+         *
+         *     * ``records`` — the page itself.
+         *     * ``count`` — ``len(records)``.
+         *     * ``next_cursor`` — the ``ts`` to pass as ``before_ts`` for the
+         *       next page, or ``null`` when this is the last page.
          */
         get: operations["get_audit_log_api_v1_audit_get"];
         put?: never;
@@ -936,6 +1027,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Prometheus exposition
+         * @description Return the registry's current exposition in Prometheus text format.
+         *
+         *     ``METRICS_REQUIRE_ADMIN=true`` opts into Bearer auth at the same
+         *     ladder as ``/api/v1/admin/*``. The check fires *before* the
+         *     library-availability check so an unauthenticated probe cannot use
+         *     the 503-vs-200 difference to fingerprint whether the metrics
+         *     backend is loaded.
+         */
+        get: operations["metrics_endpoint_metrics_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/overlay/{overlay_id}": {
         parameters: {
             query?: never;
@@ -1038,6 +1155,61 @@ export interface components {
              * @description Overlay id used as OID
              */
             name: string;
+        };
+        /**
+         * CustomOverlayPatch
+         * @description Partial update for a custom overlay's appearance.
+         *
+         *     Every field is optional — the patch is a thin admin-side wrapper around
+         *     ``OverlayStateStore.update_state``. When ``theme`` is set, the matching
+         *     preset from ``app.overlay.themes`` is applied first; ``colors`` and
+         *     ``preferred_style`` are then merged on top so explicit overrides win
+         *     over the theme defaults.
+         */
+        CustomOverlayPatch: {
+            /**
+             * Colors
+             * @description Color overrides merged into overlay_control.colors. Common keys: set_bg, set_text, game_bg, game_text.
+             */
+            colors?: {
+                [key: string]: string;
+            } | null;
+            /**
+             * Preferred Style
+             * @description Switch the Jinja template served at /overlay/{output_key}. Must match an entry in GET /api/config/{id}.availableStyles.
+             */
+            preferred_style?: string | null;
+            /**
+             * Theme
+             * @description Apply a preset theme (e.g. 'dark', 'esports'). Available themes are listed by GET /api/themes.
+             */
+            theme?: string | null;
+        };
+        /**
+         * CustomOverlayUsage
+         * @description Snapshot of how many live consumers a custom overlay has.
+         */
+        CustomOverlayUsage: {
+            /**
+             * Frontend Ws Clients
+             * @description Connected scoreboard control tabs (frontend WebSocket subscribers).
+             */
+            frontend_ws_clients: number;
+            /**
+             * Has Active Session
+             * @description True when SessionManager has a live GameSession.
+             */
+            has_active_session: boolean;
+            /**
+             * Obs Clients
+             * @description Connected OBS / browser-source viewers.
+             */
+            obs_clients: number;
+            /**
+             * Seconds Since Last Activity
+             * @description Seconds elapsed since the session was last touched; null when no session is active.
+             */
+            seconds_since_last_activity?: number | null;
         };
         /** GameStateResponse */
         GameStateResponse: {
@@ -1671,6 +1843,76 @@ export interface operations {
             };
         };
     };
+    patch_custom_overlay_api_v1_admin_custom_overlays__name__patch: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string;
+            };
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CustomOverlayPatch"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_custom_overlay_usage_api_v1_admin_custom_overlays__name__usage_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string;
+            };
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CustomOverlayUsage"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     admin_login_api_v1_admin_login_post: {
         parameters: {
             query?: never;
@@ -1759,6 +2001,42 @@ export interface operations {
             };
         };
     };
+    replay_dead_letter_webhooks_api_v1_admin_webhooks_replay_post: {
+        parameters: {
+            query?: {
+                /** @description Only replay records whose ``ts`` is >= this Unix-seconds value. Useful for restricting replay to entries that landed after the receiving service came back online. */
+                since?: number | null;
+                /** @description Cap the number of records redelivered in this call. ``replay_records`` blocks on per-record retries with exponential backoff (~25 s worst case per record), so a fully-loaded dead-letter would otherwise pin the handler for tens of minutes. Use the ``remaining_in_dl`` field in the response to decide whether to call again. */
+                max_records?: number;
+            };
+            header?: {
+                authorization?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     app_config_api_v1_app_config_get: {
         parameters: {
             query?: never;
@@ -1783,6 +2061,8 @@ export interface operations {
         parameters: {
             query?: {
                 limit?: number;
+                /** @description Pagination cursor: only return records strictly older than this timestamp. Use the ``next_cursor`` value from the previous response. Omit for the first page. */
+                before_ts?: number | null;
                 /** @description Overlay ID */
                 oid?: string | null;
                 /** @description Alias of `oid` for backward compatibility */
@@ -3072,6 +3352,35 @@ export interface operations {
         responses: {
             /** @description Successful Response */
             204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    metrics_endpoint_metrics_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/requirements.lock
+++ b/requirements.lock
@@ -14,7 +14,7 @@ charset-normalizer==3.4.7
     # via requests
 click==8.3.2
     # via uvicorn
-fastapi==0.136.0
+fastapi==0.136.1
     # via -r requirements.txt
 h11==0.16.0
     # via uvicorn
@@ -28,6 +28,8 @@ jinja2==3.1.6
     # via -r requirements.txt
 markupsafe==3.0.3
     # via jinja2
+prometheus-client==0.25.0
+    # via -r requirements.txt
 pydantic==2.13.2
     # via fastapi
 pydantic-core==2.46.2
@@ -56,7 +58,7 @@ typing-inspection==0.4.2
     #   pydantic
 urllib3==2.6.3
     # via requests
-uvicorn==0.44.0
+uvicorn==0.46.0
     # via -r requirements.txt
 uvloop==0.22.1
     # via uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests==2.33.1
 python-dotenv==1.2.2
 websocket-client>=1.9.0
 jinja2>=3.1.6
+prometheus-client>=0.20.0

--- a/tests/test_action_log.py
+++ b/tests/test_action_log.py
@@ -184,6 +184,173 @@ class TestActionLog:
 
 
 # ---------------------------------------------------------------------------
+# Rotation (M13)
+# ---------------------------------------------------------------------------
+
+
+class TestActionLogRotation:
+    """Verify size-based rotation, cross-file reads, and cleanup."""
+
+    @pytest.fixture
+    def small_rotation(self, monkeypatch):
+        """Shrink AUDIT_LOG_MAX_BYTES so rotation is reachable from a test.
+
+        The constant is read at import time; setting the env var afterwards
+        is too late. Patch the module attribute directly instead so the
+        next ``append`` sees the new threshold.
+        """
+        monkeypatch.setattr(action_log, "AUDIT_LOG_MAX_BYTES", 200)
+        monkeypatch.setattr(action_log, "AUDIT_LOG_MAX_FILES", 3)
+        yield
+
+    def _spam(self, oid: str, n: int) -> None:
+        for i in range(n):
+            action_log.append(oid, "add_point", {"team": 1, "i": i}, {"x": i})
+
+    def test_no_rotation_under_threshold(self, small_rotation):
+        # Two small records stay well under 200 bytes — file should not rotate.
+        action_log.append("rot-1", "add_point", {"team": 1}, {"x": 1})
+        action_log.append("rot-1", "add_point", {"team": 2}, {"x": 2})
+        path = action_log._path("rot-1")
+        assert os.path.exists(path)
+        assert not os.path.exists(action_log._rotated_path(path, 1))
+        assert len(action_log.read_all("rot-1")) == 2
+
+    def test_rotates_when_active_exceeds_threshold(self, monkeypatch):
+        # Cap=10 is generous enough that 10 records (~95 B each, threshold
+        # 200 B → rotation every ~3 records → ~4 files) all survive. This
+        # specifically exercises read_all stitching across the rotation
+        # boundary; the cap-eviction case is covered by
+        # test_oldest_records_dropped_when_cap_hit below.
+        monkeypatch.setattr(action_log, "AUDIT_LOG_MAX_BYTES", 200)
+        monkeypatch.setattr(action_log, "AUDIT_LOG_MAX_FILES", 10)
+        self._spam("rot-2", 10)
+        path = action_log._path("rot-2")
+        assert os.path.exists(action_log._rotated_path(path, 1))
+        records = action_log.read_all("rot-2")
+        assert len(records) == 10
+        assert [r["params"]["i"] for r in records] == list(range(10))
+
+    def test_rotation_caps_at_max_files(self, small_rotation):
+        # AUDIT_LOG_MAX_FILES=3 means active + .1 + .2 (3 files total).
+        self._spam("rot-3", 60)
+        path = action_log._path("rot-3")
+        # Slot .3 must never appear.
+        assert not os.path.exists(action_log._rotated_path(path, 3))
+        # Slot .2 (oldest survivor) and .1 (newest rotated) may exist.
+        assert os.path.exists(action_log._rotated_path(path, 2))
+        assert os.path.exists(action_log._rotated_path(path, 1))
+
+    def test_oldest_records_dropped_when_cap_hit(self, small_rotation):
+        self._spam("rot-4", 60)
+        records = action_log.read_all("rot-4")
+        # Some prefix of records was lost to the cap; every surviving
+        # record's index must be strictly increasing (no shuffling).
+        ids = [r["params"]["i"] for r in records]
+        assert ids == sorted(ids)
+        # The newest record (i=59) must always survive — it's in the
+        # active file.
+        assert ids[-1] == 59
+
+    def test_clear_removes_all_rotated_files(self, small_rotation):
+        self._spam("rot-5", 60)
+        path = action_log._path("rot-5")
+        assert os.path.exists(action_log._rotated_path(path, 1))
+        action_log.clear("rot-5")
+        assert not os.path.exists(path)
+        for i in range(1, 5):
+            assert not os.path.exists(action_log._rotated_path(path, i))
+        assert action_log.read_all("rot-5") == []
+
+    def test_delete_removes_all_rotated_files(self, small_rotation):
+        self._spam("rot-6", 60)
+        path = action_log._path("rot-6")
+        assert action_log.delete("rot-6") is True
+        assert not os.path.exists(path)
+        for i in range(1, 5):
+            assert not os.path.exists(action_log._rotated_path(path, i))
+        # Second delete returns False (idempotent).
+        assert action_log.delete("rot-6") is False
+
+    def test_pop_can_tombstone_record_in_rotated_file(self, small_rotation):
+        # Forward record lands in rotated archive after enough spam;
+        # tombstone goes to the active file. read_all must hide both.
+        self._spam("rot-7", 30)
+        path = action_log._path("rot-7")
+        assert os.path.exists(action_log._rotated_path(path, 1))
+        # Pop the most recent forward; target may live in the active
+        # file but the cross-file machinery is exercised regardless.
+        target = action_log.pop_last_forward("rot-7")
+        assert target is not None
+        records = action_log.read_all("rot-7")
+        # The popped record must not appear in the visible view.
+        assert target not in records
+        # The tombstone itself must also be hidden.
+        assert all(r["action"] != "_pop" for r in records)
+
+
+# ---------------------------------------------------------------------------
+# Cursor pagination (M13)
+# ---------------------------------------------------------------------------
+
+
+class TestReadPage:
+    """``read_page`` is the cursor-based building block of GET /audit."""
+
+    def _seed(self, oid: str, n: int) -> None:
+        for i in range(n):
+            action_log.append(oid, "add_point", {"team": 1, "i": i}, {"x": i})
+
+    def test_first_page_returns_newest_records(self):
+        self._seed("page-1", 50)
+        page, cursor = action_log.read_page("page-1", limit=10)
+        assert len(page) == 10
+        # Chronological within window: i=40..49.
+        assert [r["params"]["i"] for r in page] == list(range(40, 50))
+        assert cursor == page[0]["ts"]
+
+    def test_walking_pages_covers_every_record(self):
+        self._seed("page-2", 25)
+        seen: list[int] = []
+        cursor = None
+        # Cap iterations defensively so a bug cannot hang the test.
+        for _ in range(20):
+            page, cursor = action_log.read_page(
+                "page-2", limit=7, before_ts=cursor,
+            )
+            seen = [r["params"]["i"] for r in page] + seen
+            if cursor is None:
+                break
+        assert seen == list(range(25))
+        assert cursor is None
+
+    def test_cursor_null_on_final_page(self):
+        self._seed("page-3", 5)
+        page, cursor = action_log.read_page("page-3", limit=10)
+        assert len(page) == 5
+        assert cursor is None  # no more records remain
+
+    def test_empty_log_returns_empty_with_null_cursor(self):
+        page, cursor = action_log.read_page("never-written", limit=10)
+        assert page == []
+        assert cursor is None
+
+    def test_invalid_limit_returns_empty(self):
+        page, cursor = action_log.read_page("page-3", limit=0)
+        assert page == []
+        assert cursor is None
+
+    def test_pagination_skips_tombstoned_records(self):
+        self._seed("page-4", 5)
+        # Pop the most recent forward — i=4 should disappear from the page.
+        action_log.pop_last_forward("page-4")
+        page, _ = action_log.read_page("page-4", limit=10)
+        ids = [r["params"]["i"] for r in page]
+        assert 4 not in ids
+        assert ids == [0, 1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
 # GameService write path
 # ---------------------------------------------------------------------------
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -429,6 +429,7 @@ class TestWebhookReplayEndpoint:
             "succeeded": 0,
             "still_failing": 0,
             "skipped_unknown_url": 0,
+            "remaining_in_dl": 0,
         }
 
     def test_redelivers_and_prunes_successes(self, client, replay_env):
@@ -454,6 +455,43 @@ class TestWebhookReplayEndpoint:
         assert body["still_failing"] == 0
         # The DL file is now empty.
         assert webhook_dead_letter.read_all() == []
+
+    def test_max_records_caps_per_call_and_reports_remaining(
+        self, client, replay_env,
+    ):
+        from unittest.mock import MagicMock, patch
+
+        from app.api import webhook_dead_letter
+
+        # Seed 5 records — all targeting the same configured URL.
+        for i in range(5):
+            webhook_dead_letter.append({
+                "url": "https://hooks.example.com/x",
+                "event": "set_end", "oid": f"o{i}", "body": "{}",
+            })
+        with patch(
+            "app.api.webhooks.requests.post",
+            return_value=MagicMock(status_code=200),
+        ) as post:
+            res = client.post(
+                "/api/v1/admin/webhooks/replay",
+                params={"max_records": 2},
+                headers=_auth(),
+            )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["considered"] == 2
+        assert body["succeeded"] == 2
+        # 3 remaining records (5 seeded - 2 redelivered) stayed in
+        # the file, untouched by this call.
+        assert body["remaining_in_dl"] == 3
+        # Two redeliveries hit the network.
+        assert post.call_count == 2
+        # File content matches: 3 oldest-eligible records were
+        # consumed by replay, so the 3 newest remain.
+        remaining = webhook_dead_letter.read_all()
+        assert len(remaining) == 3
+        assert [r["oid"] for r in remaining] == ["o2", "o3", "o4"]
 
     def test_since_filter_keeps_older_records_untouched(self, client, replay_env):
         import time as _time

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -393,6 +393,107 @@ def test_delete_missing(client):
 
 
 # ---------------------------------------------------------------------------
+# POST /webhooks/replay  (M16 — Fase 4)
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookReplayEndpoint:
+    """Operator-triggered redelivery of dead-lettered webhooks."""
+
+    @pytest.fixture
+    def replay_env(self, monkeypatch, tmp_path):
+        """Isolate the dead-letter file and shrink retry timing."""
+        from app.api import webhook_dead_letter, webhooks
+
+        monkeypatch.setattr(webhooks, "WEBHOOK_RETRY_ATTEMPTS", 0)
+        monkeypatch.setattr(webhooks, "WEBHOOK_RETRY_BASE_SECONDS", 0)
+        monkeypatch.setattr(webhooks, "WEBHOOK_RETRY_MAX_SECONDS", 0)
+        monkeypatch.setattr(webhook_dead_letter, "_data_dir", lambda: str(tmp_path))
+        monkeypatch.setenv("WEBHOOKS_ALLOW_PRIVATE_IPS", "true")
+        monkeypatch.setenv("WEBHOOKS_URL", "https://hooks.example.com/x")
+        webhooks.webhook_dispatcher.reload()
+        yield
+
+    def test_requires_auth(self, client, replay_env):
+        res = client.post("/api/v1/admin/webhooks/replay")
+        assert res.status_code == 401
+
+    def test_empty_dead_letter_is_a_clean_no_op(self, client, replay_env):
+        res = client.post(
+            "/api/v1/admin/webhooks/replay", headers=_auth(),
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body == {
+            "considered": 0,
+            "succeeded": 0,
+            "still_failing": 0,
+            "skipped_unknown_url": 0,
+        }
+
+    def test_redelivers_and_prunes_successes(self, client, replay_env):
+        from unittest.mock import MagicMock, patch
+
+        from app.api import webhook_dead_letter
+        webhook_dead_letter.append({
+            "url": "https://hooks.example.com/x",
+            "event": "set_end", "oid": "o", "body": "{}",
+            "last_error": "HTTP 503", "attempts": 4,
+        })
+        with patch(
+            "app.api.webhooks.requests.post",
+            return_value=MagicMock(status_code=200),
+        ):
+            res = client.post(
+                "/api/v1/admin/webhooks/replay", headers=_auth(),
+            )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["considered"] == 1
+        assert body["succeeded"] == 1
+        assert body["still_failing"] == 0
+        # The DL file is now empty.
+        assert webhook_dead_letter.read_all() == []
+
+    def test_since_filter_keeps_older_records_untouched(self, client, replay_env):
+        import time as _time
+        from unittest.mock import MagicMock, patch
+
+        from app.api import webhook_dead_letter
+
+        old_ts = _time.time() - 3600
+        recent_ts = _time.time()
+        webhook_dead_letter.append({
+            "ts": old_ts,
+            "url": "https://hooks.example.com/x",
+            "event": "set_end", "oid": "old", "body": "{}",
+        })
+        webhook_dead_letter.append({
+            "ts": recent_ts,
+            "url": "https://hooks.example.com/x",
+            "event": "set_end", "oid": "new", "body": "{}",
+        })
+        with patch(
+            "app.api.webhooks.requests.post",
+            return_value=MagicMock(status_code=200),
+        ):
+            # Replay only the recent one.
+            res = client.post(
+                "/api/v1/admin/webhooks/replay",
+                params={"since": recent_ts - 1},
+                headers=_auth(),
+            )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["considered"] == 1
+        assert body["succeeded"] == 1
+        # The old record is still on disk.
+        remaining = webhook_dead_letter.read_all()
+        assert len(remaining) == 1
+        assert remaining[0]["oid"] == "old"
+
+
+# ---------------------------------------------------------------------------
 # Public overlays endpoint no longer merges managed overlays
 # ---------------------------------------------------------------------------
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -294,6 +294,43 @@ class TestPatchCustomOverlay:
         assert res.status_code == 400
         assert "preferred_style" in res.json()["detail"]
 
+    def test_combined_patch_writes_state_once(self, client, overlay_named):
+        """Theme + overrides must collapse into a single ``update_state``.
+
+        Two ``update_state`` calls would mean two disk writes plus two
+        WebSocket broadcasts for one logical edit. Mock the store call
+        directly to prove the call count.
+        """
+        from unittest.mock import AsyncMock
+
+        from app.overlay import overlay_state_store
+
+        original = overlay_state_store.update_state
+        mock = AsyncMock(side_effect=original)
+        overlay_state_store.update_state = mock
+        try:
+            res = client.patch(
+                f"/api/v1/admin/custom-overlays/{overlay_named}",
+                json={
+                    "theme": "dark",
+                    "colors": {"set_bg": "#FF00FF"},
+                    "preferred_style": "default",
+                },
+                headers=_auth(),
+            )
+        finally:
+            overlay_state_store.update_state = original
+        assert res.status_code == 200
+        # Single coalesced write — used to be two (theme then overrides).
+        assert mock.call_count == 1
+        merged = mock.call_args.args[1]
+        # Theme baseline survived (game_text from "dark"); explicit
+        # set_bg won; preferred_style folded into the same payload.
+        oc = merged["overlay_control"]
+        assert oc["colors"]["set_bg"] == "#FF00FF"
+        assert oc["colors"]["game_text"] == "#FFFFFF"
+        assert oc["preferredStyle"] == "default"
+
     def test_default_preferred_style_accepted(self, client, overlay_named):
         # ``default`` is the implicit fallback (index.html) and not in
         # get_available_styles_list — the handler must accept it explicitly.

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -177,6 +177,205 @@ def test_create_copy_missing_source(client):
     assert res.status_code == 404
 
 
+# ---------------------------------------------------------------------------
+# PATCH /custom-overlays/{name}  (M4 — Fase 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def overlay_named(client):
+    """Create a fresh custom overlay and yield its id."""
+    name = "patchme"
+    res = client.post(
+        "/api/v1/admin/custom-overlays",
+        json={"name": name}, headers=_auth(),
+    )
+    assert res.status_code == 200
+    yield name
+
+
+class TestPatchCustomOverlay:
+    def test_requires_auth(self, client, overlay_named):
+        res = client.patch(
+            f"/api/v1/admin/custom-overlays/{overlay_named}",
+            json={"theme": "dark"},
+        )
+        assert res.status_code == 401
+
+    def test_unknown_overlay_returns_404(self, client):
+        res = client.patch(
+            "/api/v1/admin/custom-overlays/ghost",
+            json={"theme": "dark"}, headers=_auth(),
+        )
+        assert res.status_code == 404
+
+    def test_empty_patch_rejected(self, client, overlay_named):
+        res = client.patch(
+            f"/api/v1/admin/custom-overlays/{overlay_named}",
+            json={}, headers=_auth(),
+        )
+        assert res.status_code == 400
+        assert "at least one of" in res.json()["detail"]
+
+    def test_invalid_id_rejected(self, client):
+        res = client.patch(
+            "/api/v1/admin/custom-overlays/bad..name",
+            json={"theme": "dark"}, headers=_auth(),
+        )
+        # ``..`` is filtered by _validate_overlay_id (rejects ".." stem).
+        # The pattern actually allows dots, so ``bad..name`` matches the
+        # admin-side allow-list — the failure comes from "not found".
+        assert res.status_code in (400, 404)
+
+    def test_unknown_theme_returns_404(self, client, overlay_named):
+        res = client.patch(
+            f"/api/v1/admin/custom-overlays/{overlay_named}",
+            json={"theme": "no-such-theme"}, headers=_auth(),
+        )
+        assert res.status_code == 404
+        assert "no-such-theme" in res.json()["detail"]
+
+    def test_apply_theme_persists_colors(self, client, overlay_named):
+        res = client.patch(
+            f"/api/v1/admin/custom-overlays/{overlay_named}",
+            json={"theme": "dark"}, headers=_auth(),
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["id"] == overlay_named
+        state = overlay_state_store.get_state(overlay_named)
+        # ``dark`` theme sets specific bg/text colors — verify a couple.
+        colors = state["overlay_control"]["colors"]
+        assert colors["set_bg"] == "#222222"
+        assert colors["game_text"] == "#FFFFFF"
+
+    def test_apply_theme_with_preferred_style(self, client, overlay_named):
+        # ``esports`` includes preferredStyle on top of colors.
+        res = client.patch(
+            f"/api/v1/admin/custom-overlays/{overlay_named}",
+            json={"theme": "esports"}, headers=_auth(),
+        )
+        assert res.status_code == 200
+        state = overlay_state_store.get_state(overlay_named)
+        assert state["overlay_control"]["preferredStyle"] == "esports"
+        assert state["overlay_control"]["colors"]["set_text"] == "#00FFFF"
+
+    def test_colors_only_merge(self, client, overlay_named):
+        res = client.patch(
+            f"/api/v1/admin/custom-overlays/{overlay_named}",
+            json={"colors": {"set_bg": "#123456", "team_home": "#abcdef"}},
+            headers=_auth(),
+        )
+        assert res.status_code == 200
+        state = overlay_state_store.get_state(overlay_named)
+        assert state["overlay_control"]["colors"]["set_bg"] == "#123456"
+        assert state["overlay_control"]["colors"]["team_home"] == "#abcdef"
+
+    def test_explicit_colors_override_theme(self, client, overlay_named):
+        # Theme baseline + override on top: the operator's explicit color
+        # must win, not the theme's.
+        res = client.patch(
+            f"/api/v1/admin/custom-overlays/{overlay_named}",
+            json={"theme": "dark", "colors": {"set_bg": "#FF00FF"}},
+            headers=_auth(),
+        )
+        assert res.status_code == 200
+        state = overlay_state_store.get_state(overlay_named)
+        assert state["overlay_control"]["colors"]["set_bg"] == "#FF00FF"
+        # The other theme colors survive (deep-merge, not replace).
+        assert state["overlay_control"]["colors"]["game_text"] == "#FFFFFF"
+
+    def test_invalid_preferred_style_rejected(self, client, overlay_named):
+        res = client.patch(
+            f"/api/v1/admin/custom-overlays/{overlay_named}",
+            json={"preferred_style": "non-existent-template"},
+            headers=_auth(),
+        )
+        assert res.status_code == 400
+        assert "preferred_style" in res.json()["detail"]
+
+    def test_default_preferred_style_accepted(self, client, overlay_named):
+        # ``default`` is the implicit fallback (index.html) and not in
+        # get_available_styles_list — the handler must accept it explicitly.
+        res = client.patch(
+            f"/api/v1/admin/custom-overlays/{overlay_named}",
+            json={"preferred_style": "default"}, headers=_auth(),
+        )
+        assert res.status_code == 200
+        state = overlay_state_store.get_state(overlay_named)
+        assert state["overlay_control"]["preferredStyle"] == "default"
+
+
+# ---------------------------------------------------------------------------
+# GET /custom-overlays/{name}/usage  (M7 — Fase 1)
+# ---------------------------------------------------------------------------
+
+
+class TestCustomOverlayUsage:
+    def test_requires_auth(self, client, overlay_named):
+        res = client.get(
+            f"/api/v1/admin/custom-overlays/{overlay_named}/usage",
+        )
+        assert res.status_code == 401
+
+    def test_unknown_overlay_returns_404(self, client):
+        res = client.get(
+            "/api/v1/admin/custom-overlays/ghost/usage",
+            headers=_auth(),
+        )
+        assert res.status_code == 404
+
+    def test_idle_overlay_reports_zero(self, client, overlay_named):
+        res = client.get(
+            f"/api/v1/admin/custom-overlays/{overlay_named}/usage",
+            headers=_auth(),
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body == {
+            "obs_clients": 0,
+            "frontend_ws_clients": 0,
+            "has_active_session": False,
+            "seconds_since_last_activity": None,
+        }
+
+    def test_reports_active_session(self, client, overlay_named):
+        # Materialise a GameSession for the overlay — ``SessionManager.get``
+        # is the same path the WS / API routes take, so this exercises the
+        # real registry rather than a mock.
+        from app.api.session_manager import SessionManager
+        SessionManager.get_or_create(overlay_named)
+        try:
+            res = client.get(
+                f"/api/v1/admin/custom-overlays/{overlay_named}/usage",
+                headers=_auth(),
+            )
+            assert res.status_code == 200
+            body = res.json()
+            assert body["has_active_session"] is True
+            assert isinstance(body["seconds_since_last_activity"], int)
+            assert body["seconds_since_last_activity"] >= 0
+        finally:
+            SessionManager.remove(overlay_named)
+
+    def test_reports_obs_client_count(self, client, overlay_named):
+        # The hub treats ``add_client`` as the canonical way to register
+        # an OBS source — fake one with a sentinel object since we only
+        # care about the count, not real WebSocket I/O.
+        from app.overlay import obs_broadcast_hub
+        sentinel = object()
+        obs_broadcast_hub._clients.setdefault(overlay_named, []).append(sentinel)
+        try:
+            res = client.get(
+                f"/api/v1/admin/custom-overlays/{overlay_named}/usage",
+                headers=_auth(),
+            )
+            assert res.status_code == 200
+            assert res.json()["obs_clients"] == 1
+        finally:
+            obs_broadcast_hub._clients.pop(overlay_named, None)
+
+
 def test_delete_custom_overlay(client):
     client.post(
         "/api/v1/admin/custom-overlays",

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -272,3 +272,138 @@ class TestWSHubResilience:
 
         assert "oid1" not in WSHub._connections
         WSHub.clear()
+
+
+# ---------------------------------------------------------------------------
+# WSHub cap + heartbeat (M14 — Fase 4)
+# ---------------------------------------------------------------------------
+
+
+class TestWSHubCap:
+    """``connect`` must reject upgrades once an OID is at its cap."""
+
+    def test_connect_raises_when_at_cap(self, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        from app.api.ws_hub import WSHub, WSHubFull
+
+        WSHub.clear()
+        monkeypatch.setattr(WSHub, "_MAX_CLIENTS_PER_OID", 2)
+        # Pre-populate two healthy clients so the next accept hits the cap.
+        WSHub._connections["oid-cap"] = {object(), object()}
+
+        ws = AsyncMock()
+        import asyncio as _asyncio
+
+        with pytest.raises(WSHubFull) as excinfo:
+            _asyncio.run(WSHub.connect(ws, "oid-cap"))
+        assert excinfo.value.oid == "oid-cap"
+        assert excinfo.value.cap == 2
+        # The handshake must NOT have been accepted on the rejected upgrade.
+        ws.accept.assert_not_called()
+        WSHub.clear()
+
+    def test_websocket_endpoint_closes_with_1013_when_at_cap(
+        self, client, fake_backend_cls, monkeypatch,
+    ):
+        from app.api.ws_hub import WSHub
+
+        # Spin up a real session so check_oid_access / SessionManager pass.
+        with patch(
+            "app.api.routes.session.Backend", return_value=fake_backend_cls,
+        ):
+            r = client.post("/api/v1/session/init", json={"oid": "cap-oid"})
+            assert r.status_code == 200
+
+        # Force the cap to 0 so the very first WS connect is refused.
+        monkeypatch.setattr(WSHub, "_MAX_CLIENTS_PER_OID", 0)
+
+        # The TestClient WebSocket helper raises on close-before-accept,
+        # but FastAPI emits the 1013 close *after* the handshake message
+        # — so just verify the endpoint did not register the client.
+        # The TestClient WebSocket helper raises on close-before-accept
+        # with a variety of exceptions across Starlette versions, so
+        # catch broadly: the assertion below is what actually proves
+        # the cap held.
+        try:
+            with client.websocket_connect("/api/v1/ws?oid=cap-oid"):
+                pass
+        except Exception:
+            pass
+        assert "cap-oid" not in WSHub._connections
+        WSHub.clear()
+
+
+class TestWSHubHeartbeat:
+    """``_heartbeat_tick`` evicts zombies and pings the rest."""
+
+    def test_tick_evicts_idle_socket_past_timeout(self, monkeypatch):
+        import asyncio as _asyncio
+        import time as _time
+        from unittest.mock import AsyncMock
+
+        from app.api import ws_hub
+        from app.api.ws_hub import WSHub
+
+        WSHub.clear()
+        # 1s timeout for the test; pretend the client has been idle 5s.
+        monkeypatch.setattr(ws_hub, "WSHUB_CLIENT_TIMEOUT_SECONDS", 1.0)
+
+        zombie = AsyncMock()
+        WSHub._connections["oid-z"] = {zombie}
+        WSHub._last_seen[zombie] = _time.monotonic() - 5.0
+
+        _asyncio.run(WSHub._heartbeat_tick())
+
+        # Eviction sends a 1011 close and then disconnects bookkeeping.
+        zombie.close.assert_called_once()
+        assert "oid-z" not in WSHub._connections
+        assert zombie not in WSHub._last_seen
+        WSHub.clear()
+
+    def test_tick_pings_healthy_socket(self, monkeypatch):
+        import asyncio as _asyncio
+        import time as _time
+        from unittest.mock import AsyncMock
+
+        from app.api import ws_hub
+        from app.api.ws_hub import WSHub
+
+        WSHub.clear()
+        monkeypatch.setattr(ws_hub, "WSHUB_CLIENT_TIMEOUT_SECONDS", 60.0)
+
+        healthy = AsyncMock()
+        WSHub._connections["oid-h"] = {healthy}
+        WSHub._last_seen[healthy] = _time.monotonic()
+
+        _asyncio.run(WSHub._heartbeat_tick())
+
+        # Stays connected and received the application-level ping frame.
+        assert "oid-h" in WSHub._connections
+        healthy.send_text.assert_called_once_with('{"type":"ping"}')
+        healthy.close.assert_not_called()
+        WSHub.clear()
+
+    def test_mark_active_bumps_last_seen(self, monkeypatch):
+        import time as _time
+        from unittest.mock import AsyncMock
+
+        from app.api.ws_hub import WSHub
+
+        WSHub.clear()
+        ws = AsyncMock()
+        # mark_active is a no-op for unknown sockets — only registered
+        # clients are tracked.
+        WSHub._last_seen[ws] = _time.monotonic() - 5.0
+        before = WSHub._last_seen[ws]
+        WSHub.mark_active(ws)
+        assert WSHub._last_seen[ws] >= before
+        WSHub.clear()
+
+    def test_start_heartbeat_no_op_when_disabled(self):
+        from app.api.ws_hub import WSHub
+
+        WSHub.stop_heartbeat()
+        # Default is 0 — no task should be scheduled.
+        WSHub.start_heartbeat()
+        assert WSHub._heartbeat_task is None

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -407,3 +407,73 @@ class TestWSHubHeartbeat:
         # Default is 0 — no task should be scheduled.
         WSHub.start_heartbeat()
         assert WSHub._heartbeat_task is None
+
+    def test_tick_runs_pings_concurrently(self, monkeypatch):
+        """A 200-client OID must not turn into 200 × timeout of wall time.
+
+        Five mock clients each take 0.1 s to respond to ``send_text``.
+        Serial would be ~0.5 s; concurrent must be ~0.1 s. Cut the
+        threshold at 0.3 s to absorb scheduler jitter while still
+        catching a regression to the serial loop.
+        """
+        import asyncio as _asyncio
+        import time as _time
+        from unittest.mock import AsyncMock
+
+        from app.api import ws_hub
+        from app.api.ws_hub import WSHub
+
+        WSHub.clear()
+        monkeypatch.setattr(ws_hub, "WSHUB_CLIENT_TIMEOUT_SECONDS", 60.0)
+        monkeypatch.setattr(WSHub, "_BROADCAST_SEND_TIMEOUT", 1.0)
+
+        async def _slow_send(_msg):
+            await _asyncio.sleep(0.1)
+
+        clients = []
+        for _ in range(5):
+            c = AsyncMock()
+            c.send_text.side_effect = _slow_send
+            clients.append(c)
+        WSHub._connections["oid-c"] = set(clients)
+        for c in clients:
+            WSHub._last_seen[c] = _time.monotonic()
+
+        start = _time.monotonic()
+        _asyncio.run(WSHub._heartbeat_tick())
+        elapsed = _time.monotonic() - start
+        assert elapsed < 0.3, (
+            f"heartbeat tick ran serially ({elapsed:.2f}s for 5 clients)"
+        )
+        # All five clients got their ping.
+        for c in clients:
+            c.send_text.assert_called_once_with('{"type":"ping"}')
+        WSHub.clear()
+
+    def test_tick_evicts_only_zombie_when_mixed_with_healthy(self, monkeypatch):
+        """Healthy + zombie clients in the same tick: zombie evicted, healthy kept."""
+        import asyncio as _asyncio
+        import time as _time
+        from unittest.mock import AsyncMock
+
+        from app.api import ws_hub
+        from app.api.ws_hub import WSHub
+
+        WSHub.clear()
+        monkeypatch.setattr(ws_hub, "WSHUB_CLIENT_TIMEOUT_SECONDS", 1.0)
+
+        zombie = AsyncMock()
+        healthy = AsyncMock()
+        WSHub._connections["oid-mix"] = {zombie, healthy}
+        WSHub._last_seen[zombie] = _time.monotonic() - 5.0
+        WSHub._last_seen[healthy] = _time.monotonic()
+
+        _asyncio.run(WSHub._heartbeat_tick())
+
+        # Zombie gone, healthy stayed and was pinged.
+        assert "oid-mix" in WSHub._connections
+        assert healthy in WSHub._connections["oid-mix"]
+        assert zombie not in WSHub._connections["oid-mix"]
+        zombie.close.assert_called_once()
+        healthy.send_text.assert_called_once_with('{"type":"ping"}')
+        WSHub.clear()

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,131 @@
+"""Tests for the env-var overrides of the tunable constants in
+``app.constants``.
+
+The constants are read at import time, so each test uses
+``importlib.reload`` after ``monkeypatch.setenv`` to force re-evaluation
+under the patched environment. ``importlib.reload`` is preferred over
+re-importing because the module may already be cached by other test
+fixtures (``app.api.session_manager`` re-exports
+``SESSION_TTL_SECONDS``).
+"""
+import importlib
+
+import pytest
+
+from app import constants as _constants
+
+
+@pytest.fixture
+def reloaded_constants(monkeypatch):
+    """Yield a callable that reloads ``app.constants`` under the current
+    ``monkeypatch`` env, and restores the module's defaults on teardown."""
+    def _reload():
+        return importlib.reload(_constants)
+    yield _reload
+    # Tear down: clear any env vars the test set and reload once more so
+    # later tests see the unmodified defaults.
+    for key in (
+        "SESSION_TTL_SECONDS",
+        "WS_BROADCAST_SEND_TIMEOUT_SECONDS",
+        "WS_RECONNECT_BASE_SECONDS",
+        "WS_RECONNECT_MAX_SECONDS",
+        "WS_HEARTBEAT_INTERVAL_SECONDS",
+        "WS_ZOMBIE_DEADLINE_SECONDS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    importlib.reload(_constants)
+
+
+class TestSessionTtlOverride:
+    def test_default_is_24_hours(self, reloaded_constants):
+        c = reloaded_constants()
+        assert c.SESSION_TTL_SECONDS == 24 * 60 * 60
+
+    def test_env_override_respected(self, monkeypatch, reloaded_constants):
+        monkeypatch.setenv("SESSION_TTL_SECONDS", "60")
+        c = reloaded_constants()
+        assert c.SESSION_TTL_SECONDS == 60
+
+    def test_garbage_falls_back_to_default(self, monkeypatch, reloaded_constants):
+        monkeypatch.setenv("SESSION_TTL_SECONDS", "not-a-number")
+        c = reloaded_constants()
+        assert c.SESSION_TTL_SECONDS == 24 * 60 * 60
+
+    def test_negative_falls_back_to_default(self, monkeypatch, reloaded_constants):
+        monkeypatch.setenv("SESSION_TTL_SECONDS", "-5")
+        c = reloaded_constants()
+        assert c.SESSION_TTL_SECONDS == 24 * 60 * 60
+
+    def test_zero_falls_back_to_default(self, monkeypatch, reloaded_constants):
+        # Zero is non-positive — a 0-second TTL would expire every
+        # session immediately, which is never what the operator wants.
+        monkeypatch.setenv("SESSION_TTL_SECONDS", "0")
+        c = reloaded_constants()
+        assert c.SESSION_TTL_SECONDS == 24 * 60 * 60
+
+    def test_empty_string_falls_back_to_default(self, monkeypatch, reloaded_constants):
+        monkeypatch.setenv("SESSION_TTL_SECONDS", "")
+        c = reloaded_constants()
+        assert c.SESSION_TTL_SECONDS == 24 * 60 * 60
+
+    def test_whitespace_only_falls_back_to_default(self, monkeypatch, reloaded_constants):
+        monkeypatch.setenv("SESSION_TTL_SECONDS", "   ")
+        c = reloaded_constants()
+        assert c.SESSION_TTL_SECONDS == 24 * 60 * 60
+
+
+class TestWebSocketTimeouts:
+    def test_defaults_match_legacy_values(self, reloaded_constants):
+        c = reloaded_constants()
+        assert c.WS_BROADCAST_SEND_TIMEOUT_SECONDS == 2.0
+        assert c.WS_RECONNECT_BASE_SECONDS == 1.0
+        assert c.WS_RECONNECT_MAX_SECONDS == 30.0
+        assert c.WS_HEARTBEAT_INTERVAL_SECONDS == 25.0
+        assert c.WS_ZOMBIE_DEADLINE_SECONDS == 55.0
+
+    def test_broadcast_timeout_env_override(self, monkeypatch, reloaded_constants):
+        monkeypatch.setenv("WS_BROADCAST_SEND_TIMEOUT_SECONDS", "0.5")
+        c = reloaded_constants()
+        assert c.WS_BROADCAST_SEND_TIMEOUT_SECONDS == 0.5
+
+    def test_reconnect_envs_respected(self, monkeypatch, reloaded_constants):
+        monkeypatch.setenv("WS_RECONNECT_BASE_SECONDS", "0.25")
+        monkeypatch.setenv("WS_RECONNECT_MAX_SECONDS", "10")
+        monkeypatch.setenv("WS_HEARTBEAT_INTERVAL_SECONDS", "5")
+        monkeypatch.setenv("WS_ZOMBIE_DEADLINE_SECONDS", "12")
+        c = reloaded_constants()
+        assert c.WS_RECONNECT_BASE_SECONDS == 0.25
+        assert c.WS_RECONNECT_MAX_SECONDS == 10.0
+        assert c.WS_HEARTBEAT_INTERVAL_SECONDS == 5.0
+        assert c.WS_ZOMBIE_DEADLINE_SECONDS == 12.0
+
+    def test_garbage_float_falls_back(self, monkeypatch, reloaded_constants):
+        monkeypatch.setenv("WS_BROADCAST_SEND_TIMEOUT_SECONDS", "fast")
+        c = reloaded_constants()
+        assert c.WS_BROADCAST_SEND_TIMEOUT_SECONDS == 2.0
+
+    def test_negative_float_falls_back(self, monkeypatch, reloaded_constants):
+        monkeypatch.setenv("WS_BROADCAST_SEND_TIMEOUT_SECONDS", "-1.5")
+        c = reloaded_constants()
+        assert c.WS_BROADCAST_SEND_TIMEOUT_SECONDS == 2.0
+
+
+class TestLegacyAliasesPickUpReload:
+    """The legacy module-level names re-export from ``app.constants`` at
+    import time; they must reflect any env override after a reload."""
+
+    def test_session_manager_alias_follows_env(self, monkeypatch, reloaded_constants):
+        import app.api.session_manager as session_manager
+        monkeypatch.setenv("SESSION_TTL_SECONDS", "120")
+        reloaded_constants()
+        importlib.reload(session_manager)
+        assert session_manager.SESSION_TTL_SECONDS == 120
+
+    def test_ws_client_aliases_follow_env(self, monkeypatch, reloaded_constants):
+        import app.ws_client as ws_client
+        monkeypatch.setenv("WS_HEARTBEAT_INTERVAL_SECONDS", "7")
+        monkeypatch.setenv("WS_ZOMBIE_DEADLINE_SECONDS", "20")
+        reloaded_constants()
+        importlib.reload(ws_client)
+        assert ws_client._HEARTBEAT_INTERVAL == 7.0
+        assert ws_client._ZOMBIE_DEADLINE == 20.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,133 @@
+"""Tests for the Prometheus exposition surface (M15)."""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.bootstrap import create_app
+
+pytestmark = pytest.mark.usefixtures("clean_sessions")
+
+
+@pytest.fixture
+def client():
+    with TestClient(create_app()) as c:
+        yield c
+
+
+class TestMetricsEndpoint:
+    def test_returns_prometheus_text_format(self, client):
+        res = client.get("/metrics")
+        assert res.status_code == 200
+        ctype = res.headers.get("content-type", "")
+        # Prometheus exposition uses text/plain; the exact MIME string
+        # carries a version param so just assert on the prefix.
+        assert ctype.startswith("text/plain")
+        body = res.text
+        # The histogram must be defined in the registry on every boot
+        # so dashboards do not need a "first request" warm-up.
+        assert "voc_http_request_duration_seconds" in body
+        assert "voc_webhook_delivery_total" in body
+        assert "voc_ws_clients_total" in body
+        assert "voc_ws_oids_active" in body
+        assert "voc_active_sessions" in body
+
+    def test_records_request_latency(self, client):
+        # Hit a route a few times so the histogram has observations.
+        for _ in range(3):
+            client.get("/api/v1/admin/status")
+        res = client.get("/metrics")
+        # The route template (``/api/v1/admin/status``) must appear in
+        # the metric output, not the raw path with any query string.
+        body = res.text
+        assert "/api/v1/admin/status" in body
+        # And the count of observations for that bucket should be at
+        # least the number of requests we just sent.
+        # ``_count`` lines look like:
+        #   voc_http_request_duration_seconds_count{...} 3.0
+        count_lines = [
+            ln for ln in body.splitlines()
+            if ln.startswith("voc_http_request_duration_seconds_count")
+            and "/api/v1/admin/status" in ln
+        ]
+        assert count_lines, "no observation recorded for /admin/status"
+        # Parse the trailing float and require at least 3.
+        for line in count_lines:
+            try:
+                value = float(line.rsplit(" ", 1)[1])
+            except (IndexError, ValueError):
+                continue
+            assert value >= 3.0
+
+
+class TestMetricsAdminGate:
+    def test_default_no_auth_required(self, client, monkeypatch):
+        monkeypatch.delenv("METRICS_REQUIRE_ADMIN", raising=False)
+        res = client.get("/metrics")
+        assert res.status_code == 200
+
+    def test_admin_required_when_env_set(self, client, monkeypatch):
+        monkeypatch.setenv("METRICS_REQUIRE_ADMIN", "true")
+        monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", "topsecret")
+        # Without the Bearer the route refuses.
+        res = client.get("/metrics")
+        assert res.status_code == 401
+        # With the right Bearer it lets through.
+        res = client.get(
+            "/metrics",
+            headers={"Authorization": "Bearer topsecret"},
+        )
+        assert res.status_code == 200
+
+    def test_admin_required_but_password_unset_503(self, client, monkeypatch):
+        monkeypatch.setenv("METRICS_REQUIRE_ADMIN", "true")
+        monkeypatch.delenv("OVERLAY_MANAGER_PASSWORD", raising=False)
+        res = client.get("/metrics")
+        # The auth helper returns 503 when admin is requested but
+        # OVERLAY_MANAGER_PASSWORD is unset, mirroring /api/v1/admin/*.
+        assert res.status_code == 503
+
+
+class TestWebhookCounter:
+    """``record_webhook_outcome`` updates the labelled counter."""
+
+    def test_success_outcome_increments_counter(self):
+        from app.metrics import record_webhook_outcome, webhook_delivery_total
+
+        # Snapshot the current value, increment, then assert delta.
+        # ``_value.get()`` is the prometheus_client convention for
+        # reading a Counter sample; tests in the python-prometheus
+        # docs use the same pattern.
+        sample = webhook_delivery_total.labels(event="set_end", status="success")
+        before = sample._value.get()
+        record_webhook_outcome("set_end", "success")
+        assert sample._value.get() == before + 1
+
+
+class TestWsGauges:
+    """``WSHub`` keeps the two unlabelled gauges in sync."""
+
+    def test_connect_disconnect_updates_gauges(self, monkeypatch):
+        import asyncio as _asyncio
+        from unittest.mock import AsyncMock
+
+        from app.api.ws_hub import WSHub
+        from app.metrics import ws_clients_total, ws_oids_active
+
+        WSHub.clear()
+        # Bypass the cap so we can register a synthetic socket.
+        monkeypatch.setattr(WSHub, "_MAX_CLIENTS_PER_OID", 10)
+
+        async def _go():
+            ws = AsyncMock()
+            await WSHub.connect(ws, "g-oid")
+            return ws
+
+        ws = _asyncio.run(_go())
+        assert ws_clients_total._value.get() == 1
+        assert ws_oids_active._value.get() == 1
+
+        WSHub.disconnect(ws, "g-oid")
+        assert ws_clients_total._value.get() == 0
+        assert ws_oids_active._value.get() == 0
+        WSHub.clear()

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -354,6 +354,59 @@ class TestWebhookRetries:
         assert "ConnectTimeout" in records[0]["last_error"]
 
 
+class TestDeadLetterCap:
+    """``append`` must keep the DL file under the configured cap."""
+
+    @pytest.fixture
+    def small_cap(self, monkeypatch, tmp_path):
+        from app.api import webhook_dead_letter
+
+        monkeypatch.setattr(
+            webhook_dead_letter, "WEBHOOK_DEAD_LETTER_MAX_RECORDS", 3,
+        )
+        monkeypatch.setattr(
+            webhook_dead_letter, "_data_dir", lambda: str(tmp_path),
+        )
+        yield
+
+    def test_under_cap_appends_normally(self, small_cap):
+        from app.api import webhook_dead_letter
+
+        for i in range(3):
+            webhook_dead_letter.append({"url": "u", "event": "e", "oid": f"o{i}"})
+        records = webhook_dead_letter.read_all()
+        assert [r["oid"] for r in records] == ["o0", "o1", "o2"]
+
+    def test_overflow_evicts_oldest(self, small_cap):
+        from app.api import webhook_dead_letter
+
+        for i in range(5):
+            webhook_dead_letter.append({"url": "u", "event": "e", "oid": f"o{i}"})
+        records = webhook_dead_letter.read_all()
+        # Cap=3 and we wrote 5 → the two oldest (o0, o1) were evicted.
+        assert len(records) == 3
+        assert [r["oid"] for r in records] == ["o2", "o3", "o4"]
+
+    def test_count_reflects_disk_state(self, small_cap):
+        from app.api import webhook_dead_letter
+
+        assert webhook_dead_letter.count() == 0
+        webhook_dead_letter.append({"url": "u", "event": "e", "oid": "x"})
+        assert webhook_dead_letter.count() == 1
+
+    def test_gauge_tracks_size(self, small_cap):
+        from app.api import webhook_dead_letter
+        from app.metrics import webhook_dead_letter_size
+
+        webhook_dead_letter_size.set(0)  # reset for test isolation
+        webhook_dead_letter.append({"url": "u", "event": "e", "oid": "g0"})
+        assert webhook_dead_letter_size._value.get() == 1
+        webhook_dead_letter.append({"url": "u", "event": "e", "oid": "g1"})
+        assert webhook_dead_letter_size._value.get() == 2
+        webhook_dead_letter.clear()
+        assert webhook_dead_letter_size._value.get() == 0
+
+
 class TestReplayRecords:
     def test_replay_redelivers_on_success(self, monkeypatch, fast_retries):
         monkeypatch.setenv("WEBHOOKS_URL", "https://hooks.example.com/x")

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,6 +1,7 @@
 """Tests for app/api/webhooks.py and the GameService firing path."""
 import json
-from unittest.mock import patch
+import time
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -226,6 +227,194 @@ class TestDispatch:
         assert any(
             target_url in (r.args or ()) for r in records
         )
+
+
+# ---------------------------------------------------------------------------
+# Retries + dead-letter (M16 — Fase 4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fast_retries(monkeypatch, tmp_path):
+    """Shrink retry timing and isolate the dead-letter file to *tmp_path*.
+
+    The retry loop calls ``time.sleep`` between attempts; with the
+    production defaults (1 / 2 / 4 s) a single failing test would
+    take seven seconds. ``WEBHOOK_RETRY_BASE_SECONDS=0`` skips that
+    entirely so the tests stay snappy.
+
+    The DL helper writes to ``data/webhooks_dead_letter.jsonl``
+    relative to the repo, which would persist across tests; redirect
+    its ``_data_dir`` at the module level so each test gets a clean
+    file inside ``tmp_path``.
+    """
+    from app.api import webhook_dead_letter, webhooks
+
+    monkeypatch.setattr(webhooks, "WEBHOOK_RETRY_ATTEMPTS", 2)
+    monkeypatch.setattr(webhooks, "WEBHOOK_RETRY_BASE_SECONDS", 0)
+    monkeypatch.setattr(webhooks, "WEBHOOK_RETRY_MAX_SECONDS", 0)
+    monkeypatch.setenv("WEBHOOKS_ALLOW_PRIVATE_IPS", "true")
+    monkeypatch.setattr(webhook_dead_letter, "_data_dir", lambda: str(tmp_path))
+    yield
+
+
+def _drain(dispatcher):
+    if dispatcher._executor is not None:
+        dispatcher._executor.shutdown(wait=True)
+        dispatcher._executor = None
+
+
+class TestWebhookRetries:
+    def test_first_attempt_success_is_not_retried(self, monkeypatch, fast_retries):
+        monkeypatch.setenv("WEBHOOKS_URL", "https://hooks.example.com/x")
+        d = WebhookDispatcher()
+        with patch("app.api.webhooks.requests.post") as post:
+            post.return_value.status_code = 200
+            d.dispatch("set_end", "oid", {})
+            _drain(d)
+            assert post.call_count == 1
+
+    def test_5xx_retries_then_succeeds(self, monkeypatch, fast_retries):
+        monkeypatch.setenv("WEBHOOKS_URL", "https://hooks.example.com/x")
+        d = WebhookDispatcher()
+        # First two attempts return 503, third returns 200 — total
+        # ATTEMPTS+1 = 3 POSTs (the dispatcher's view).
+        responses = [
+            MagicMock(status_code=503),
+            MagicMock(status_code=503),
+            MagicMock(status_code=200),
+        ]
+        with patch("app.api.webhooks.requests.post", side_effect=responses) as post:
+            d.dispatch("set_end", "oid", {})
+            _drain(d)
+            assert post.call_count == 3
+        # Nothing should have landed in the DL since the final attempt
+        # succeeded.
+        from app.api import webhook_dead_letter
+        assert webhook_dead_letter.read_all() == []
+
+    def test_5xx_exhausts_retries_writes_to_dead_letter(
+        self, monkeypatch, fast_retries,
+    ):
+        monkeypatch.setenv("WEBHOOKS_URL", "https://hooks.example.com/x")
+        d = WebhookDispatcher()
+        with patch(
+            "app.api.webhooks.requests.post",
+            return_value=MagicMock(status_code=503),
+        ) as post:
+            d.dispatch("set_end", "oid-X", {"k": "v"})
+            _drain(d)
+            # ATTEMPTS=2 → 3 total POSTs.
+            assert post.call_count == 3
+        from app.api import webhook_dead_letter
+        records = webhook_dead_letter.read_all()
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["url"] == "https://hooks.example.com/x"
+        assert rec["event"] == "set_end"
+        assert rec["oid"] == "oid-X"
+        assert rec["last_error"] == "HTTP 503"
+        assert rec["attempts"] == 3
+        # Body is round-tripped as the JSON string that would have been sent.
+        body = json.loads(rec["body"])
+        assert body["event"] == "set_end"
+        assert body["oid"] == "oid-X"
+        assert body["k"] == "v"
+
+    def test_4xx_does_not_retry_or_dead_letter(self, monkeypatch, fast_retries):
+        monkeypatch.setenv("WEBHOOKS_URL", "https://hooks.example.com/x")
+        d = WebhookDispatcher()
+        with patch(
+            "app.api.webhooks.requests.post",
+            return_value=MagicMock(status_code=403),
+        ) as post:
+            d.dispatch("set_end", "oid", {})
+            _drain(d)
+            # 4xx is permanent → exactly one attempt.
+            assert post.call_count == 1
+        from app.api import webhook_dead_letter
+        assert webhook_dead_letter.read_all() == []
+
+    def test_request_exception_retries_then_dead_letters(
+        self, monkeypatch, fast_retries,
+    ):
+        import requests
+        monkeypatch.setenv("WEBHOOKS_URL", "https://hooks.example.com/x")
+        d = WebhookDispatcher()
+        with patch(
+            "app.api.webhooks.requests.post",
+            side_effect=requests.ConnectTimeout("nope"),
+        ) as post:
+            d.dispatch("set_end", "oid", {})
+            _drain(d)
+            assert post.call_count == 3
+        from app.api import webhook_dead_letter
+        records = webhook_dead_letter.read_all()
+        assert len(records) == 1
+        assert "ConnectTimeout" in records[0]["last_error"]
+
+
+class TestReplayRecords:
+    def test_replay_redelivers_on_success(self, monkeypatch, fast_retries):
+        monkeypatch.setenv("WEBHOOKS_URL", "https://hooks.example.com/x")
+        d = WebhookDispatcher()
+        # Seed a DL record manually.
+        record = {
+            "ts": time.time(),
+            "url": "https://hooks.example.com/x",
+            "event": "set_end",
+            "oid": "oid-1",
+            "body": json.dumps({"event": "set_end", "oid": "oid-1"}),
+            "last_error": "HTTP 503",
+            "attempts": 3,
+        }
+        with patch(
+            "app.api.webhooks.requests.post",
+            return_value=MagicMock(status_code=200),
+        ) as post:
+            succeeded, still_failing, skipped = d.replay_records([record])
+        assert succeeded == 1
+        assert still_failing == []
+        assert skipped == 0
+        assert post.call_count == 1
+
+    def test_replay_keeps_records_with_unknown_url(
+        self, monkeypatch, fast_retries,
+    ):
+        monkeypatch.setenv("WEBHOOKS_URL", "https://hooks.example.com/x")
+        d = WebhookDispatcher()
+        record = {
+            "ts": time.time(),
+            "url": "https://stale.example.com/old-target",
+            "event": "set_end", "oid": "oid", "body": "{}",
+        }
+        with patch("app.api.webhooks.requests.post") as post:
+            succeeded, still_failing, skipped = d.replay_records([record])
+        assert succeeded == 0
+        assert skipped == 1
+        assert len(still_failing) == 1
+        assert post.call_count == 0
+
+    def test_replay_failure_increments_attempts(self, monkeypatch, fast_retries):
+        monkeypatch.setenv("WEBHOOKS_URL", "https://hooks.example.com/x")
+        d = WebhookDispatcher()
+        record = {
+            "ts": time.time(),
+            "url": "https://hooks.example.com/x",
+            "event": "set_end", "oid": "o", "body": "{}",
+            "attempts": 3,
+        }
+        with patch(
+            "app.api.webhooks.requests.post",
+            return_value=MagicMock(status_code=503),
+        ):
+            succeeded, still_failing, skipped = d.replay_records([record])
+        assert succeeded == 0
+        assert skipped == 0
+        assert len(still_failing) == 1
+        # original 3 + (ATTEMPTS=2 + 1) = 6
+        assert still_failing[0]["attempts"] == 6
+        assert still_failing[0]["last_error"] == "HTTP 503"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Plan-driven roadmap delivered as 9 commits across three phases. Backend-heavy: 960 passing tests at the tip (was 885 on `main`).

**Fase 0 — quick wins** (`7c387f3`, `e4b124e`)
- A11y delete-confirmation modal in `/manage` (replaces `window.confirm`); ARIA labels on action buttons; responsive table below 600 px (stacked-card layout via `data-label::before`).
- `SESSION_TTL_SECONDS` and the WS-client tunables centralised in `app.constants` with env overrides; legacy module-level names preserved as re-exports so existing tests/monkeypatches keep working.
- Shared `handleAuthError` helper on the manager page so a rotated `OVERLAY_MANAGER_PASSWORD` mid-session expels the operator from every admin call (previously only `loadOverlays` did).

**Fase 1 — `/manage` becomes a real console** (`fd542a5`, `3c26044`)
- `PATCH /api/v1/admin/custom-overlays/{name}` (theme + colors + `preferred_style`, validated against the renderable templates).
- `GET /api/v1/admin/custom-overlays/{name}/usage` returning OBS / scoreboard / session counts plus relative `seconds_since_last_activity` (avoids confusing `time.monotonic` with epoch).
- `PRESET_THEMES` extracted to `app.overlay.themes` to break the would-be admin↔overlay import cycle and prepare the seam Fase 2 / M8 will widen for directory-backed themes.
- Frontend: live filter input (`aria-live="polite"` count); per-row checkboxes + select-all + bulk delete with shared modal that switches between 1-overlay metadata view and a capped list (>10 overlays); detail drawer with a sandboxed live preview iframe, theme dropdown wired through PATCH (M4), and a Live-usage panel fed by `GET /usage` with green/grey dot + human-readable "X seconds ago".
- Sequential bulk deletes so a 401 mid-batch bounces to login instead of fanning out N parallel failures.

**Fase 4 — operational hardening** (`2693917`, `ee42160`, `3e3aca3`, `e58d4ae`)
- **Audit log rotation + cursor pagination.** Logrotate-style rotation of `data/audit_<hash>.jsonl` at 5 MiB × 5 files (configurable). `read_all` / `pop_last_forward` / `peek_last_forward` walk the active + rotated set so `match_archive` and undo see the full visible history. New `read_page(oid, limit, before_ts)` and `GET /audit?before_ts=...` cursor pagination; old "no cursor = last N" behaviour preserved.
- **WSHub connection cap (always-on) + opt-in heartbeat.** `WSHUB_MAX_CLIENTS_PER_OID` (default 200) refuses new upgrades with a 1013 close before `accept()`. Optional heartbeat (`WSHUB_HEARTBEAT_INTERVAL_SECONDS`, default 0 = disabled) sends `{"type":"ping"}` and evicts clients idle past `WSHUB_CLIENT_TIMEOUT_SECONDS`. New `_env_float_nonneg` helper lets `KEY=0` survive validation as a genuine "off" signal.
- **Webhook retries + dead-letter + admin replay.** Exponential backoff on 5xx + `RequestException` (4xx is permanent client rejection — never retried, never DL'd). Failed deliveries land in `data/webhooks_dead_letter.jsonl` (HMAC secret intentionally not persisted; replay re-resolves from live config). `POST /api/v1/admin/webhooks/replay` (paginated, `run_in_threadpool`'d) drains the file with `since` / `max_records` controls and reports `remaining_in_dl`.
- **Prometheus `/metrics`.** Histogram of HTTP latency (route-template label, not raw path), webhook outcome counter, total WS clients + active OIDs (unlabelled — declined `ws_clients_per_oid` to avoid unbounded cardinality), active-session gauge, dead-letter size gauge. Default-no-auth (only aggregates exposed); `METRICS_REQUIRE_ADMIN=true` opts into Bearer auth. Graceful degradation when `prometheus-client` is missing.

**Code-review follow-ups** (`d57097d`)
- Replay endpoint: `max_records` query (default 50, cap 500) + `run_in_threadpool` so a fully-loaded DL no longer pins the handler for tens of minutes; reports `remaining_in_dl` for iterative drain.
- Dead-letter cap: `WEBHOOK_DEAD_LETTER_MAX_RECORDS` (default 1000) with FIFO eviction via atomic rewrite; `voc_webhook_dead_letter_size` gauge updates on every mutation.
- Heartbeat tick now classifies clients once and fans zombie-closes + healthy-pings out via `asyncio.gather(return_exceptions=True)` so 200 clients no longer takes 200 × `BROADCAST_SEND_TIMEOUT` of wall time.

## Test plan

- [x] `pytest -q` — **960 passed** (was 885 on `main`; +75 new tests across `test_admin.py`, `test_constants.py`, `test_action_log.py`, `test_webhooks.py`, `test_api_routes.py`, `test_metrics.py`).
- [x] `ruff check` clean on every Python file touched.
- [x] `mypy` clean on the four files in commit `7c387f3`.
- [x] Manual smoke of `/manage`: create, copy, edit (theme apply via PATCH M4), bulk delete via filter, drawer preview iframe, ESC closes drawer/modals, Cancel default-focused on delete, mobile viewport (<600 px) collapses to cards.
- [ ] Regenerate `docs/screenshots/05-manage-page.png` (`bash scripts/screenshots/run.sh`) — deferred; needs Node + Playwright + a live server. The Fase 0 viewport (1024×700) didn't change, but the Fase 1 toolbar now has 3 buttons and a checkbox column, so the screenshot is stale.
- [ ] Smoke test `/metrics` against a real Prometheus scrape config in staging.
- [ ] Confirm webhook replay end-to-end against a real receiver after a forced outage.

## Notable design decisions

- **`ws_clients_per_oid` rejected as a label** — the plan asked for a per-OID gauge, but that's the textbook unbounded-cardinality anti-pattern in Prometheus. Replaced with `voc_ws_clients_total` + `voc_ws_oids_active` (both unlabelled). Same dashboard story, no cardinality risk.
- **HMAC secret not persisted in the dead-letter** — replay re-resolves from the live config so rotating `WEBHOOKS_SECRET` doesn't strand legacy entries with stale signatures, and a leaked DL file doesn't leak signing keys.
- **Heartbeat is opt-in by default** — the existing browser client doesn't ack application-level pings; turning it on without coordinating the frontend would churn live tabs every timeout. (Caveat noted in review: `mark_active` already counts any inbound traffic, including the client's own `"ping"` text — so in practice the eviction would only hit truly silent zombies. Followup verification belongs with whoever next touches the frontend WS hook.)

https://claude.ai/code/session_011soXxTGrLbGQu1qyPh8N2C

---
_Generated by [Claude Code](https://claude.ai/code/session_011soXxTGrLbGQu1qyPh8N2C)_