### PR TITLE
Configuration presets (replaces Fase 2 themes-editables) + /metrics SPA shadow fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,83 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Added
+
+- **Configuration presets — replaces the originally planned
+  Fase 2 (themes editables).** Operators can now save subsets of an
+  overlay's current state under a name and reapply them — to the
+  same overlay or any other — without going through the legacy
+  hardcoded ``PRESET_THEMES`` catalogue. Five scopes shipped:
+  * ``team_home`` / ``team_away`` — name, short name, primary /
+    secondary colors and logo URL. Live-match keys (``points``,
+    ``sets_won``, ``set_history``, ``serving``, ``timeouts_taken``)
+    are intentionally excluded so a preset apply can never
+    silently rewind a match.
+  * ``overlay_layout`` — ``overlay_control.geometry``.
+  * ``overlay_colors`` — ``overlay_control.colors`` (set_bg /
+    set_text / game_bg / game_text). These keys do reach the
+    rendered overlay end-to-end via
+    ``overlay_static/js/app.js:123-126`` — apologies for the earlier
+    rollout note that flagged them as no-op; the original PR #281
+    diagnosis missed the JavaScript layer that consumes them as CSS
+    custom properties (``--set-bg`` / ``--game-bg`` / etc.). Twelve
+    of the sixteen overlay templates render them.
+  * ``overlay_style`` — ``overlay_control.preferredStyle`` (which
+    Jinja template is served).
+
+  Storage lives at ``data/presets/preset_<sha20(slug)>.json`` —
+  same hex-only-basename pattern as overlay state, so a
+  user-supplied name never flows into a filesystem path.
+  ``PRESETS_MAX_NAME_LEN`` (default 80) and ``PRESETS_MAX_RECORDS``
+  (default 500) cap slug length and catalogue size; both override
+  via env. Duplicate slugs collide loudly on create (HTTP 409),
+  but on re-import they suffix ``-2``, ``-3``... up to ``-99`` so a
+  reimport of the same JSON does not silently overwrite the
+  catalogue.
+
+  Seven new admin endpoints under ``/api/v1/admin/presets``:
+  ``GET`` (list), ``POST`` (create from a source OID's state),
+  ``GET /{slug}`` (full record incl. snapshots), ``DELETE /{slug}``,
+  ``POST /{slug}/apply`` (target_oid + optional scope subset),
+  ``GET /{slug}/export`` (portable JSON), ``POST /import``
+  (round-trips ``export`` + tolerates unknown future scopes).
+
+  All apply paths coalesce: a single ``OverlayStateStore.update_state``
+  per request, regardless of how many scopes ride along. Same
+  one-write/one-broadcast invariant the M4 PATCH endpoint locked in.
+
+  Manager UI ships two new buttons in the Info drawer ("Save as
+  preset…" and "Apply preset…"), each backed by an a11y modal
+  reusing the existing focus trap / ESC dismissal / opener-restore
+  scaffolding. Save-modal pre-selects ``overlay_layout`` /
+  ``overlay_colors`` / ``overlay_style`` (the most common
+  "tournament template" combo); apply-modal pre-selects every
+  scope the chosen preset carries and greys out the ones it
+  doesn't.
+
+  Tests: 38 new in ``tests/test_presets.py`` covering scope
+  extract / apply / merge invariants, store CRUD with cap and
+  collision suffixing, the seven endpoints and an export →
+  import round-trip. ``team_home`` snapshot's no-leak guarantee
+  is pinned by name (``test_team_home_excludes_match_state``)
+  so a future scope edit cannot regress the live-match
+  protection. Full suite: 999 passed (was 961 + 38 new).
+
+### Fixed
+
+- **`/metrics` was being shadowed by the SPA catch-all when a
+  ``frontend/dist`` was present.** ``include_router(metrics_router)``
+  in ``app/bootstrap.py`` ran *after* ``_register_spa(application)``
+  so any deployment that ships a built frontend (i.e. production)
+  would see the SPA shell ``index.html`` returned for
+  ``GET /metrics`` instead of the Prometheus exposition. CI runs
+  built without the frontend and never tripped, but local +
+  production setups did. Same symptom class as the ``/manage``
+  bug fixed in PR #281: server-rendered route mounted after the
+  catch-all. Moved the include to ``_register_api_routes`` next
+  to admin / match-report so the metrics endpoint is reachable
+  before the SPA fallback inspects the path.
+
 ### Removed
 
 - **Theme selector pulled from the ``/manage`` detail drawer.**

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -92,6 +92,71 @@ class CustomOverlayPatch(BaseModel):
     )
 
 
+class PresetCreateRequest(BaseModel):
+    """Save the current state of a custom overlay as a named preset."""
+
+    name: str = Field(
+        ..., min_length=1, max_length=120,
+        description=(
+            "Human-readable preset name. The slug used in URLs and on "
+            "disk is derived from this value (lowercase ASCII + dashes). "
+            "Names that would slugify to an empty string are rejected."
+        ),
+    )
+    source_oid: str = Field(
+        ...,
+        description="Custom overlay id whose live state seeds the preset.",
+    )
+    scopes: list[str] = Field(
+        ..., min_length=1,
+        description=(
+            "Subset of the catalogue (``team_home``, ``team_away``, "
+            "``overlay_layout``, ``overlay_colors``, ``overlay_style``) "
+            "to capture. Scopes whose extractor returns an empty "
+            "snapshot for the source state are dropped silently — the "
+            "operator does not get a preset that no-ops on apply."
+        ),
+    )
+
+
+class PresetApplyRequest(BaseModel):
+    """Apply a preset to a target custom overlay."""
+
+    target_oid: str = Field(
+        ..., description="Custom overlay id to apply the preset to.",
+    )
+    scopes: list[str] | None = Field(
+        default=None,
+        description=(
+            "Optional subset of the preset's scopes to actually apply. "
+            "When omitted, every scope the preset carries is applied. "
+            "Useful for cases where the operator only wants the "
+            "``team_home`` half of a 'club presets' record."
+        ),
+    )
+
+
+class PresetImportRequest(BaseModel):
+    """Import a preset previously exported from this or another instance."""
+
+    payload: dict = Field(
+        ...,
+        description=(
+            "On-disk preset schema (with ``_meta``, ``scopes``, "
+            "``snapshots``). Slug collisions are resolved by suffixing "
+            "``-2``, ``-3``... up to ``-99``."
+        ),
+    )
+    name_override: str | None = Field(
+        default=None, max_length=120,
+        description=(
+            "When set, replaces the imported preset's ``_meta.name`` so "
+            "the operator can re-tag the entry on the way in (e.g. for "
+            "a per-tournament variant of a shared club preset)."
+        ),
+    )
+
+
 class CustomOverlayUsage(BaseModel):
     """Snapshot of how many live consumers a custom overlay has."""
 
@@ -561,6 +626,315 @@ async def replay_dead_letter_webhooks(
         "skipped_unknown_url": skipped,
         "remaining_in_dl": len(new_dl),
     }
+
+
+# ---------------------------------------------------------------------------
+# Configuration presets
+# ---------------------------------------------------------------------------
+#
+# Presets are global, scope-tagged snapshots of overlay state — see
+# ``app.api.preset_scopes`` for the catalogue and ``app.api.presets_store``
+# for the on-disk format. Endpoints share the same Bearer ``OVERLAY_MANAGER_PASSWORD``
+# auth ladder as the rest of ``/api/v1/admin/*``.
+
+
+def _preset_summary(record: dict) -> dict:
+    """Return the catalogue-level view of a preset (no snapshots payload)."""
+    meta = record.get("_meta") or {}
+    return {
+        "slug": meta.get("slug"),
+        "name": meta.get("name"),
+        "created_at": meta.get("created_at"),
+        "scopes": list(record.get("scopes") or []),
+    }
+
+
+@admin_router.get(
+    "/presets",
+    dependencies=[Depends(require_admin)],
+    summary="List configuration presets",
+)
+def list_presets():
+    """Return the catalogue of saved presets, ordered by name.
+
+    Snapshots are intentionally omitted from the list view to keep
+    response sizes bounded — fetch a specific preset with
+    ``GET /presets/{slug}`` to inspect its payload.
+    """
+    from app.api import presets_store
+    return [_preset_summary(r) for r in presets_store.list_all()]
+
+
+@admin_router.post(
+    "/presets",
+    dependencies=[Depends(require_admin)],
+    summary="Save the current state of a custom overlay as a preset",
+)
+def create_preset(payload: PresetCreateRequest):
+    """Capture the requested scopes from ``source_oid``'s live state.
+
+    Scopes whose extractor returns an empty dict are dropped from the
+    saved record so a preset never claims to cover a scope it actually
+    cannot replay (e.g. ``overlay_layout`` saved off an overlay that
+    never had a ``geometry`` set).
+    """
+    from app.api import preset_scopes, presets_store
+
+    source_oid = _validate_overlay_id(payload.source_oid)
+    store = _overlay_store()
+    if not store.overlay_exists(source_oid):
+        raise HTTPException(
+            status_code=404,
+            detail=f"Source overlay '{source_oid}' not found.",
+        )
+
+    unknown = [s for s in payload.scopes if not preset_scopes.is_known_scope(s)]
+    if unknown:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unknown scope(s): {unknown}. "
+                f"Known scopes: {list(preset_scopes.SCOPES)}"
+            ),
+        )
+
+    state = store.get_state(source_oid)
+    snapshots: dict[str, dict] = {}
+    for scope in payload.scopes:
+        snapshot = preset_scopes.extract(state, scope)
+        if snapshot:
+            snapshots[scope] = snapshot
+    if not snapshots:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Source overlay has nothing to save under the "
+                "requested scopes. Pick scopes whose data is set "
+                "on the source before saving."
+            ),
+        )
+
+    try:
+        record = presets_store.create(
+            name=payload.name,
+            scopes=list(snapshots.keys()),
+            snapshots=snapshots,
+        )
+    except presets_store.PresetExists:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"A preset with that name already exists "
+                f"(slug={presets_store.slugify(payload.name)}). "
+                "Pick a different name."
+            ),
+        ) from None
+    except presets_store.PresetCatalogueFull as exc:
+        raise HTTPException(status_code=507, detail=str(exc)) from None
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    return _preset_summary(record)
+
+
+@admin_router.get(
+    "/presets/{slug}",
+    dependencies=[Depends(require_admin)],
+    summary="Inspect a preset's snapshots",
+)
+def get_preset(slug: str):
+    """Return the full preset record (including ``snapshots``) for *slug*."""
+    from app.api import presets_store
+    try:
+        record = presets_store.read(slug)
+    except presets_store.PresetNotFound:
+        raise HTTPException(
+            status_code=404, detail=f"Preset '{slug}' not found.",
+        ) from None
+    return record
+
+
+@admin_router.delete(
+    "/presets/{slug}",
+    dependencies=[Depends(require_admin)],
+    summary="Delete a preset",
+)
+def delete_preset(slug: str):
+    from app.api import presets_store
+    if not presets_store.delete(slug):
+        raise HTTPException(
+            status_code=404, detail=f"Preset '{slug}' not found.",
+        )
+    return {"ok": True}
+
+
+@admin_router.post(
+    "/presets/{slug}/apply",
+    dependencies=[Depends(require_admin)],
+    summary="Apply a preset to a custom overlay",
+)
+async def apply_preset(slug: str, payload: PresetApplyRequest):
+    """Merge the preset's snapshots into ``target_oid``'s state.
+
+    The merge is coalesced: every selected scope contributes to a
+    single ``OverlayStateStore.update_state`` call so the operator
+    triggers exactly one disk write and one WebSocket broadcast,
+    regardless of how many scopes the preset covers.
+    """
+    from app.api import preset_scopes, presets_store
+
+    target_oid = _validate_overlay_id(payload.target_oid)
+    store = _overlay_store()
+    if not store.overlay_exists(target_oid):
+        raise HTTPException(
+            status_code=404,
+            detail=f"Target overlay '{target_oid}' not found.",
+        )
+
+    try:
+        record = presets_store.read(slug)
+    except presets_store.PresetNotFound:
+        raise HTTPException(
+            status_code=404, detail=f"Preset '{slug}' not found.",
+        ) from None
+
+    available = list(record.get("scopes") or [])
+    snapshots = record.get("snapshots") or {}
+
+    if payload.scopes is None:
+        scopes_to_apply = available
+    else:
+        unknown_in_preset = [s for s in payload.scopes if s not in available]
+        if unknown_in_preset:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Preset '{slug}' does not cover scope(s): "
+                    f"{unknown_in_preset}. Available: {available}"
+                ),
+            )
+        scopes_to_apply = list(payload.scopes)
+
+    payloads = []
+    applied: list[str] = []
+    for scope in scopes_to_apply:
+        snapshot = snapshots.get(scope)
+        if not snapshot:
+            continue
+        partial = preset_scopes.apply_payload(snapshot, scope)
+        if partial:
+            payloads.append(partial)
+            applied.append(scope)
+
+    if not payloads:
+        # Nothing actionable: every requested scope had an empty
+        # snapshot or unknown handler. Treat as a 400 so the caller
+        # sees "you asked us to no-op" rather than a misleading 200.
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Selected scopes carry no replayable snapshot data — "
+                "preset apply would be a no-op."
+            ),
+        )
+
+    merged = preset_scopes.merge_payloads(payloads)
+    await store.update_state(target_oid, merged)
+    logger.info(
+        "Preset slug=%s applied to overlay '%s' (scopes=%s)",
+        slug, target_oid, applied,
+    )
+    return {
+        "slug": slug,
+        "target_oid": target_oid,
+        "applied_scopes": applied,
+    }
+
+
+@admin_router.get(
+    "/presets/{slug}/export",
+    dependencies=[Depends(require_admin)],
+    summary="Export a preset as a portable JSON document",
+)
+def export_preset(slug: str):
+    """Return the on-disk preset schema for backup / cross-instance reuse.
+
+    The returned object round-trips through ``POST /presets/import`` —
+    the schema is identical to what's persisted on disk.
+    """
+    from app.api import presets_store
+    try:
+        return presets_store.export_payload(slug)
+    except presets_store.PresetNotFound:
+        raise HTTPException(
+            status_code=404, detail=f"Preset '{slug}' not found.",
+        ) from None
+
+
+@admin_router.post(
+    "/presets/import",
+    dependencies=[Depends(require_admin)],
+    summary="Import a preset from an exported JSON document",
+)
+def import_preset(payload: PresetImportRequest):
+    """Persist *payload* as a new preset.
+
+    Slug collisions are resolved by appending ``-2``, ``-3``... up to
+    ``-99`` so re-importing the same JSON does not overwrite the
+    existing entry. Unknown scopes inside the payload are stripped
+    silently — same forward-compatibility stance as overlay state
+    fields the consumer doesn't recognise.
+    """
+    from app.api import preset_scopes, presets_store
+
+    raw = payload.payload or {}
+    snapshots = raw.get("snapshots") or {}
+    scopes = raw.get("scopes") or []
+
+    # Filter out any scope the running deployment does not know about.
+    # Importing an "older" file that names a since-removed scope must
+    # not 400; we just skip the missing handlers.
+    known_snapshots = {
+        s: snap for s, snap in snapshots.items()
+        if preset_scopes.is_known_scope(s)
+    }
+    known_scopes = [s for s in scopes if preset_scopes.is_known_scope(s)]
+    if not known_snapshots:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Imported payload has no recognised scopes. "
+                f"Known scopes: {list(preset_scopes.SCOPES)}"
+            ),
+        )
+
+    cleaned = {
+        "_meta": raw.get("_meta") or {},
+        "scopes": known_scopes or list(known_snapshots.keys()),
+        "snapshots": known_snapshots,
+    }
+
+    try:
+        record = presets_store.import_payload(
+            cleaned, override_name=payload.name_override,
+        )
+    except presets_store.PresetExists as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Could not allocate a unique slug for the imported "
+                f"preset (collision base: {exc!s})."
+            ),
+        ) from None
+    except presets_store.PresetCatalogueFull as exc:
+        raise HTTPException(status_code=507, detail=str(exc)) from None
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    return _preset_summary(record)
+
+
+# ---------------------------------------------------------------------------
+# Custom overlay deletion
+# ---------------------------------------------------------------------------
 
 
 @admin_router.delete("/custom-overlays/{name}", dependencies=[Depends(require_admin)])

--- a/app/admin/static/overlays.html
+++ b/app/admin/static/overlays.html
@@ -227,6 +227,35 @@
     overflow-y: auto;
     padding: 1rem 1.25rem;
   }
+  .scope-fieldset {
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.5rem 0.75rem;
+    margin: 0 0 1rem;
+    min-width: 0;
+  }
+  .scope-fieldset legend {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--muted);
+    padding: 0 0.4rem;
+  }
+  .scope-fieldset[disabled] { opacity: 0.55; }
+  .scope-row {
+    display: flex;
+    gap: 0.55rem;
+    align-items: flex-start;
+    padding: 0.3rem 0;
+    font-size: 0.92rem;
+  }
+  .scope-row input[type="checkbox"] {
+    margin-top: 0.2rem;
+    flex-shrink: 0;
+  }
+  .scope-row label { color: var(--text); }
+  .scope-row label small { display: block; color: var(--muted); }
+
   .drawer-section { margin-bottom: 1.5rem; }
   .drawer-section h3 {
     margin: 0 0 0.5rem;
@@ -461,8 +490,88 @@
         <h3>Live usage</h3>
         <div id="drawerUsage" class="muted">Loading…</div>
       </section>
+
+      <section class="drawer-section">
+        <h3>Configuration presets</h3>
+        <p class="muted" style="margin: 0 0 0.5rem;">
+          Capture parts of this overlay's current configuration as a
+          named preset, or apply a previously-saved one. Presets are
+          shared across overlays — no preset is tied to a single OID.
+        </p>
+        <div class="toolbar" style="justify-content: flex-start;">
+          <button id="drawerSavePresetBtn" type="button">
+            Save as preset…
+          </button>
+          <button id="drawerApplyPresetBtn" type="button" class="secondary">
+            Apply preset…
+          </button>
+        </div>
+      </section>
     </div>
   </aside>
+
+  <!-- Save preset modal -->
+  <div id="savePresetModal" class="modal-backdrop hidden"
+       role="dialog" aria-modal="true"
+       aria-labelledby="savePresetTitle">
+    <div class="modal">
+      <h2 id="savePresetTitle">Save as preset</h2>
+      <p class="muted">
+        Picks the selected parts of this overlay's current
+        configuration and stores them under a new name. Live match
+        state (points, sets, history, serving, timeouts) is never
+        captured — presets are configuration only.
+      </p>
+      <div class="field">
+        <label for="presetName">Name</label>
+        <input type="text" id="presetName"
+               placeholder="e.g. Liga ACB - Final"
+               autocomplete="off" maxlength="120" />
+      </div>
+      <fieldset class="scope-fieldset" id="saveScopeFieldset">
+        <legend>Include</legend>
+      </fieldset>
+      <div id="savePresetError" class="status error hidden"></div>
+      <div class="toolbar">
+        <button type="button" id="savePresetCancelBtn"
+                class="secondary">Cancel</button>
+        <button type="button" id="savePresetConfirmBtn">Save preset</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Apply preset modal -->
+  <div id="applyPresetModal" class="modal-backdrop hidden"
+       role="dialog" aria-modal="true"
+       aria-labelledby="applyPresetTitle">
+    <div class="modal">
+      <h2 id="applyPresetTitle">Apply preset</h2>
+      <p class="muted">
+        Restores the selected scopes from the chosen preset onto
+        this overlay. Other state (live match data, scopes you don't
+        select below) stays untouched.
+      </p>
+      <div class="field">
+        <label for="presetPicker">Preset</label>
+        <select id="presetPicker">
+          <option value="">— Loading… —</option>
+        </select>
+      </div>
+      <fieldset class="scope-fieldset" id="applyScopeFieldset" disabled>
+        <legend>Apply scopes</legend>
+        <p class="muted" style="margin: 0;">
+          Pick a preset above to choose which scopes to restore.
+        </p>
+      </fieldset>
+      <div id="applyPresetError" class="status error hidden"></div>
+      <div class="toolbar">
+        <button type="button" id="applyPresetCancelBtn"
+                class="secondary">Cancel</button>
+        <button type="button" id="applyPresetConfirmBtn"
+                disabled>Apply preset</button>
+      </div>
+    </div>
+  </div>
 
   <!-- Delete confirmation modal -->
   <div id="deleteModal" class="modal-backdrop hidden"
@@ -530,6 +639,45 @@
   const drawerPreview = $('drawerPreview');
   const drawerOpenInTab = $('drawerOpenInTab');
   const drawerUsage = $('drawerUsage');
+  const drawerSavePresetBtn = $('drawerSavePresetBtn');
+  const drawerApplyPresetBtn = $('drawerApplyPresetBtn');
+  // Save preset modal
+  const savePresetModal = $('savePresetModal');
+  const presetName = $('presetName');
+  const saveScopeFieldset = $('saveScopeFieldset');
+  const savePresetError = $('savePresetError');
+  const savePresetCancelBtn = $('savePresetCancelBtn');
+  const savePresetConfirmBtn = $('savePresetConfirmBtn');
+  // Apply preset modal
+  const applyPresetModal = $('applyPresetModal');
+  const presetPicker = $('presetPicker');
+  const applyScopeFieldset = $('applyScopeFieldset');
+  const applyPresetError = $('applyPresetError');
+  const applyPresetCancelBtn = $('applyPresetCancelBtn');
+  const applyPresetConfirmBtn = $('applyPresetConfirmBtn');
+
+  // Hardcoded scope catalogue. Mirrors ``app.api.preset_scopes.SCOPES``;
+  // this is the only place the manager UI knows about scope IDs and
+  // labels. Adding a scope server-side here means re-syncing this list
+  // (or — TODO — sourcing it from a future ``GET /presets/scopes``
+  // endpoint when the catalogue grows past trivial size).
+  const _PRESET_SCOPES = [
+    { id: 'team_home',
+      label: 'Home team identity',
+      hint: 'name, short name, colors, logo_url' },
+    { id: 'team_away',
+      label: 'Away team identity',
+      hint: 'name, short name, colors, logo_url' },
+    { id: 'overlay_layout',
+      label: 'Overlay position and size',
+      hint: 'overlay_control.geometry (x, y, w, h)' },
+    { id: 'overlay_colors',
+      label: 'Overlay colors',
+      hint: 'set/game backgrounds and text colors' },
+    { id: 'overlay_style',
+      label: 'Overlay style',
+      hint: 'preferredStyle (which Jinja template is served)' },
+  ];
 
   let _filterText = '';
   const _selectedIds = new Set();
@@ -1047,6 +1195,216 @@
         '<p class="status error">'
         + escapeHtml(err.message || 'Could not load usage.')
         + '</p>';
+    }
+  }
+
+  // ---- Configuration presets --------------------------------------------
+  // Two flows: "Save as preset" captures parts of the current overlay
+  // state under a name (POST /presets); "Apply preset" pulls a saved
+  // record and merges the selected scopes onto the current overlay
+  // (POST /presets/{slug}/apply). Both share the same scope checkbox
+  // pattern via ``_renderScopeRows``.
+
+  drawerSavePresetBtn.addEventListener('click', () => {
+    if (!_drawerOverlay) return;
+    openSavePresetModal(drawerSavePresetBtn);
+  });
+  drawerApplyPresetBtn.addEventListener('click', () => {
+    if (!_drawerOverlay) return;
+    openApplyPresetModal(drawerApplyPresetBtn);
+  });
+
+  savePresetCancelBtn.addEventListener('click', () => closeModal(savePresetModal));
+  savePresetModal.addEventListener('click', (e) => {
+    if (e.target === savePresetModal) closeModal(savePresetModal);
+  });
+  savePresetConfirmBtn.addEventListener('click', performSavePreset);
+
+  applyPresetCancelBtn.addEventListener('click', () => closeModal(applyPresetModal));
+  applyPresetModal.addEventListener('click', (e) => {
+    if (e.target === applyPresetModal) closeModal(applyPresetModal);
+  });
+  applyPresetConfirmBtn.addEventListener('click', performApplyPreset);
+  presetPicker.addEventListener('change', onApplyPresetPicked);
+
+  function _renderScopeRows(container, options) {
+    // options: { allowedScopes (array|null), checkedScopes (array|null), idPrefix }
+    const allowed = options.allowedScopes;
+    const checked = new Set(options.checkedScopes || []);
+    const rows = _PRESET_SCOPES.map((scope) => {
+      const allowedHere = !allowed || allowed.includes(scope.id);
+      const id = options.idPrefix + scope.id;
+      return `
+        <div class="scope-row">
+          <input type="checkbox" id="${id}"
+                 data-scope-id="${escapeAttr(scope.id)}"
+                 ${checked.has(scope.id) ? 'checked' : ''}
+                 ${allowedHere ? '' : 'disabled'} />
+          <label for="${id}">
+            ${escapeHtml(scope.label)}
+            <small>${escapeHtml(scope.hint)}</small>
+          </label>
+        </div>`;
+    }).join('');
+    container.innerHTML = '<legend>'
+      + (options.legend || 'Scopes') + '</legend>' + rows;
+  }
+
+  function _readSelectedScopes(container) {
+    return Array.from(
+      container.querySelectorAll('input[type="checkbox"]:checked:not(:disabled)'),
+    ).map((cb) => cb.getAttribute('data-scope-id'));
+  }
+
+  function openSavePresetModal(opener) {
+    presetName.value = '';
+    clearError(savePresetError);
+    savePresetConfirmBtn.disabled = false;
+    // Default: pre-select the three scopes most commonly captured at
+    // the start of a tournament (overlay layout, colors, style). The
+    // operator can opt into team_* explicitly when the preset is
+    // intended as branding.
+    _renderScopeRows(saveScopeFieldset, {
+      legend: 'Include',
+      idPrefix: 'save-scope-',
+      checkedScopes: ['overlay_layout', 'overlay_colors', 'overlay_style'],
+    });
+    openModal(savePresetModal, opener, presetName);
+  }
+
+  async function performSavePreset() {
+    const overlay = _drawerOverlay;
+    if (!overlay) return;
+    clearError(savePresetError);
+    const name = (presetName.value || '').trim();
+    if (!name) {
+      showError(savePresetError, 'Name is required.');
+      return;
+    }
+    const scopes = _readSelectedScopes(saveScopeFieldset);
+    if (scopes.length === 0) {
+      showError(savePresetError, 'Pick at least one scope to save.');
+      return;
+    }
+    savePresetConfirmBtn.disabled = true;
+    try {
+      const body = await apiCall('POST', '/presets', {
+        name, source_oid: overlay.id, scopes,
+      });
+      closeModal(savePresetModal);
+      const skipped = scopes.length - (body.scopes || []).length;
+      const skippedHint = skipped > 0
+        ? ` (${skipped} scope${skipped === 1 ? '' : 's'} dropped — empty on this overlay)`
+        : '';
+      showStatus('Preset saved as “' + body.name + '”' + skippedHint + '.', 'success');
+    } catch (err) {
+      if (handleAuthError(err)) return;
+      showError(savePresetError, err.message || 'Could not save preset.');
+      savePresetConfirmBtn.disabled = false;
+    }
+  }
+
+  let _applyPresetCache = null;  // last full record fetched, keyed by slug
+  async function openApplyPresetModal(opener) {
+    clearError(applyPresetError);
+    applyScopeFieldset.disabled = true;
+    applyPresetConfirmBtn.disabled = true;
+    presetPicker.innerHTML = '<option value="">— Loading… —</option>';
+    applyScopeFieldset.innerHTML = `
+      <legend>Apply scopes</legend>
+      <p class="muted" style="margin: 0;">
+        Pick a preset above to choose which scopes to restore.
+      </p>`;
+    openModal(applyPresetModal, opener, presetPicker);
+    try {
+      const records = await apiCall('GET', '/presets');
+      const list = Array.isArray(records) ? records : [];
+      if (list.length === 0) {
+        presetPicker.innerHTML = '<option value="">— No presets saved yet —</option>';
+        applyPresetConfirmBtn.disabled = true;
+        return;
+      }
+      const opts = ['<option value="">— Pick one —</option>']
+        .concat(list.map((r) =>
+          `<option value="${escapeAttr(r.slug)}">${escapeHtml(r.name || r.slug)}</option>`));
+      presetPicker.innerHTML = opts.join('');
+      _applyPresetCache = null;
+    } catch (err) {
+      if (handleAuthError(err)) return;
+      presetPicker.innerHTML = '<option value="">— Error loading —</option>';
+      showError(applyPresetError, err.message || 'Could not load presets.');
+    }
+  }
+
+  async function onApplyPresetPicked() {
+    const slug = presetPicker.value;
+    clearError(applyPresetError);
+    if (!slug) {
+      applyScopeFieldset.disabled = true;
+      applyScopeFieldset.innerHTML = `
+        <legend>Apply scopes</legend>
+        <p class="muted" style="margin: 0;">
+          Pick a preset above to choose which scopes to restore.
+        </p>`;
+      applyPresetConfirmBtn.disabled = true;
+      return;
+    }
+    try {
+      const detail = await apiCall(
+        'GET', '/presets/' + encodeURIComponent(slug));
+      _applyPresetCache = detail;
+      const scopesIn = Array.isArray(detail.scopes) ? detail.scopes : [];
+      _renderScopeRows(applyScopeFieldset, {
+        legend: 'Apply scopes',
+        idPrefix: 'apply-scope-',
+        allowedScopes: scopesIn,   // greys out scopes the preset does not carry
+        checkedScopes: scopesIn,    // pre-select all available
+      });
+      applyScopeFieldset.disabled = false;
+      applyPresetConfirmBtn.disabled = false;
+    } catch (err) {
+      if (handleAuthError(err)) return;
+      showError(applyPresetError, err.message || 'Could not load preset.');
+      applyPresetConfirmBtn.disabled = true;
+    }
+  }
+
+  async function performApplyPreset() {
+    const overlay = _drawerOverlay;
+    if (!overlay) return;
+    const slug = presetPicker.value;
+    if (!slug) return;
+    clearError(applyPresetError);
+    const scopes = _readSelectedScopes(applyScopeFieldset);
+    if (scopes.length === 0) {
+      showError(applyPresetError, 'Pick at least one scope to apply.');
+      return;
+    }
+    applyPresetConfirmBtn.disabled = true;
+    try {
+      const body = await apiCall(
+        'POST', '/presets/' + encodeURIComponent(slug) + '/apply',
+        { target_oid: overlay.id, scopes });
+      closeModal(applyPresetModal);
+      const applied = body.applied_scopes || [];
+      showStatus(
+        applied.length === 1
+          ? 'Preset applied (1 scope restored).'
+          : `Preset applied (${applied.length} scopes restored).`,
+        'success');
+      // Bust the iframe cache so the operator sees the new look right
+      // away — same trick as the old apply-theme flow.
+      try {
+        const u = new URL(drawerPreview.src, window.location.origin);
+        u.searchParams.set('t', String(Date.now()));
+        drawerPreview.src = u.pathname + u.search;
+      } catch (_) { /* preview not loaded yet — ignore */ }
+      // Refresh usage panel; apply triggered a state-update broadcast.
+      loadDrawerUsage(overlay.id);
+    } catch (err) {
+      if (handleAuthError(err)) return;
+      showError(applyPresetError, err.message || 'Could not apply preset.');
+      applyPresetConfirmBtn.disabled = false;
     }
   }
 

--- a/app/api/preset_scopes.py
+++ b/app/api/preset_scopes.py
@@ -1,0 +1,210 @@
+"""Scope registry for the preset system.
+
+A "preset" is a named, on-disk subset of an overlay's state that the
+operator can save from one OID and replay on another. Each preset
+records which *scopes* it covers and a snapshot of the relevant state
+keys at save time. This module owns the contract between scope IDs
+and the state shape:
+
+* ``SCOPES`` — the public ordered list of scope IDs accepted at the
+  admin API surface. Anything outside this set is rejected with 400
+  before it reaches disk.
+* ``extract(state, scope_id)`` — pull the sub-state a scope cares
+  about out of an :class:`OverlayStateStore` snapshot.
+* ``apply_payload(snapshot, scope_id)`` — take a snapshot previously
+  produced by :func:`extract` and turn it into the partial dict that
+  ``OverlayStateStore.update_state`` deep-merges into the target.
+
+Keeping the two halves in this single module means a scope is added /
+renamed in exactly one place: register it in ``_SCOPE_HANDLERS`` and
+the create / apply / list endpoints inherit the change automatically.
+
+The intentional design omissions:
+
+* Match-state keys (``points``, ``sets_won``, ``set_history``,
+  ``serving``, ``timeouts_taken``, ``current_set``, ``match_started_at``)
+  are **never** copied — they describe the live game, not a reusable
+  configuration. Letting an operator restore them by accident would
+  silently rewind a real match.
+* ``raw_remote_model`` / ``raw_remote_customization`` are also
+  excluded; they are the overlays.uno passthrough payloads handled by
+  ``set_raw_config`` and live outside the preset model. Roundtripping
+  them is the job of the future overlay export/import (M10), not of
+  preset apply.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Scope handlers
+# ---------------------------------------------------------------------------
+
+
+def _extract_team(state: dict, slot: str) -> dict:
+    team = state.get(slot) or {}
+    # Only keep the identity-level keys; in particular skip points,
+    # sets_won, set_history, serving and timeouts_taken so a preset
+    # apply never overwrites a live match score.
+    return {
+        key: team.get(key)
+        for key in ("name", "short_name", "color_primary",
+                    "color_secondary", "logo_url")
+        if team.get(key) is not None
+    }
+
+
+def _apply_team(snapshot: dict, slot: str) -> dict:
+    if not snapshot:
+        return {}
+    return {slot: dict(snapshot)}
+
+
+def _extract_overlay_layout(state: dict) -> dict:
+    geometry = (state.get("overlay_control") or {}).get("geometry")
+    return {"geometry": dict(geometry)} if isinstance(geometry, dict) and geometry else {}
+
+
+def _apply_overlay_layout(snapshot: dict) -> dict:
+    geometry = snapshot.get("geometry")
+    if not isinstance(geometry, dict) or not geometry:
+        return {}
+    return {"overlay_control": {"geometry": dict(geometry)}}
+
+
+def _extract_overlay_colors(state: dict) -> dict:
+    colors = (state.get("overlay_control") or {}).get("colors")
+    return {"colors": dict(colors)} if isinstance(colors, dict) and colors else {}
+
+
+def _apply_overlay_colors(snapshot: dict) -> dict:
+    colors = snapshot.get("colors")
+    if not isinstance(colors, dict) or not colors:
+        return {}
+    return {"overlay_control": {"colors": dict(colors)}}
+
+
+def _extract_overlay_style(state: dict) -> dict:
+    ps = (state.get("overlay_control") or {}).get("preferredStyle")
+    return {"preferredStyle": ps} if isinstance(ps, str) and ps else {}
+
+
+def _apply_overlay_style(snapshot: dict) -> dict:
+    ps = snapshot.get("preferredStyle")
+    if not isinstance(ps, str) or not ps:
+        return {}
+    return {"overlay_control": {"preferredStyle": ps}}
+
+
+# Each entry maps scope_id → (extractor, applier, human_label).
+# ``human_label`` is what the manager UI renders next to the checkbox
+# so the source of truth for the label lives next to the implementation.
+_SCOPE_HANDLERS: dict[
+    str,
+    tuple[Callable[[dict], dict], Callable[[dict], dict], str],
+] = {
+    "team_home": (
+        lambda s: _extract_team(s, "team_home"),
+        lambda snap: _apply_team(snap, "team_home"),
+        "Home team identity (name, short name, colors, logo)",
+    ),
+    "team_away": (
+        lambda s: _extract_team(s, "team_away"),
+        lambda snap: _apply_team(snap, "team_away"),
+        "Away team identity (name, short name, colors, logo)",
+    ),
+    "overlay_layout": (
+        _extract_overlay_layout,
+        _apply_overlay_layout,
+        "Overlay position and size (geometry)",
+    ),
+    "overlay_colors": (
+        _extract_overlay_colors,
+        _apply_overlay_colors,
+        "Overlay colors (set/game backgrounds and text)",
+    ),
+    "overlay_style": (
+        _extract_overlay_style,
+        _apply_overlay_style,
+        "Overlay style (preferredStyle template)",
+    ),
+}
+
+
+# Public ordered list — the order is what the UI renders and what
+# sets the canonical column order in any future export format.
+SCOPES: tuple[str, ...] = tuple(_SCOPE_HANDLERS.keys())
+
+
+def is_known_scope(scope_id: str) -> bool:
+    return scope_id in _SCOPE_HANDLERS
+
+
+def scope_label(scope_id: str) -> str:
+    """Return the human-readable label for *scope_id*, or the id itself."""
+    handler = _SCOPE_HANDLERS.get(scope_id)
+    return handler[2] if handler else scope_id
+
+
+def list_scopes_with_labels() -> list[dict[str, str]]:
+    """Return ``[{id, label}, ...]`` for the manager UI to render."""
+    return [
+        {"id": scope_id, "label": handler[2]}
+        for scope_id, handler in _SCOPE_HANDLERS.items()
+    ]
+
+
+def extract(state: dict, scope_id: str) -> dict:
+    """Return the snapshot for *scope_id* drawn from *state*.
+
+    Empty dict signals "this OID has nothing to save under that
+    scope" — callers should drop the scope from the preset rather
+    than persisting an empty payload that would replay as a no-op.
+    """
+    handler = _SCOPE_HANDLERS.get(scope_id)
+    if handler is None:
+        return {}
+    return handler[0](state) or {}
+
+
+def apply_payload(snapshot: dict, scope_id: str) -> dict[str, Any]:
+    """Return the partial state ``update_state`` should deep-merge.
+
+    Empty dict means "the snapshot does not carry enough to actually
+    apply this scope" — the caller should skip it rather than firing
+    a redundant write.
+    """
+    handler = _SCOPE_HANDLERS.get(scope_id)
+    if handler is None:
+        return {}
+    return handler[1](snapshot or {}) or {}
+
+
+def merge_payloads(payloads: list[dict]) -> dict:
+    """Deep-merge a sequence of ``update_state`` payloads in order.
+
+    Later payloads win on conflicts. Used to fold the per-scope
+    payloads from :func:`apply_payload` into a single
+    ``update_state`` call so an apply triggers exactly one disk
+    write and one WebSocket broadcast — same coalescing rationale
+    as the ``patch_custom_overlay`` review fix.
+    """
+    merged: dict = {}
+    for payload in payloads:
+        _deep_merge(merged, payload)
+    return merged
+
+
+def _deep_merge(base: dict, overlay: dict) -> dict:
+    for key, value in overlay.items():
+        if (
+            key in base
+            and isinstance(base[key], dict)
+            and isinstance(value, dict)
+        ):
+            _deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base

--- a/app/api/presets_store.py
+++ b/app/api/presets_store.py
@@ -1,0 +1,326 @@
+"""On-disk catalogue for overlay configuration presets.
+
+A *preset* is a named, scope-tagged subset of an overlay's state that
+the operator saves once and applies anywhere. The catalogue is global
+(presets are not per-OID) so the same "Real Madrid as home" preset
+can be applied to any overlay that needs it.
+
+Files live at ``data/presets/preset_<sha256(slug)[:20]>.json``. The
+hex-only basename keeps user-supplied names from flowing into
+filesystem paths (same security pattern ``OverlayStateStore`` uses
+for overlay state). The original name plus the slug are recorded in
+the JSON payload's ``_meta`` block so listings and lookups can
+recover them.
+
+Concurrency: a single process-wide :class:`threading.RLock` guards
+every read and write. Presets are an admin surface — write rate is
+operator-keystroke, never hot-path — so the simpler global lock is
+preferable to the per-slug pool ``action_log`` uses for game events.
+
+All I/O is best-effort: filesystem failures are logged but never
+propagate, so a busted ``data/presets`` directory cannot wedge a
+live match by surfacing a 500 from the admin handler.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import tempfile
+import threading
+import time
+
+from app.constants import PRESETS_MAX_NAME_LEN, PRESETS_MAX_RECORDS
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Slug + filename helpers
+# ---------------------------------------------------------------------------
+
+# A slug is at most ``PRESETS_MAX_NAME_LEN`` characters of lowercase
+# alphanumerics plus dashes. The hash-based filename means the slug
+# never reaches the filesystem directly, but keeping it well-formed
+# helps the admin UI render legible URLs and JSON.
+_SLUG_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
+_FILENAME_HASH_LEN = 20
+_HASHED_FILENAME_PATTERN = re.compile(
+    r"^preset_[0-9a-f]{" + str(_FILENAME_HASH_LEN) + r"}\.json$",
+)
+
+
+def slugify(name: str) -> str:
+    """Return a filesystem-safe slug for *name*.
+
+    Lowercase ASCII alphanumerics plus dashes; runs of any other
+    character collapse to a single dash; leading and trailing dashes
+    trimmed; empty result raises ``ValueError`` so the caller surfaces
+    a 400 instead of writing an unaddressable preset. Length is
+    clamped to ``PRESETS_MAX_NAME_LEN`` to keep slugs manageable in
+    URLs and JSON.
+    """
+    if not isinstance(name, str):
+        raise ValueError("Preset name must be a string.")
+    # Lower + ASCII fold via NFKD would catch accented characters
+    # too, but the operator-facing audit trail benefits from keeping
+    # the original ``name`` separate from the slug. We just normalise
+    # what makes a valid filesystem-and-URL-safe identifier.
+    cleaned = re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-")
+    cleaned = cleaned[:max(1, PRESETS_MAX_NAME_LEN)]
+    if not cleaned or _SLUG_PATTERN.match(cleaned) is None:
+        raise ValueError(f"Cannot derive a valid slug from {name!r}.")
+    return cleaned
+
+
+def _data_dir() -> str:
+    """Return the on-disk preset directory."""
+    base = os.path.dirname(os.path.abspath(__file__))
+    return os.path.normpath(os.path.join(base, "..", "..", "data", "presets"))
+
+
+def _hashed_basename(slug: str) -> str:
+    digest = hashlib.sha256(slug.encode("utf-8")).hexdigest()[:_FILENAME_HASH_LEN]
+    return f"preset_{digest}.json"
+
+
+def _path(slug: str) -> str:
+    """Return the on-disk path for a preset *slug*. Caller must have validated."""
+    return os.path.join(_data_dir(), _hashed_basename(slug))
+
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+_lock = threading.RLock()
+
+
+def _validate_name(name: str) -> str:
+    if not isinstance(name, str):
+        raise ValueError("Preset name must be a string.")
+    name = name.strip()
+    if not name:
+        raise ValueError("Preset name is required.")
+    if len(name) > PRESETS_MAX_NAME_LEN:
+        raise ValueError(
+            f"Preset name exceeds {PRESETS_MAX_NAME_LEN} characters.",
+        )
+    return name
+
+
+def _serialize(preset: dict) -> bytes:
+    return (json.dumps(preset, ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def _write_atomic_locked(path: str, payload: dict) -> None:
+    """Tempfile + ``os.replace`` write while holding ``_lock``."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(_serialize(payload))
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_payload(path: str) -> dict | None:
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, encoding="utf-8") as f:
+            payload = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Skipping unreadable preset '%s': %s", path, exc)
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _build_record(
+    name: str, slug: str, scopes: list[str], snapshots: dict[str, dict],
+) -> dict:
+    return {
+        "_meta": {
+            "name": name,
+            "slug": slug,
+            "created_at": time.time(),
+        },
+        "scopes": list(scopes),
+        "snapshots": dict(snapshots),
+    }
+
+
+class PresetExists(Exception):
+    """A preset with the requested slug is already on disk."""
+
+
+class PresetNotFound(Exception):
+    """No preset matches the requested slug."""
+
+
+class PresetCatalogueFull(Exception):
+    """The catalogue would exceed ``PRESETS_MAX_RECORDS``."""
+
+
+def create(
+    name: str, scopes: list[str], snapshots: dict[str, dict],
+) -> dict:
+    """Persist a new preset and return the saved record.
+
+    Raises:
+      * ``ValueError`` for invalid names / unknown scopes.
+      * :class:`PresetExists` when the derived slug collides with an
+        existing preset (caller can offer a rename / overwrite).
+      * :class:`PresetCatalogueFull` when the catalogue is at its cap.
+    """
+    name = _validate_name(name)
+    slug = slugify(name)
+    path = _path(slug)
+    with _lock:
+        if os.path.exists(path):
+            raise PresetExists(slug)
+        # Cheap cap check — counts the directory once on create. The
+        # admin surface is low-volume; an O(n) listdir per save is
+        # fine and simpler than maintaining a counter.
+        if _count_locked() >= PRESETS_MAX_RECORDS:
+            raise PresetCatalogueFull(
+                f"Preset catalogue is full ({PRESETS_MAX_RECORDS} entries). "
+                f"Delete unused presets before saving more.",
+            )
+        record = _build_record(name, slug, scopes, snapshots)
+        _write_atomic_locked(path, record)
+    logger.info("Preset '%s' (slug=%s) created", name, slug)
+    return record
+
+
+def read(slug: str) -> dict:
+    """Return the preset record for *slug*. Raises :class:`PresetNotFound`."""
+    if _SLUG_PATTERN.match(slug) is None:
+        raise PresetNotFound(slug)
+    with _lock:
+        payload = _read_payload(_path(slug))
+    if payload is None:
+        raise PresetNotFound(slug)
+    return payload
+
+
+def delete(slug: str) -> bool:
+    """Remove a preset. Returns ``True`` when a file was removed."""
+    if _SLUG_PATTERN.match(slug) is None:
+        return False
+    with _lock:
+        path = _path(slug)
+        if not os.path.exists(path):
+            return False
+        try:
+            os.remove(path)
+        except OSError as exc:
+            logger.warning("Failed to delete preset '%s': %s", slug, exc)
+            return False
+    logger.info("Preset slug=%s deleted", slug)
+    return True
+
+
+def list_all() -> list[dict]:
+    """Return every preset record, ordered by name (case-insensitive)."""
+    with _lock:
+        records = list(_iter_payloads_locked())
+    records.sort(key=lambda r: (r.get("_meta", {}).get("name") or "").lower())
+    return records
+
+
+def import_payload(payload: dict, *, override_name: str | None = None) -> dict:
+    """Persist a preset record sourced from an external JSON document.
+
+    The payload must already be the on-disk schema produced by
+    :func:`create` or :func:`export_payload`. Slug collisions are
+    resolved by appending ``-2``, ``-3``... up to ``-99`` so reimport
+    of the same export does not silently overwrite the existing
+    catalogue entry. ``override_name`` (when supplied by the operator)
+    wins over whatever ``_meta.name`` carries — useful when the same
+    preset is imported as a variant.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError("Preset import payload must be a JSON object.")
+    snapshots = payload.get("snapshots") or {}
+    scopes = payload.get("scopes") or []
+    if not isinstance(snapshots, dict) or not isinstance(scopes, list):
+        raise ValueError("Preset payload is missing 'scopes' / 'snapshots'.")
+    name_source = override_name or payload.get("_meta", {}).get("name", "")
+    name = _validate_name(name_source)
+    base_slug = slugify(name)
+    slug = base_slug
+    suffix = 1
+    with _lock:
+        while os.path.exists(_path(slug)):
+            suffix += 1
+            if suffix > 99:
+                raise PresetExists(base_slug)
+            slug = f"{base_slug}-{suffix}"
+            # Re-validate the (longer) candidate slug; the suffix
+            # might push the original past ``MAX_NAME_LEN``.
+            if len(slug) > PRESETS_MAX_NAME_LEN:
+                raise ValueError(
+                    "Preset name too long to disambiguate on import.",
+                )
+        if _count_locked() >= PRESETS_MAX_RECORDS:
+            raise PresetCatalogueFull(
+                f"Preset catalogue is full ({PRESETS_MAX_RECORDS} entries).",
+            )
+        record = _build_record(name, slug, list(scopes), dict(snapshots))
+        _write_atomic_locked(_path(slug), record)
+    logger.info("Preset '%s' (slug=%s) imported", name, slug)
+    return record
+
+
+def export_payload(slug: str) -> dict:
+    """Return the on-disk record for *slug* as a portable JSON dict.
+
+    The returned dict is identical to what :func:`import_payload`
+    accepts — round-trip is guaranteed by sharing the schema.
+    """
+    return read(slug)
+
+
+def count() -> int:
+    """Return the current number of presets on disk."""
+    with _lock:
+        return _count_locked()
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _iter_payloads_locked():
+    directory = _data_dir()
+    if not os.path.isdir(directory):
+        return
+    for filename in os.listdir(directory):
+        if not _HASHED_FILENAME_PATTERN.fullmatch(filename):
+            continue
+        path = os.path.join(directory, filename)
+        payload = _read_payload(path)
+        if payload is None:
+            continue
+        yield payload
+
+
+def _count_locked() -> int:
+    n = 0
+    directory = _data_dir()
+    if not os.path.isdir(directory):
+        return 0
+    for filename in os.listdir(directory):
+        if _HASHED_FILENAME_PATTERN.fullmatch(filename):
+            n += 1
+    return n

--- a/app/api/presets_store.py
+++ b/app/api/presets_store.py
@@ -42,11 +42,14 @@ logger = logging.getLogger(__name__)
 # Slug + filename helpers
 # ---------------------------------------------------------------------------
 
-# A slug is at most ``PRESETS_MAX_NAME_LEN`` characters of lowercase
-# alphanumerics plus dashes. The hash-based filename means the slug
-# never reaches the filesystem directly, but keeping it well-formed
-# helps the admin UI render legible URLs and JSON.
-_SLUG_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
+# A slug is lowercase ASCII alphanumerics plus dashes, beginning and
+# ending with an alphanumeric. Length is **not** baked into the regex
+# on purpose: it's enforced by ``slugify`` against
+# ``PRESETS_MAX_NAME_LEN`` so changing the env-overridable cap does
+# not require also editing this pattern (and so the cap can grow above
+# the legacy 64-char ceiling without the regex silently rejecting
+# valid slugs).
+_SLUG_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
 _FILENAME_HASH_LEN = 20
 _HASHED_FILENAME_PATTERN = re.compile(
     r"^preset_[0-9a-f]{" + str(_FILENAME_HASH_LEN) + r"}\.json$",
@@ -69,8 +72,14 @@ def slugify(name: str) -> str:
     # too, but the operator-facing audit trail benefits from keeping
     # the original ``name`` separate from the slug. We just normalise
     # what makes a valid filesystem-and-URL-safe identifier.
-    cleaned = re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-")
-    cleaned = cleaned[:max(1, PRESETS_MAX_NAME_LEN)]
+    cleaned = re.sub(r"[^a-z0-9]+", "-", name.strip().lower())
+    # ``strip("-")`` runs *after* truncation so a name whose cut
+    # point falls inside a run of non-alphanumeric characters
+    # (which collapse to a single ``-``) does not yield a slug
+    # that ends in ``-`` and would otherwise be rejected by
+    # ``_SLUG_PATTERN`` with a misleading "cannot derive a valid
+    # slug" error.
+    cleaned = cleaned[:max(1, PRESETS_MAX_NAME_LEN)].strip("-")
     if not cleaned or _SLUG_PATTERN.match(cleaned) is None:
         raise ValueError(f"Cannot derive a valid slug from {name!r}.")
     return cleaned

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -190,6 +190,14 @@ def _register_api_routes(application: FastAPI) -> None:
     # Print-friendly per-match HTML report. Mounted before the SPA
     # catch-all so /match/{id}/report is served by FastAPI.
     application.include_router(match_report_router)
+    # Prometheus exposition. Must be registered before the SPA mount
+    # for the same reason as ``/manage`` and ``/match/{id}/report``:
+    # otherwise the SPA catch-all serves index.html for /metrics in
+    # any deployment that ships a built ``frontend/dist`` (i.e.
+    # production), turning the Prometheus scrape into "200 OK +
+    # text/html" — which is exactly the kind of silent-misconfig
+    # ``METRICS_REQUIRE_ADMIN`` should not be needed to detect.
+    application.include_router(metrics_router)
 
 
 def _register_overlay_routes(application: FastAPI) -> None:
@@ -469,7 +477,6 @@ def create_app() -> FastAPI:
     #           GZip           (compresses after headers are decided)
     #             RequestContext (populates contextvars for logging)
     #               ExceptionLogging (innermost — sees raw handler exceptions)
-    application.include_router(metrics_router)
     application.add_middleware(ExceptionLoggingMiddleware)
     # Metrics observes every HTTP request — keep it inside ExceptionLogging
     # (so handler exceptions still surface as 500 + log) but outside

--- a/app/constants.py
+++ b/app/constants.py
@@ -118,6 +118,13 @@ WEBHOOK_DEAD_LETTER_MAX_RECORDS = _env_int(
     "WEBHOOK_DEAD_LETTER_MAX_RECORDS", 1000,
 )
 
+# Preset catalogue caps. ``MAX_NAME_LEN`` keeps slugs to a
+# reasonable filesystem-friendly length; ``MAX_RECORDS`` is a
+# defensive limit on the global preset count so a buggy automation
+# script cannot fill the disk with files. Both override via env.
+PRESETS_MAX_NAME_LEN = _env_int("PRESETS_MAX_NAME_LEN", 80)
+PRESETS_MAX_RECORDS = _env_int("PRESETS_MAX_RECORDS", 500)
+
 # ``WSControlClient`` reconnect/heartbeat tuning. ``WS_ZOMBIE_DEADLINE``
 # must stay > 2 * ``WS_HEARTBEAT_INTERVAL`` so a single dropped pong
 # does not churn the connection.

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -741,6 +741,98 @@
         "title": "OverlayStateUpdate",
         "type": "object"
       },
+      "PresetApplyRequest": {
+        "description": "Apply a preset to a target custom overlay.",
+        "properties": {
+          "scopes": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional subset of the preset's scopes to actually apply. When omitted, every scope the preset carries is applied. Useful for cases where the operator only wants the ``team_home`` half of a 'club presets' record.",
+            "title": "Scopes"
+          },
+          "target_oid": {
+            "description": "Custom overlay id to apply the preset to.",
+            "title": "Target Oid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "target_oid"
+        ],
+        "title": "PresetApplyRequest",
+        "type": "object"
+      },
+      "PresetCreateRequest": {
+        "description": "Save the current state of a custom overlay as a named preset.",
+        "properties": {
+          "name": {
+            "description": "Human-readable preset name. The slug used in URLs and on disk is derived from this value (lowercase ASCII + dashes). Names that would slugify to an empty string are rejected.",
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "scopes": {
+            "description": "Subset of the catalogue (``team_home``, ``team_away``, ``overlay_layout``, ``overlay_colors``, ``overlay_style``) to capture. Scopes whose extractor returns an empty snapshot for the source state are dropped silently \u2014 the operator does not get a preset that no-ops on apply.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Scopes",
+            "type": "array"
+          },
+          "source_oid": {
+            "description": "Custom overlay id whose live state seeds the preset.",
+            "title": "Source Oid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "source_oid",
+          "scopes"
+        ],
+        "title": "PresetCreateRequest",
+        "type": "object"
+      },
+      "PresetImportRequest": {
+        "description": "Import a preset previously exported from this or another instance.",
+        "properties": {
+          "name_override": {
+            "anyOf": [
+              {
+                "maxLength": 120,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When set, replaces the imported preset's ``_meta.name`` so the operator can re-tag the entry on the way in (e.g. for a per-tournament variant of a shared club preset).",
+            "title": "Name Override"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "description": "On-disk preset schema (with ``_meta``, ``scopes``, ``snapshots``). Slug collisions are resolved by suffixing ``-2``, ``-3``... up to ``-99``.",
+            "title": "Payload",
+            "type": "object"
+          }
+        },
+        "required": [
+          "payload"
+        ],
+        "title": "PresetImportRequest",
+        "type": "object"
+      },
       "RawConfigPayload": {
         "additionalProperties": true,
         "properties": {
@@ -1822,6 +1914,354 @@
           }
         },
         "summary": "Mint a short-lived signed URL for a match report",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/v1/admin/presets": {
+      "get": {
+        "description": "Return the catalogue of saved presets, ordered by name.\n\nSnapshots are intentionally omitted from the list view to keep\nresponse sizes bounded \u2014 fetch a specific preset with\n``GET /presets/{slug}`` to inspect its payload.",
+        "operationId": "list_presets_api_v1_admin_presets_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List configuration presets",
+        "tags": [
+          "Admin"
+        ]
+      },
+      "post": {
+        "description": "Capture the requested scopes from ``source_oid``'s live state.\n\nScopes whose extractor returns an empty dict are dropped from the\nsaved record so a preset never claims to cover a scope it actually\ncannot replay (e.g. ``overlay_layout`` saved off an overlay that\nnever had a ``geometry`` set).",
+        "operationId": "create_preset_api_v1_admin_presets_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PresetCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Save the current state of a custom overlay as a preset",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/v1/admin/presets/import": {
+      "post": {
+        "description": "Persist *payload* as a new preset.\n\nSlug collisions are resolved by appending ``-2``, ``-3``... up to\n``-99`` so re-importing the same JSON does not overwrite the\nexisting entry. Unknown scopes inside the payload are stripped\nsilently \u2014 same forward-compatibility stance as overlay state\nfields the consumer doesn't recognise.",
+        "operationId": "import_preset_api_v1_admin_presets_import_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PresetImportRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Import a preset from an exported JSON document",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/v1/admin/presets/{slug}": {
+      "delete": {
+        "operationId": "delete_preset_api_v1_admin_presets__slug__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete a preset",
+        "tags": [
+          "Admin"
+        ]
+      },
+      "get": {
+        "description": "Return the full preset record (including ``snapshots``) for *slug*.",
+        "operationId": "get_preset_api_v1_admin_presets__slug__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Inspect a preset's snapshots",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/v1/admin/presets/{slug}/apply": {
+      "post": {
+        "description": "Merge the preset's snapshots into ``target_oid``'s state.\n\nThe merge is coalesced: every selected scope contributes to a\nsingle ``OverlayStateStore.update_state`` call so the operator\ntriggers exactly one disk write and one WebSocket broadcast,\nregardless of how many scopes the preset covers.",
+        "operationId": "apply_preset_api_v1_admin_presets__slug__apply_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PresetApplyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Apply a preset to a custom overlay",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/v1/admin/presets/{slug}/export": {
+      "get": {
+        "description": "Return the on-disk preset schema for backup / cross-instance reuse.\n\nThe returned object round-trips through ``POST /presets/import`` \u2014\nthe schema is identical to what's persisted on disk.",
+        "operationId": "export_preset_api_v1_admin_presets__slug__export_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Export a preset as a portable JSON document",
         "tags": [
           "Admin"
         ]

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -252,6 +252,134 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/presets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List configuration presets
+         * @description Return the catalogue of saved presets, ordered by name.
+         *
+         *     Snapshots are intentionally omitted from the list view to keep
+         *     response sizes bounded — fetch a specific preset with
+         *     ``GET /presets/{slug}`` to inspect its payload.
+         */
+        get: operations["list_presets_api_v1_admin_presets_get"];
+        put?: never;
+        /**
+         * Save the current state of a custom overlay as a preset
+         * @description Capture the requested scopes from ``source_oid``'s live state.
+         *
+         *     Scopes whose extractor returns an empty dict are dropped from the
+         *     saved record so a preset never claims to cover a scope it actually
+         *     cannot replay (e.g. ``overlay_layout`` saved off an overlay that
+         *     never had a ``geometry`` set).
+         */
+        post: operations["create_preset_api_v1_admin_presets_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/presets/import": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Import a preset from an exported JSON document
+         * @description Persist *payload* as a new preset.
+         *
+         *     Slug collisions are resolved by appending ``-2``, ``-3``... up to
+         *     ``-99`` so re-importing the same JSON does not overwrite the
+         *     existing entry. Unknown scopes inside the payload are stripped
+         *     silently — same forward-compatibility stance as overlay state
+         *     fields the consumer doesn't recognise.
+         */
+        post: operations["import_preset_api_v1_admin_presets_import_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/presets/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Inspect a preset's snapshots
+         * @description Return the full preset record (including ``snapshots``) for *slug*.
+         */
+        get: operations["get_preset_api_v1_admin_presets__slug__get"];
+        put?: never;
+        post?: never;
+        /** Delete a preset */
+        delete: operations["delete_preset_api_v1_admin_presets__slug__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/presets/{slug}/apply": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Apply a preset to a custom overlay
+         * @description Merge the preset's snapshots into ``target_oid``'s state.
+         *
+         *     The merge is coalesced: every selected scope contributes to a
+         *     single ``OverlayStateStore.update_state`` call so the operator
+         *     triggers exactly one disk write and one WebSocket broadcast,
+         *     regardless of how many scopes the preset covers.
+         */
+        post: operations["apply_preset_api_v1_admin_presets__slug__apply_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/presets/{slug}/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export a preset as a portable JSON document
+         * @description Return the on-disk preset schema for backup / cross-instance reuse.
+         *
+         *     The returned object round-trips through ``POST /presets/import`` —
+         *     the schema is identical to what's persisted on disk.
+         */
+        get: operations["export_preset_api_v1_admin_presets__slug__export_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/status": {
         parameters: {
             query?: never;
@@ -1371,6 +1499,61 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /**
+         * PresetApplyRequest
+         * @description Apply a preset to a target custom overlay.
+         */
+        PresetApplyRequest: {
+            /**
+             * Scopes
+             * @description Optional subset of the preset's scopes to actually apply. When omitted, every scope the preset carries is applied. Useful for cases where the operator only wants the ``team_home`` half of a 'club presets' record.
+             */
+            scopes?: string[] | null;
+            /**
+             * Target Oid
+             * @description Custom overlay id to apply the preset to.
+             */
+            target_oid: string;
+        };
+        /**
+         * PresetCreateRequest
+         * @description Save the current state of a custom overlay as a named preset.
+         */
+        PresetCreateRequest: {
+            /**
+             * Name
+             * @description Human-readable preset name. The slug used in URLs and on disk is derived from this value (lowercase ASCII + dashes). Names that would slugify to an empty string are rejected.
+             */
+            name: string;
+            /**
+             * Scopes
+             * @description Subset of the catalogue (``team_home``, ``team_away``, ``overlay_layout``, ``overlay_colors``, ``overlay_style``) to capture. Scopes whose extractor returns an empty snapshot for the source state are dropped silently — the operator does not get a preset that no-ops on apply.
+             */
+            scopes: string[];
+            /**
+             * Source Oid
+             * @description Custom overlay id whose live state seeds the preset.
+             */
+            source_oid: string;
+        };
+        /**
+         * PresetImportRequest
+         * @description Import a preset previously exported from this or another instance.
+         */
+        PresetImportRequest: {
+            /**
+             * Name Override
+             * @description When set, replaces the imported preset's ``_meta.name`` so the operator can re-tag the entry on the way in (e.g. for a per-tournament variant of a shared club preset).
+             */
+            name_override?: string | null;
+            /**
+             * Payload
+             * @description On-disk preset schema (with ``_meta``, ``scopes``, ``snapshots``). Slug collisions are resolved by suffixing ``-2``, ``-3``... up to ``-99``.
+             */
+            payload: {
+                [key: string]: unknown;
+            };
+        };
         /** RawConfigPayload */
         RawConfigPayload: {
             /** Customization */
@@ -1968,6 +2151,243 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MatchSignUrlResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_presets_api_v1_admin_presets_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_preset_api_v1_admin_presets_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PresetCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    import_preset_api_v1_admin_presets_import_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PresetImportRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_preset_api_v1_admin_presets__slug__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string;
+            };
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_preset_api_v1_admin_presets__slug__delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string;
+            };
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    apply_preset_api_v1_admin_presets__slug__apply_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string;
+            };
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PresetApplyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    export_preset_api_v1_admin_presets__slug__export_get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string;
+            };
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,567 @@
+"""Tests for the preset system (Fase 2 replacement).
+
+Covers three layers:
+
+* ``app.api.preset_scopes`` — extract/apply contracts per scope.
+* ``app.api.presets_store`` — disk CRUD + slug collisions + caps.
+* The admin HTTP endpoints — auth gates, create-from-OID, apply,
+  export round-trip, import-with-collision and apply-with-subset.
+"""
+
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.admin import admin_router
+from app.api import api_router, preset_scopes, presets_store
+from app.overlay import overlay_state_store
+
+ADMIN_PASSWORD = "s3cret"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state(tmp_path, monkeypatch):
+    """Point the overlay store and preset store at an isolated tmp dir.
+
+    Mirrors the pattern in ``test_admin.py``: overlay state files land
+    directly under ``tmp_path`` (the directory already exists, the
+    state store does not create it on demand), while the preset store
+    gets a child directory it owns end-to-end since it always calls
+    ``os.makedirs(..., exist_ok=True)`` before writing.
+    """
+    overlay_state_store._data_dir = str(tmp_path)
+    overlay_state_store._overlays = {}
+    overlay_state_store._output_key_cache = {}
+    overlay_state_store._available_styles = None
+    overlay_state_store._renderable_styles = None
+    monkeypatch.setattr(
+        presets_store, "_data_dir", lambda: str(tmp_path / "presets"),
+    )
+    monkeypatch.delenv("PREDEFINED_OVERLAYS", raising=False)
+    monkeypatch.delenv("OVERLAY_MANAGER_PASSWORD", raising=False)
+    yield
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("OVERLAY_MANAGER_PASSWORD", ADMIN_PASSWORD)
+    app = FastAPI()
+    app.include_router(admin_router)
+    app.include_router(api_router)
+    return TestClient(app)
+
+
+def _auth():
+    return {"Authorization": f"Bearer {ADMIN_PASSWORD}"}
+
+
+# ---------------------------------------------------------------------------
+# preset_scopes
+# ---------------------------------------------------------------------------
+
+
+class TestPresetScopes:
+    """The scope registry's contract is what the persistence builds on."""
+
+    SAMPLE_STATE = {
+        "team_home": {
+            "name": "Real Madrid",
+            "short_name": "RMA",
+            "color_primary": "#FFFFFF",
+            "color_secondary": "#FEC23E",
+            "logo_url": "https://example.com/rm.png",
+            # Live match keys — must NEVER leak into the snapshot:
+            "points": 7,
+            "sets_won": 2,
+            "set_history": {"set_1": 25, "set_2": 23},
+            "serving": True,
+            "timeouts_taken": 1,
+        },
+        "team_away": {
+            "name": "FC Barcelona",
+            "color_primary": "#A50044",
+        },
+        "overlay_control": {
+            "geometry": {"x": 10, "y": 20, "w": 1280, "h": 200},
+            "colors": {"set_bg": "#000", "game_text": "#FFF"},
+            "preferredStyle": "esports",
+            # Visibility flags — explicitly NOT in any scope:
+            "show_main_scoreboard": True,
+            "show_bottom_ticker": False,
+        },
+        "match_info": {"current_set": 3, "best_of_sets": 5},
+    }
+
+    def test_known_scopes_are_the_documented_five(self):
+        assert preset_scopes.SCOPES == (
+            "team_home", "team_away", "overlay_layout",
+            "overlay_colors", "overlay_style",
+        )
+
+    def test_team_home_excludes_match_state(self):
+        snap = preset_scopes.extract(self.SAMPLE_STATE, "team_home")
+        # Identity keys present:
+        assert snap["name"] == "Real Madrid"
+        assert snap["color_primary"] == "#FFFFFF"
+        # Live-match keys absent — protecting against accidental rewinds:
+        for forbidden in (
+            "points", "sets_won", "set_history", "serving", "timeouts_taken",
+        ):
+            assert forbidden not in snap, (
+                f"team_home snapshot leaked match key {forbidden!r}"
+            )
+
+    def test_team_away_extracts_only_present_keys(self):
+        # away has only 'name' and 'color_primary' set — extractor
+        # must drop the missing keys instead of writing None.
+        snap = preset_scopes.extract(self.SAMPLE_STATE, "team_away")
+        assert snap == {"name": "FC Barcelona", "color_primary": "#A50044"}
+
+    def test_overlay_layout_round_trip(self):
+        snap = preset_scopes.extract(self.SAMPLE_STATE, "overlay_layout")
+        assert snap == {"geometry": {"x": 10, "y": 20, "w": 1280, "h": 200}}
+        payload = preset_scopes.apply_payload(snap, "overlay_layout")
+        assert payload == {"overlay_control": {
+            "geometry": {"x": 10, "y": 20, "w": 1280, "h": 200},
+        }}
+
+    def test_overlay_colors_round_trip(self):
+        snap = preset_scopes.extract(self.SAMPLE_STATE, "overlay_colors")
+        payload = preset_scopes.apply_payload(snap, "overlay_colors")
+        assert payload == {"overlay_control": {
+            "colors": {"set_bg": "#000", "game_text": "#FFF"},
+        }}
+
+    def test_overlay_style_round_trip(self):
+        snap = preset_scopes.extract(self.SAMPLE_STATE, "overlay_style")
+        assert snap == {"preferredStyle": "esports"}
+        payload = preset_scopes.apply_payload(snap, "overlay_style")
+        assert payload == {"overlay_control": {"preferredStyle": "esports"}}
+
+    def test_unknown_scope_returns_empty(self):
+        assert preset_scopes.extract(self.SAMPLE_STATE, "ghost") == {}
+        assert preset_scopes.apply_payload({"x": 1}, "ghost") == {}
+        assert preset_scopes.is_known_scope("ghost") is False
+
+    def test_empty_extract_means_skip_on_apply(self):
+        # An overlay with no geometry set must produce an empty
+        # snapshot and an empty apply payload — the endpoint relies
+        # on this to drop scopes that would no-op.
+        empty_state = {"overlay_control": {}}
+        assert preset_scopes.extract(empty_state, "overlay_layout") == {}
+        assert preset_scopes.apply_payload({}, "overlay_layout") == {}
+
+    def test_merge_payloads_deep_merges(self):
+        a = preset_scopes.apply_payload(
+            preset_scopes.extract(self.SAMPLE_STATE, "overlay_colors"),
+            "overlay_colors",
+        )
+        b = preset_scopes.apply_payload(
+            preset_scopes.extract(self.SAMPLE_STATE, "overlay_style"),
+            "overlay_style",
+        )
+        merged = preset_scopes.merge_payloads([a, b])
+        # Both keys land under overlay_control without one wiping the
+        # other — that's the whole point of the deep merge:
+        assert merged["overlay_control"]["preferredStyle"] == "esports"
+        assert merged["overlay_control"]["colors"]["set_bg"] == "#000"
+
+
+# ---------------------------------------------------------------------------
+# presets_store
+# ---------------------------------------------------------------------------
+
+
+class TestPresetsStore:
+    def test_slugify_normalises_input(self):
+        assert presets_store.slugify("Real Madrid as Home") == "real-madrid-as-home"
+        assert presets_store.slugify("  ACB  Final  ") == "acb-final"
+        assert presets_store.slugify("name_with-dashes/slashes") == "name-with-dashes-slashes"
+
+    def test_slugify_rejects_invalid(self):
+        for bad in ("", "   ", "---", "!!!"):
+            with pytest.raises(ValueError):
+                presets_store.slugify(bad)
+
+    def test_create_persists_and_round_trips(self):
+        rec = presets_store.create(
+            name="Real Madrid as home",
+            scopes=["team_home"],
+            snapshots={"team_home": {"name": "Real Madrid"}},
+        )
+        assert rec["_meta"]["slug"] == "real-madrid-as-home"
+        assert rec["_meta"]["name"] == "Real Madrid as home"
+        # Round-trip:
+        read = presets_store.read("real-madrid-as-home")
+        assert read["snapshots"]["team_home"]["name"] == "Real Madrid"
+
+    def test_duplicate_slug_raises(self):
+        presets_store.create("Dup", ["team_home"], {"team_home": {"name": "x"}})
+        with pytest.raises(presets_store.PresetExists):
+            presets_store.create(
+                "Dup", ["team_home"], {"team_home": {"name": "y"}},
+            )
+
+    def test_delete_idempotent(self):
+        presets_store.create("Tmp", ["team_home"], {"team_home": {"name": "x"}})
+        assert presets_store.delete("tmp") is True
+        assert presets_store.delete("tmp") is False
+
+    def test_list_sorted_case_insensitive(self):
+        for n in ("Bravo", "alpha", "Charlie"):
+            presets_store.create(n, ["team_home"], {"team_home": {"name": n}})
+        names = [r["_meta"]["name"] for r in presets_store.list_all()]
+        assert names == ["alpha", "Bravo", "Charlie"]
+
+    def test_import_collision_appends_suffix(self):
+        original = presets_store.create(
+            "Same", ["team_home"], {"team_home": {"name": "x"}},
+        )
+        imported = presets_store.import_payload(original)
+        assert imported["_meta"]["slug"] == "same-2"
+        # Both are independently readable:
+        assert presets_store.read("same")["_meta"]["slug"] == "same"
+        assert presets_store.read("same-2")["_meta"]["slug"] == "same-2"
+
+    def test_import_with_override_name(self):
+        original = presets_store.create(
+            "Original", ["team_home"], {"team_home": {"name": "x"}},
+        )
+        imported = presets_store.import_payload(
+            original, override_name="Renamed copy",
+        )
+        assert imported["_meta"]["name"] == "Renamed copy"
+        assert imported["_meta"]["slug"] == "renamed-copy"
+
+    def test_catalogue_cap_rejects_overflow(self, monkeypatch):
+        monkeypatch.setattr(presets_store, "PRESETS_MAX_RECORDS", 2)
+        for n in ("a", "b"):
+            presets_store.create(n, ["team_home"], {"team_home": {"name": n}})
+        with pytest.raises(presets_store.PresetCatalogueFull):
+            presets_store.create(
+                "c", ["team_home"], {"team_home": {"name": "c"}},
+            )
+
+
+# ---------------------------------------------------------------------------
+# Admin endpoints
+# ---------------------------------------------------------------------------
+
+
+def _seed_overlay(client, name: str = "src", **state) -> str:
+    """Create a custom overlay and apply *state* via PATCH-equivalent."""
+    res = client.post(
+        "/api/v1/admin/custom-overlays",
+        json={"name": name}, headers=_auth(),
+    )
+    assert res.status_code == 200, res.text
+    if state:
+        # Use the state store directly — exercising a minimum dependency
+        # surface; the PATCH endpoint is tested elsewhere.
+        overlay_state_store.update_state_sync(name, state)
+    return name
+
+
+class TestPresetEndpointsAuth:
+    def test_list_requires_auth(self, client):
+        assert client.get("/api/v1/admin/presets").status_code == 401
+
+    def test_create_requires_auth(self, client):
+        res = client.post(
+            "/api/v1/admin/presets",
+            json={"name": "x", "source_oid": "y", "scopes": ["team_home"]},
+        )
+        assert res.status_code == 401
+
+    def test_apply_requires_auth(self, client):
+        res = client.post(
+            "/api/v1/admin/presets/anything/apply",
+            json={"target_oid": "x"},
+        )
+        assert res.status_code == 401
+
+
+class TestPresetCreate:
+    def test_create_from_overlay_state(self, client):
+        _seed_overlay(client, "src", team_home={
+            "name": "Real Madrid", "color_primary": "#FFF",
+        })
+        res = client.post(
+            "/api/v1/admin/presets",
+            json={
+                "name": "RM home",
+                "source_oid": "src",
+                "scopes": ["team_home"],
+            },
+            headers=_auth(),
+        )
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert body["slug"] == "rm-home"
+        assert body["scopes"] == ["team_home"]
+
+        detail = client.get(
+            "/api/v1/admin/presets/rm-home", headers=_auth(),
+        ).json()
+        assert detail["snapshots"]["team_home"]["name"] == "Real Madrid"
+        # color_primary was set on the source — must be in the snapshot:
+        assert detail["snapshots"]["team_home"]["color_primary"] == "#FFF"
+
+    def test_create_drops_empty_scopes(self, client):
+        # Source OID has no overlay_layout (geometry never set), so
+        # the saved record must drop overlay_layout from its scopes
+        # rather than persisting an empty snapshot.
+        _seed_overlay(client, "src", team_home={"name": "RM"})
+        res = client.post(
+            "/api/v1/admin/presets",
+            json={
+                "name": "RM with empty scope",
+                "source_oid": "src",
+                "scopes": ["team_home", "overlay_layout"],
+            },
+            headers=_auth(),
+        )
+        assert res.status_code == 200
+        assert res.json()["scopes"] == ["team_home"]
+
+    def test_create_with_only_empty_scopes_400(self, client):
+        _seed_overlay(client, "src")
+        res = client.post(
+            "/api/v1/admin/presets",
+            json={
+                "name": "Empty everything",
+                "source_oid": "src",
+                "scopes": ["overlay_layout"],
+            },
+            headers=_auth(),
+        )
+        assert res.status_code == 400
+        assert "nothing to save" in res.json()["detail"]
+
+    def test_unknown_scope_400(self, client):
+        _seed_overlay(client, "src")
+        res = client.post(
+            "/api/v1/admin/presets",
+            json={
+                "name": "Bad",
+                "source_oid": "src",
+                "scopes": ["team_home", "bogus"],
+            },
+            headers=_auth(),
+        )
+        assert res.status_code == 400
+
+    def test_unknown_source_oid_404(self, client):
+        res = client.post(
+            "/api/v1/admin/presets",
+            json={"name": "x", "source_oid": "ghost", "scopes": ["team_home"]},
+            headers=_auth(),
+        )
+        assert res.status_code == 404
+
+    def test_duplicate_slug_409(self, client):
+        _seed_overlay(client, "src", team_home={"name": "RM"})
+        client.post(
+            "/api/v1/admin/presets",
+            json={"name": "RM", "source_oid": "src", "scopes": ["team_home"]},
+            headers=_auth(),
+        )
+        res = client.post(
+            "/api/v1/admin/presets",
+            json={"name": "RM", "source_oid": "src", "scopes": ["team_home"]},
+            headers=_auth(),
+        )
+        assert res.status_code == 409
+
+
+class TestPresetApply:
+    def test_apply_full_preset(self, client):
+        _seed_overlay(client, "src", team_home={
+            "name": "Real Madrid", "color_primary": "#FFF",
+        }, overlay_control={"preferredStyle": "esports"})
+        client.post(
+            "/api/v1/admin/presets",
+            json={
+                "name": "RM full",
+                "source_oid": "src",
+                "scopes": ["team_home", "overlay_style"],
+            },
+            headers=_auth(),
+        )
+        # Brand new target overlay:
+        _seed_overlay(client, "dst")
+        res = client.post(
+            "/api/v1/admin/presets/rm-full/apply",
+            json={"target_oid": "dst"},
+            headers=_auth(),
+        )
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert set(body["applied_scopes"]) == {"team_home", "overlay_style"}
+        # State was actually merged into the target:
+        target_state = overlay_state_store.get_state("dst")
+        assert target_state["team_home"]["name"] == "Real Madrid"
+        assert target_state["overlay_control"]["preferredStyle"] == "esports"
+
+    def test_apply_subset_of_scopes(self, client):
+        _seed_overlay(client, "src", team_home={
+            "name": "Real Madrid",
+        }, overlay_control={"preferredStyle": "esports"})
+        client.post(
+            "/api/v1/admin/presets",
+            json={
+                "name": "RM full",
+                "source_oid": "src",
+                "scopes": ["team_home", "overlay_style"],
+            },
+            headers=_auth(),
+        )
+        _seed_overlay(client, "dst")
+        # Apply only team_home — overlay_style must NOT change on dst.
+        original_style = (
+            overlay_state_store.get_state("dst")
+            .get("overlay_control", {}).get("preferredStyle")
+        )
+        res = client.post(
+            "/api/v1/admin/presets/rm-full/apply",
+            json={"target_oid": "dst", "scopes": ["team_home"]},
+            headers=_auth(),
+        )
+        assert res.status_code == 200
+        assert res.json()["applied_scopes"] == ["team_home"]
+        target_state = overlay_state_store.get_state("dst")
+        assert target_state["team_home"]["name"] == "Real Madrid"
+        # The other scope did not flow through:
+        assert (
+            target_state.get("overlay_control", {}).get("preferredStyle")
+            == original_style
+        )
+
+    def test_apply_unknown_target_404(self, client):
+        _seed_overlay(client, "src", team_home={"name": "RM"})
+        client.post(
+            "/api/v1/admin/presets",
+            json={"name": "x", "source_oid": "src", "scopes": ["team_home"]},
+            headers=_auth(),
+        )
+        res = client.post(
+            "/api/v1/admin/presets/x/apply",
+            json={"target_oid": "ghost"},
+            headers=_auth(),
+        )
+        assert res.status_code == 404
+
+    def test_apply_unknown_preset_404(self, client):
+        _seed_overlay(client, "dst")
+        res = client.post(
+            "/api/v1/admin/presets/no-such/apply",
+            json={"target_oid": "dst"},
+            headers=_auth(),
+        )
+        assert res.status_code == 404
+
+    def test_apply_scope_not_in_preset_400(self, client):
+        _seed_overlay(client, "src", team_home={"name": "RM"})
+        client.post(
+            "/api/v1/admin/presets",
+            json={"name": "small", "source_oid": "src", "scopes": ["team_home"]},
+            headers=_auth(),
+        )
+        _seed_overlay(client, "dst")
+        res = client.post(
+            "/api/v1/admin/presets/small/apply",
+            json={"target_oid": "dst", "scopes": ["overlay_style"]},
+            headers=_auth(),
+        )
+        assert res.status_code == 400
+        assert "does not cover" in res.json()["detail"]
+
+
+class TestPresetExportImport:
+    def test_export_then_import_round_trip(self, client):
+        _seed_overlay(client, "src", team_home={"name": "RM"})
+        client.post(
+            "/api/v1/admin/presets",
+            json={"name": "RM", "source_oid": "src", "scopes": ["team_home"]},
+            headers=_auth(),
+        )
+        export = client.get(
+            "/api/v1/admin/presets/rm/export", headers=_auth(),
+        )
+        assert export.status_code == 200
+        payload = export.json()
+        # Round-trip through import — collision suffix bumps the slug.
+        imported = client.post(
+            "/api/v1/admin/presets/import",
+            json={"payload": payload},
+            headers=_auth(),
+        )
+        assert imported.status_code == 200
+        assert imported.json()["slug"] == "rm-2"
+
+    def test_import_strips_unknown_scopes(self, client):
+        # Future-compat: a payload from a newer build that names a
+        # scope this build doesn't know about must import cleanly,
+        # dropping the unknown scope, instead of 400ing.
+        body = {
+            "_meta": {"name": "Future", "slug": "future"},
+            "scopes": ["team_home", "future_scope"],
+            "snapshots": {
+                "team_home": {"name": "RM"},
+                "future_scope": {"x": 1},
+            },
+        }
+        imported = client.post(
+            "/api/v1/admin/presets/import",
+            json={"payload": body},
+            headers=_auth(),
+        )
+        assert imported.status_code == 200
+        assert imported.json()["scopes"] == ["team_home"]
+
+    def test_import_with_only_unknown_scopes_400(self, client):
+        body = {
+            "_meta": {"name": "Future"},
+            "scopes": ["future_scope"],
+            "snapshots": {"future_scope": {"x": 1}},
+        }
+        res = client.post(
+            "/api/v1/admin/presets/import",
+            json={"payload": body},
+            headers=_auth(),
+        )
+        assert res.status_code == 400
+
+
+class TestPresetList:
+    def test_list_returns_summaries_without_snapshots(self, client):
+        _seed_overlay(client, "src", team_home={"name": "RM"})
+        client.post(
+            "/api/v1/admin/presets",
+            json={"name": "Alpha", "source_oid": "src", "scopes": ["team_home"]},
+            headers=_auth(),
+        )
+        res = client.get("/api/v1/admin/presets", headers=_auth())
+        assert res.status_code == 200
+        body = res.json()
+        assert len(body) == 1
+        # ``snapshots`` must not bloat the catalogue listing:
+        assert "snapshots" not in body[0]
+        assert body[0]["slug"] == "alpha"
+
+    def test_delete_removes_from_listing(self, client):
+        _seed_overlay(client, "src", team_home={"name": "RM"})
+        client.post(
+            "/api/v1/admin/presets",
+            json={"name": "Doomed", "source_oid": "src", "scopes": ["team_home"]},
+            headers=_auth(),
+        )
+        res = client.delete("/api/v1/admin/presets/doomed", headers=_auth())
+        assert res.status_code == 200
+        listing = client.get("/api/v1/admin/presets", headers=_auth()).json()
+        assert listing == []
+
+    def test_delete_unknown_404(self, client):
+        res = client.delete("/api/v1/admin/presets/ghost", headers=_auth())
+        assert res.status_code == 404

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -184,6 +184,36 @@ class TestPresetsStore:
             with pytest.raises(ValueError):
                 presets_store.slugify(bad)
 
+    def test_slugify_strips_trailing_dash_after_truncation(self, monkeypatch):
+        # Cut-point lands inside a run of non-alphanumerics that the
+        # initial sub() already collapsed to ``-``. Without the
+        # post-truncation ``rstrip("-")`` the slug would end in ``-``
+        # and the validator would reject it with a misleading
+        # "cannot derive" error instead of the silent-trim that the
+        # operator expects when their name is over the cap.
+        monkeypatch.setattr(presets_store, "PRESETS_MAX_NAME_LEN", 9)
+        # "Real Madrid" → "real-madrid"; truncated to 9 → "real-madr"
+        # (cleanly cut). Pick a name whose 9-char prefix ends in a
+        # collapsed dash to exercise the strip:
+        name = "Real M  drid"  # double-space → "-" → "real-m--drid"
+        # Actually re.sub collapses any run of non-alnum to a single
+        # "-", so "Real M  drid" → "real-m-drid". Truncate to 7 →
+        # "real-m-" (trailing dash). ``[:7].strip("-")`` → "real-m".
+        monkeypatch.setattr(presets_store, "PRESETS_MAX_NAME_LEN", 7)
+        slug = presets_store.slugify(name)
+        assert slug == "real-m", slug
+        assert presets_store._SLUG_PATTERN.match(slug)
+
+    def test_slugify_respects_configured_max_above_default(self, monkeypatch):
+        # The legacy regex hardcoded a 64-char ceiling. After the
+        # decoupling fix, raising PRESETS_MAX_NAME_LEN to 100 must
+        # let a 90-char slug through without the regex rejecting it.
+        monkeypatch.setattr(presets_store, "PRESETS_MAX_NAME_LEN", 100)
+        name = "a" * 90
+        slug = presets_store.slugify(name)
+        assert len(slug) == 90
+        assert presets_store._SLUG_PATTERN.match(slug)
+
     def test_create_persists_and_round_trips(self):
         rec = presets_store.create(
             name="Real Madrid as home",


### PR DESCRIPTION
## Summary

Replaces the originally-planned **Fase 2 (themes editables)** with a more useful primitive: **named, scope-tagged on-disk snapshots of overlay configuration** that operators save once and replay anywhere.

3 commits:

1. **`40e090f` — backend feature.** Scope registry + on-disk store + 7 admin endpoints + 38 tests.
2. **`272e090` — bootstrap fix for `/metrics`.** Self-introduced bug in `e58d4ae` (M15): `include_router(metrics_router)` ran *after* the SPA catch-all so any deployment shipping a built `frontend/dist` returned the SPA shell for `GET /metrics` instead of the Prometheus exposition. CI never tripped because it skips the frontend build. Same class as the `/manage` shadow fixed in PR #281.
3. **`7d9fa8c` — manager UI + schema + CHANGELOG.**

## Backend — what's new

**Scope catalogue (`app/api/preset_scopes.py`):**

| Scope | What it captures | Notes |
|---|---|---|
| `team_home` / `team_away` | name, short_name, color_primary, color_secondary, logo_url | **Live-match keys (`points`, `sets_won`, `set_history`, `serving`, `timeouts_taken`) are explicitly excluded.** A test pins this by name. |
| `overlay_layout` | `overlay_control.geometry` (x/y/w/h) | |
| `overlay_colors` | `overlay_control.colors` (`set_bg`/`set_text`/`game_bg`/`game_text`) | **Note:** these *do* render end-to-end via `overlay_static/js/app.js:123-126` (12/16 templates use them as `--set-bg`/`--game-bg` CSS vars). My PR #281 rollout note that flagged them as no-op was wrong; corrected in CHANGELOG. |
| `overlay_style` | `overlay_control.preferredStyle` | |

**Storage (`app/api/presets_store.py`):**
- `data/presets/preset_<sha20(slug)>.json` — same hex-only-basename pattern as `OverlayStateStore` (user-supplied names never reach filesystem paths).
- Atomic tempfile + `os.replace` rewrites under a single `threading.RLock`.
- `PRESETS_MAX_NAME_LEN` (80), `PRESETS_MAX_RECORDS` (500), env-overridable.
- Slug collisions: HTTP 409 on create; `-2`/`-3`/.../`-99` suffix on import (so re-importing the same JSON doesn't silently overwrite).

**Endpoints (`app/admin/routes.py`, all gated by `OVERLAY_MANAGER_PASSWORD`):**

```
GET    /api/v1/admin/presets              List catalogue summaries (no snapshots)
POST   /api/v1/admin/presets              Create from source_oid + scopes
GET    /api/v1/admin/presets/{slug}       Full record incl. snapshots
DELETE /api/v1/admin/presets/{slug}       Remove
POST   /api/v1/admin/presets/{slug}/apply Apply to target_oid (optional scope subset)
GET    /api/v1/admin/presets/{slug}/export  Portable JSON
POST   /api/v1/admin/presets/import        Tolerates unknown scopes (forward-compat)
```

Apply paths coalesce: a single `update_state` per request regardless of scope count → one disk write, one WS broadcast (same one-write/one-broadcast invariant as the M4 PATCH).

## Frontend — what's new

Two new buttons in the Info drawer:

- **`Save as preset…`** — name input + 5 scope checkboxes. Defaults: `overlay_layout` + `overlay_colors` + `overlay_style` pre-ticked (the "tournament template" combo); team_* off by default (typically branding presets saved on their own).
- **`Apply preset…`** — dropdown populated from `GET /presets` on open. Selecting a preset rebuilds the scope checklist with only the scopes the preset carries enabled. Pre-selects every available scope. Successful apply busts the iframe preview cache and refreshes the Live-usage panel.

Both modals reuse the existing focus trap / ESC / opener-restore scaffolding.

## Test plan

- [x] `pytest -q` — **999 passed** (was 961 + 38 new in `tests/test_presets.py`).
- [x] `ruff check` clean on every Python file touched.
- [x] Frontend `npm run lint` (only pre-existing warnings in `TeamPanel.tsx`/`useRecentEvents.ts`), `npm run typecheck` clean, `npm run test:coverage` 27/27 files / 328 tests.
- [x] HTML sanity-check on `overlays.html` (balanced `<div>`/`<aside>`/`<section>`, no `window.confirm`).
- [x] OpenAPI schema + `schema.d.ts` regenerated; the `gen:types` CI gate would have failed otherwise.
- [ ] Manual smoke pending — flow: save Real Madrid as `team_home` from one OID, apply to a fresh OID, verify name/color land. Then apply with subset (only `overlay_style`) and confirm `team_home` doesn't change. Then export → re-import (slug should suffix `-2`).
- [ ] Verify `/metrics` actually returns `text/plain` against the production `:dev` image after merge (the bootstrap fix lands here).

## Notable design decisions

- **`overlay_colors` is included in the catalogue** even though my PR #281 rolled back the theme dropdown citing them as no-op. That diagnosis was wrong: I missed the JavaScript layer in `app.js:123-126` that consumes them as CSS custom properties. CHANGELOG carries the correction explicitly. Apologies for the bouncing.
- **No `match_metadata` / `match_rules` / `overlay_visibility` scopes.** Operator decision; can be added by registering more handlers in `_SCOPE_HANDLERS` without touching endpoints, storage, or schema.
- **Forward-compat on import:** unknown scope IDs in an imported payload are stripped silently, matching the overlay state pattern. A payload from a future build with extra scopes still imports cleanly under the current scope set.
- **Slug collisions on `create` fail loudly (409); on `import` they suffix.** Different intents — create is "new save", import is "round-trip a JSON I already have".

https://claude.ai/code/session_011soXxTGrLbGQu1qyPh8N2C

---
_Generated by [Claude Code](https://claude.ai/code/session_011soXxTGrLbGQu1qyPh8N2C)_