### PR TITLE
fix(metrics,admin): bound /metrics route cardinality + drop private-attr access

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -520,9 +520,9 @@ def get_custom_overlay_usage(name: str):
     from app.overlay import obs_broadcast_hub
 
     obs_count = obs_broadcast_hub.get_client_count(name)
-    frontend_count = len(WSHub._connections.get(name, set()))
+    frontend_count = WSHub.connection_count(name)
 
-    session = SessionManager._sessions.get(name)
+    session = SessionManager.peek(name)
     has_session = session is not None
     seconds_since: int | None = None
     if session is not None:

--- a/app/api/middleware/metrics.py
+++ b/app/api/middleware/metrics.py
@@ -45,9 +45,7 @@ class MetricsMiddleware:
             # bucket under ``unmatched`` to keep the label cardinality
             # bounded even on a hostile probe storm.
             route_obj = scope.get("route")
-            route = "unmatched"
-            if route_obj is not None:
-                route = getattr(route_obj, "path", "unmatched")
+            route = getattr(route_obj, "path", None) or "unmatched"
             method = scope.get("method", "UNKNOWN")
             http_request_duration_seconds.labels(
                 route=route,

--- a/app/api/middleware/metrics.py
+++ b/app/api/middleware/metrics.py
@@ -45,10 +45,9 @@ class MetricsMiddleware:
             # bucket under ``unmatched`` to keep the label cardinality
             # bounded even on a hostile probe storm.
             route_obj = scope.get("route")
-            route = (
-                getattr(route_obj, "path", None)
-                or scope.get("path", "unmatched")
-            )
+            route = "unmatched"
+            if route_obj is not None:
+                route = getattr(route_obj, "path", "unmatched")
             method = scope.get("method", "UNKNOWN")
             http_request_duration_seconds.labels(
                 route=route,

--- a/app/api/session_manager.py
+++ b/app/api/session_manager.py
@@ -238,6 +238,16 @@ class SessionManager:
             return session
 
     @classmethod
+    def peek(cls, oid):
+        """Return an existing session without bumping ``last_accessed``.
+
+        Used by inspect-only paths (admin usage endpoint) that need to
+        report liveness without resetting the eviction TTL.
+        """
+        with cls._lock:
+            return cls._sessions.get(oid)
+
+    @classmethod
     def remove(cls, oid):
         """Remove a session (e.g. on disconnect)."""
         with cls._lock:

--- a/app/api/ws_hub.py
+++ b/app/api/ws_hub.py
@@ -94,6 +94,11 @@ class WSHub:
             oid, len(cls._connections[oid]))
 
     @classmethod
+    def connection_count(cls, oid: str) -> int:
+        """Return the number of frontend WS clients subscribed to *oid*."""
+        return len(cls._connections.get(oid, ()))
+
+    @classmethod
     def mark_active(cls, ws: WebSocket) -> None:
         """Record that *ws* sent or received traffic just now.
 


### PR DESCRIPTION
## Summary

Two follow-ups on the gemini-code-assist review of #284. Once merged, #284 picks them up automatically.

### `app/api/middleware/metrics.py`
`MetricsMiddleware` no longer falls through to `scope['path']` for unmatched routes. A scanner walking 404s would otherwise spawn a new `http_request_duration_seconds` series per unique URL — unbounded label cardinality. All un-routed requests now bucket under the fixed `"unmatched"` label.

### `app/admin/routes.py` — drop private-attribute access
- `WSHub._connections.get(name, set())` → `WSHub.connection_count(name)` (new public classmethod).
- `SessionManager._sessions.get(name)` → `SessionManager.peek(name)` (new no-touch counterpart to `get` so the inspect-only endpoint doesn't bump `last_accessed` and reset the eviction TTL).

## Test plan
- [x] `pytest tests/` → 1001 passed
- [x] `ruff check` clean on the four touched files
- [ ] CI green on this PR

https://claude.ai/code/session_01S7gibS6mdAgDvht7EBiqKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7gibS6mdAgDvht7EBiqKE)_