### PR TITLE
fix(manage): SW immediate takeover + drop theme selector (Edit→Info)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,45 @@ once a first tagged release ships.
 
 ### Fixed
 
+- **PWA service-worker no longer requires a force-reload after a
+  release for routes like ``/manage``.** ``frontend/vite.config.js``
+  now sets ``workbox.skipWaiting: true`` and
+  ``workbox.clientsClaim: true``. The previous default kept the old
+  service worker active until every tab closed, so on a fresh deploy
+  operators would land on the SPA shell at ``/manage`` (a route that
+  is in the ``navigateFallbackDenylist`` of the new SW but was not
+  in the old one) until they hit Ctrl+Shift+R. Operators are
+  internal users — there's no consumer-side flow that the immediate
+  SW takeover would break — so claiming clients on activation is
+  the right tradeoff for an admin app.
+
+### Removed
+
+- **Theme selector pulled from the ``/manage`` detail drawer.**
+  Validating against real overlay templates after merge revealed
+  the colour keys the dropdown wrote (``set_bg``, ``game_bg``,
+  ``set_text``, ``game_text``) are not consumed by **any** Jinja
+  template in ``overlay_templates/`` — applying ``dark`` or
+  ``light`` produced a silent no-op while ``esports`` /
+  ``neo_jersey`` / ``split_jersey`` / ``clear_jersey`` happened to
+  work only because they also flip ``preferredStyle``. Rather than
+  ship a half-working surface the dropdown was removed; the drawer
+  now exposes the live preview iframe and the Live-usage panel
+  only, and the per-row button is renamed to **Info** to match
+  the inspect-only nature of the panel.
+
+  The backend ``PATCH /api/v1/admin/custom-overlays/{name}``
+  endpoint is **kept**: it is still useful for automation
+  (especially the ``preferred_style`` field, which does drive the
+  template selection at render time and works end-to-end). The
+  manager UI just no longer wires a button to it. ``GET
+  /api/themes`` and the legacy ``POST /api/theme/{id}/{name}``
+  carry on unchanged. A future iteration that genuinely consumes
+  the colour keys in the templates can re-introduce the selector
+  without further backend changes.
+
+### Fixed
+
 - **Code-review follow-ups on Fase 4 (CR-3, CR-4, M-1).** Three
   issues surfaced in the post-fase code review:
   * **Webhook replay was a self-DoS waiting to happen.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,6 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
-### Fixed
-
-- **PWA service-worker no longer requires a force-reload after a
-  release for routes like ``/manage``.** ``frontend/vite.config.js``
-  now sets ``workbox.skipWaiting: true`` and
-  ``workbox.clientsClaim: true``. The previous default kept the old
-  service worker active until every tab closed, so on a fresh deploy
-  operators would land on the SPA shell at ``/manage`` (a route that
-  is in the ``navigateFallbackDenylist`` of the new SW but was not
-  in the old one) until they hit Ctrl+Shift+R. Operators are
-  internal users — there's no consumer-side flow that the immediate
-  SW takeover would break — so claiming clients on activation is
-  the right tradeoff for an admin app.
-
 ### Removed
 
 - **Theme selector pulled from the ``/manage`` detail drawer.**
@@ -48,6 +34,21 @@ once a first tagged release ships.
   without further backend changes.
 
 ### Fixed
+
+- **PWA service-worker no longer requires a force-reload after a
+  release for routes like ``/manage``.** ``frontend/vite.config.js``
+  now sets ``workbox.skipWaiting: true`` and
+  ``workbox.clientsClaim: true``. The previous default kept the old
+  service worker active until every tab closed, so on a fresh deploy
+  operators would land on the SPA shell at ``/manage`` (a route that
+  is in the ``navigateFallbackDenylist`` of the new SW but was not
+  in the old one) until they hit Ctrl+Shift+R. Operators are
+  internal users — there's no consumer-side flow that the immediate
+  SW takeover would break — so claiming clients on activation is
+  the right tradeoff for an admin app. Same SW config also adds
+  ``/metrics`` to the ``navigateFallbackDenylist`` so manual
+  inspection from a browser with the PWA installed hits the
+  Prometheus exposition rather than the SPA shell.
 
 - **Code-review follow-ups on Fase 4 (CR-3, CR-4, M-1).** Three
   issues surfaced in the post-fase code review:

--- a/app/admin/static/overlays.html
+++ b/app/admin/static/overlays.html
@@ -458,24 +458,6 @@
       </section>
 
       <section class="drawer-section">
-        <h3>Theme</h3>
-        <p class="muted" style="margin: 0 0 0.5rem;">
-          Applies a preset theme to the overlay. The change reaches OBS
-          browser sources in real time via the broadcast hub.
-        </p>
-        <div class="field">
-          <label for="drawerTheme">Preset</label>
-          <select id="drawerTheme">
-            <option value="">— Keep current —</option>
-          </select>
-        </div>
-        <div id="drawerError" class="status error hidden"></div>
-        <div class="toolbar">
-          <button id="drawerApplyBtn" type="button">Apply theme</button>
-        </div>
-      </section>
-
-      <section class="drawer-section">
         <h3>Live usage</h3>
         <div id="drawerUsage" class="muted">Loading…</div>
       </section>
@@ -547,15 +529,11 @@
   const drawerCloseBtn = $('drawerCloseBtn');
   const drawerPreview = $('drawerPreview');
   const drawerOpenInTab = $('drawerOpenInTab');
-  const drawerTheme = $('drawerTheme');
-  const drawerError = $('drawerError');
-  const drawerApplyBtn = $('drawerApplyBtn');
   const drawerUsage = $('drawerUsage');
 
   let _filterText = '';
   const _selectedIds = new Set();
   let _drawerOverlay = null;
-  let _themesCache = null;
 
   function showStatus(text, kind) {
     statusMsg.textContent = text;
@@ -790,8 +768,8 @@
           <td data-label="OID"><code>${escapeHtml(o.oid)}</code></td>
           <td data-label="Output key"><code>${escapeHtml(o.output_key)}</code></td>
           <td class="actions">
-            <button class="secondary" data-action="edit"
-                    aria-label="Edit overlay ${escapeAttr(o.id)}">Edit</button>
+            <button class="secondary" data-action="info"
+                    aria-label="Show info for overlay ${escapeAttr(o.id)}">Info</button>
             <button class="secondary" data-action="copy"
                     aria-label="Copy overlay ${escapeAttr(o.id)}">Copy</button>
             <button class="danger" data-action="delete"
@@ -841,7 +819,7 @@
         const tr = btn.closest('tr');
         const id = tr.getAttribute('data-id');
         const overlay = cachedOverlays.find((o) => o.id === id);
-        if (btn.dataset.action === 'edit' && overlay) openDrawer(overlay, btn);
+        if (btn.dataset.action === 'info' && overlay) openDrawer(overlay, btn);
         if (btn.dataset.action === 'copy') openCreate(id, btn);
         if (btn.dataset.action === 'delete' && overlay) openDelete([overlay], btn);
       });
@@ -988,10 +966,16 @@
     }
   });
 
-  // ---- Drawer (M5) -------------------------------------------------------
+  // ---- Drawer ------------------------------------------------------------
+  // Inspect-only panel: live preview iframe + Live-usage counters.
+  // The theme selector that shipped in the original Fase 1 frontend was
+  // removed — see CHANGELOG: the colour keys it edited (set_bg, game_bg,
+  // set_text, game_text) are not consumed by any Jinja overlay template,
+  // so applying them was a silent no-op. The PATCH endpoint that backed
+  // the dropdown still works for ``preferred_style`` and is kept around
+  // for automation; the manager UI just no longer offers it.
 
   drawerCloseBtn.addEventListener('click', closeDrawer);
-  drawerApplyBtn.addEventListener('click', applyDrawerTheme);
   // ESC also closes the drawer when no modal is on top of it.
   document.addEventListener('keydown', (e) => {
     if (e.key !== 'Escape') return;
@@ -1002,7 +986,7 @@
     }
   });
 
-  async function openDrawer(overlay, opener) {
+  function openDrawer(overlay, opener) {
     _drawerOverlay = overlay;
     drawerTitle.textContent = overlay.id;
     // Re-point the iframe even when reopening on the same overlay so the
@@ -1012,14 +996,11 @@
       + '?style=mosaic';
     drawerPreview.src = previewUrl;
     drawerOpenInTab.href = '/overlay/' + encodeURIComponent(overlay.output_key);
-    clearError(drawerError);
     drawer.classList.add('open');
     drawer.removeAttribute('inert');
     drawer.setAttribute('aria-hidden', 'false');
     drawer._opener = opener || null;
     setTimeout(() => drawerCloseBtn.focus(), 30);
-    await loadDrawerThemes();
-    drawerTheme.value = '';  // start at "keep current" each time
     loadDrawerUsage(overlay.id);
   }
 
@@ -1033,26 +1014,6 @@
     drawer._opener = null;
     _drawerOverlay = null;
     if (opener && typeof opener.focus === 'function') opener.focus();
-  }
-
-  async function loadDrawerThemes() {
-    if (_themesCache) return _themesCache;
-    try {
-      // /api/themes is unauthenticated and returns {themes: [...]}.
-      const res = await fetch('/api/themes', { method: 'GET' });
-      if (!res.ok) throw new Error('Could not list themes (' + res.status + ').');
-      const body = await res.json();
-      _themesCache = Array.isArray(body && body.themes) ? body.themes : [];
-    } catch (err) {
-      _themesCache = [];
-      showError(drawerError, err.message || 'Could not load themes.');
-    }
-    // Rebuild the dropdown.
-    const opts = ['<option value="">— Keep current —</option>']
-      .concat(_themesCache.map((t) =>
-        `<option value="${escapeAttr(t)}">${escapeHtml(t)}</option>`));
-    drawerTheme.innerHTML = opts.join('');
-    return _themesCache;
   }
 
   async function loadDrawerUsage(overlayId) {
@@ -1086,38 +1047,6 @@
         '<p class="status error">'
         + escapeHtml(err.message || 'Could not load usage.')
         + '</p>';
-    }
-  }
-
-  async function applyDrawerTheme() {
-    const overlay = _drawerOverlay;
-    if (!overlay) return;
-    const theme = drawerTheme.value;
-    if (!theme) {
-      showError(drawerError, 'Pick a theme to apply, or close the drawer.');
-      return;
-    }
-    clearError(drawerError);
-    drawerApplyBtn.disabled = true;
-    try {
-      await apiCall(
-        'PATCH',
-        '/custom-overlays/' + encodeURIComponent(overlay.id),
-        { theme });
-      showStatus(`Theme “${theme}” applied.`, 'success');
-      // Bust the iframe cache so the operator sees the new theme right
-      // away — without this, the same URL would be served from cache and
-      // only the WebSocket-pushed state would refresh.
-      const u = new URL(drawerPreview.src, window.location.origin);
-      u.searchParams.set('t', String(Date.now()));
-      drawerPreview.src = u.pathname + u.search;
-      // Refresh the usage panel — the apply broadcast bumps last_activity.
-      loadDrawerUsage(overlay.id);
-    } catch (err) {
-      if (handleAuthError(err)) return;
-      showError(drawerError, err.message || 'Could not apply theme.');
-    } finally {
-      drawerApplyBtn.disabled = false;
     }
   }
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -97,7 +97,7 @@ export default defineConfig(async () => ({
         globPatterns: ['**/*.{js,css,html,svg,ttf,otf}'],
         navigateFallback: 'index.html',
         navigateFallbackDenylist: [
-          /^\/api/, /^\/fonts/, /^\/pwa/, /^\/health/,
+          /^\/api/, /^\/fonts/, /^\/pwa/, /^\/health/, /^\/metrics(\/|\?|$)/,
           /^\/overlay/, /^\/ws(\/|\?|$)/, /^\/static/,
           /^\/(create|delete|list|manage)(\/|\?|$)/,
           // Server-rendered match-history surfaces. Without these the SW

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -83,6 +83,17 @@ export default defineConfig(async () => ({
         ],
       },
       workbox: {
+        // Apply the new SW immediately on install and take control of
+        // every open client without waiting for tabs to close. The
+        // manager UI is operator-facing (no consumer flows that would
+        // break mid-action from a hot swap), and the previous
+        // wait-for-tab-close default meant operators had to force-reload
+        // /manage after every release before the new bundle's denylist
+        // and route surface took effect. Pair with
+        // ``registerType: 'autoUpdate'`` above so the SW upgrade is
+        // genuinely automatic rather than only-in-theory.
+        skipWaiting: true,
+        clientsClaim: true,
         globPatterns: ['**/*.{js,css,html,svg,ttf,otf}'],
         navigateFallback: 'index.html',
         navigateFallbackDenylist: [


### PR DESCRIPTION
## Summary

Two operator-reported issues after the Fase 1/4 deploy.

**1. PWA service-worker required force-reload to pick up `/manage`**
After a release the new SW (which has `/manage` in its denylist) was downloaded but kept dormant until every tab closed — so the first navigation kept hitting the old SW, which served the SPA shell instead of the manager page. Added `skipWaiting: true` + `clientsClaim: true` in `frontend/vite.config.js:workbox` so the new SW activates and claims open clients on install. `/manage` is operator-facing, no consumer-side flow that this would disrupt.

**2. Drawer's "Apply theme" dropdown was a silent no-op for half the catalogue**
Verified post-merge that the colour keys `set_bg` / `game_bg` / `set_text` / `game_text` written by `dark` / `light` are **not consumed by any Jinja template** in `overlay_templates/`. The four themes that visibly worked (`esports`, `neo_jersey`, `split_jersey`, `clear_jersey`) did so only because they also flip `preferredStyle`. Rather than ship a 1-in-3 hit rate UI:

- Theme selector + Apply-theme button removed from the drawer.
- Per-row button renamed **Edit → Info** to match the inspect-only behaviour.
- Drawer keeps the live preview iframe and the Live-usage panel exactly as before.
- Backend `PATCH /api/v1/admin/custom-overlays/{name}` is **kept** for automation (the `preferred_style` field still drives template selection at render time). `GET /api/themes` and `POST /api/theme/{id}/{name}` unchanged. A future iteration that wires those colour keys into the templates can re-introduce the selector with zero backend changes.

CHANGELOG entries added under `### Fixed` (PWA) and `### Removed` (theme dropdown), explaining the rollback so future readers don't go looking for the missing UI.

## Test plan

- [x] `pytest -q` — 961 passed (backend untouched).
- [x] `npm run lint` — only pre-existing warnings in `TeamPanel.tsx` / `useRecentEvents.ts`.
- [x] `npm run typecheck` — clean.
- [x] `npm run build` — regenerates `dist/sw.js` (41 precache entries, ~811 KiB) with the new config.
- [x] HTML sanity check: no stale references to `drawerTheme` / `drawerApplyBtn` / `drawerError` / `applyDrawerTheme` / `loadDrawerThemes` / `_themesCache` / `data-action="edit"` / `aria-label="Edit overlay"`; balanced `<div>` and `<section>` tags; new `data-action="info"` and `aria-label="Show info for overlay"` present.
- [ ] Manual smoke after deploy: navigate to `/manage` from an operator workstation that already has the PWA installed; the manager page should render on the first hard navigation (no force-reload required); the per-row **Info** button opens the drawer with preview + Live-usage; no "Apply theme" UI.

https://claude.ai/code/session_011soXxTGrLbGQu1qyPh8N2C

---
_Generated by [Claude Code](https://claude.ai/code/session_011soXxTGrLbGQu1qyPh8N2C)_