### PR TITLE
feat(nav): cross-link Config panel ↔ /manage in the top bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ once a first tagged release ships.
 
 ### Added
 
+- **Cross-navigation between Config and `/manage`.** The config
+  panel's top bar now shows a `dashboard` button on the right
+  (mirroring the back-arrow on the left) that links to `/manage`,
+  and the Custom Overlay Manager header gains a back-arrow on the
+  left of its title that returns the operator to the scoreboard.
+  Both surfaces previously required typing the URL by hand.
 - **Rapid-pair undo correction (5 s window).** Two opposite
   ``add_point`` actions on the same team within
   ``RAPID_PAIR_WINDOW_S`` (5 s) now collapse to a no-op at the

--- a/app/admin/static/overlays.html
+++ b/app/admin/static/overlays.html
@@ -62,8 +62,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: 40px;
-    min-height: 40px;
+    min-width: 44px;
+    min-height: 44px;
     padding: 0 0.5rem;
     color: var(--text);
     background: var(--surface-alt);

--- a/app/admin/static/overlays.html
+++ b/app/admin/static/overlays.html
@@ -47,6 +47,42 @@
     box-shadow: var(--shadow);
   }
   header h1 { margin: 0; font-size: 1.3rem; }
+  header .header-left {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 0;
+  }
+  header .header-left h1 {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .back-to-scoreboard {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 40px;
+    min-height: 40px;
+    padding: 0 0.5rem;
+    color: var(--text);
+    background: var(--surface-alt);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    text-decoration: none;
+    font-size: 1.1rem;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+  .back-to-scoreboard:hover {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+  }
+  .back-to-scoreboard:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
   main {
     max-width: 960px;
     margin: 0 auto;
@@ -464,7 +500,11 @@
 </head>
 <body>
 <header>
-  <h1>Custom Overlay Manager</h1>
+  <div class="header-left">
+    <a href="/" class="back-to-scoreboard" title="Back to scoreboard"
+       aria-label="Back to scoreboard">&#8592;</a>
+    <h1>Custom Overlay Manager</h1>
+  </div>
   <div>
     <span id="loggedInHint" class="muted hidden">Authenticated</span>
     <button id="logoutBtn" class="secondary hidden">Log out</button>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1003,6 +1003,7 @@ body {
 .config-top-btn {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 4px;
   background: none;
   border: none;
@@ -1013,6 +1014,7 @@ body {
   min-height: 44px;
   min-width: 44px;
   border-radius: 8px;
+  text-decoration: none;
 }
 
 .config-top-btn:hover {

--- a/frontend/src/components/ConfigPanel.tsx
+++ b/frontend/src/components/ConfigPanel.tsx
@@ -269,7 +269,10 @@ export default function ConfigPanel({
           <span className="material-icons">arrow_back</span>
         </button>
         <span className="config-top-title">{t('config.title')}</span>
-        <div style={{ minWidth: 44 }} />
+        <a className="config-top-btn" href="/manage" title={t('config.openManage')}
+          aria-label={t('config.openManage')} data-testid="manage-link-button">
+          <span className="material-icons">dashboard</span>
+        </a>
       </div>
 
       <div className={`config-body ${isPortrait ? 'config-body-portrait' : 'config-body-landscape'}`}>

--- a/frontend/src/components/ConfigPanel.tsx
+++ b/frontend/src/components/ConfigPanel.tsx
@@ -270,7 +270,8 @@ export default function ConfigPanel({
         </button>
         <span className="config-top-title">{t('config.title')}</span>
         <a className="config-top-btn" href="/manage" title={t('config.openManage')}
-          aria-label={t('config.openManage')} data-testid="manage-link-button">
+          aria-label={t('config.openManage')} data-testid="manage-link-button"
+          onClick={(e) => { if (!confirmExitIfDirtyRef.current()) e.preventDefault(); }}>
           <span className="material-icons">dashboard</span>
         </a>
       </div>

--- a/frontend/src/i18n.tsx
+++ b/frontend/src/i18n.tsx
@@ -99,6 +99,7 @@ const translations: Record<string, TranslationDict> = {
     // Config panel
     'config.title': 'Config',
     'config.backToScoreboard': 'Back to scoreboard',
+    'config.openManage': 'Open Custom Overlay Manager',
     'config.save': 'Save',
     'config.saveCustomization': 'Save customization',
     'config.failedToSave': 'Failed to save customization',
@@ -308,6 +309,7 @@ const translations: Record<string, TranslationDict> = {
     // Config panel
     'config.title': 'Config',
     'config.backToScoreboard': 'Volver al marcador',
+    'config.openManage': 'Abrir gestor de overlays',
     'config.save': 'Guardar',
     'config.saveCustomization': 'Guardar personalización',
     'config.failedToSave': 'Error al guardar la personalización',


### PR DESCRIPTION
## Summary

Cross-link the two operator-facing top bars so navigating between the scoreboard's Config panel and the Custom Overlay Manager doesn't require typing URLs.

### `frontend/src/components/ConfigPanel.tsx`
Replaced the right-side 44-px spacer in `.config-top-bar` with a `dashboard` Material-icon link to `/manage`. New i18n keys `config.openManage` (en/es).

### `app/admin/static/overlays.html`
Added a back-arrow link (`←`, Unicode — the static admin page doesn't load the Material Icons font that the SPA imports) on the left of the `<h1>` title that points to `/`. Header is now `[← Custom Overlay Manager]` on the left, auth/logout on the right.

### `frontend/src/App.css`
`.config-top-btn` now sets `justify-content: center` and `text-decoration: none` so the rule works for both `<button>` and `<a>` children.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 405/405 (38 files)
- [x] `pytest tests/test_admin.py` — 39/39 (existing `test_manage_page_served` still serves the page)
- [ ] **Screenshots not regenerated** — Playwright Chromium download is blocked in this sandbox. Please refresh `docs/screenshots/04-config-panel.png` and `docs/screenshots/05-manage-page.png` before merge.

https://claude.ai/code/session_01S7gibS6mdAgDvht7EBiqKE

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7gibS6mdAgDvht7EBiqKE)_