### PR TITLE
feat(ui): stack config / share / history vertically in top-right corner

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -822,7 +822,7 @@ body {
 */
 .top-corner-icon-btn {
   position: absolute;
-  top: 1rem;
+  top: max(1rem, env(safe-area-inset-top));
   width: 44px;
   height: 44px;
   border-radius: 50%;
@@ -845,11 +845,11 @@ body {
 }
 
 .top-right-config-btn {
-  right: 1rem;
+  right: max(1rem, env(safe-area-inset-right));
 }
 
 .top-left-share-btn {
-  left: 1rem;
+  left: max(1rem, env(safe-area-inset-left));
 }
 
 .wakeup-handle {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -794,7 +794,7 @@ body {
   transition: opacity 0.3s ease-out, transform 0.3s ease-out;
 }
 
-.hud-controls.ui-hidden .top-right-config-btn {
+.hud-controls.ui-hidden .top-corner-icon-btn {
   opacity: 0;
   pointer-events: none;
   transform: translateY(-100%);
@@ -813,10 +813,16 @@ body {
   transform: translateY(100%);
 }
 
-.top-right-config-btn {
+/*
+  Shared base for the round, transparent icon buttons that pin to
+  the top corners of the scoreboard (config gear top-right, share
+  icon top-left). The visual identity stays consistent across both
+  corners; per-corner modifiers below set only the horizontal
+  edge.
+*/
+.top-corner-icon-btn {
   position: absolute;
   top: 1rem;
-  right: 1rem;
   width: 44px;
   height: 44px;
   border-radius: 50%;
@@ -829,13 +835,21 @@ body {
   cursor: pointer;
 }
 
-.top-right-config-btn:hover {
+.top-corner-icon-btn:hover {
   background: var(--hover-bg);
 }
 
-.top-right-config-btn:focus-visible {
+.top-corner-icon-btn:focus-visible {
   outline: 2px solid var(--blue, #2196f3);
   outline-offset: 2px;
+}
+
+.top-right-config-btn {
+  right: 1rem;
+}
+
+.top-left-share-btn {
+  left: 1rem;
 }
 
 .wakeup-handle {
@@ -2706,9 +2720,15 @@ body {
   behind the network round-trip.
 */
 .connection-status {
+  /*
+    Top-centre pinned so the pill clears both top-corner icon
+    buttons (share at top-left, settings at top-right) when it
+    becomes visible during a reconnect.
+  */
   position: fixed;
   top: max(0.5rem, env(safe-area-inset-top));
-  left: max(0.5rem, env(safe-area-inset-left));
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 1500;
   display: flex;
   align-items: center;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -794,7 +794,7 @@ body {
   transition: opacity 0.3s ease-out, transform 0.3s ease-out;
 }
 
-.hud-controls.ui-hidden .top-corner-icon-btn {
+.hud-controls.ui-hidden .top-corner-stack {
   opacity: 0;
   pointer-events: none;
   transform: translateY(-100%);
@@ -814,15 +814,13 @@ body {
 }
 
 /*
-  Shared base for the round, transparent icon buttons that pin to
-  the top corners of the scoreboard (config gear top-right, share
-  icon top-left). The visual identity stays consistent across both
-  corners; per-corner modifiers below set only the horizontal
-  edge.
+  Round, transparent icon buttons that pin to a top corner of the
+  scoreboard (config gear, share, history). Positioning is handled
+  by ``.top-corner-stack`` so the buttons can flow vertically with
+  consistent spacing without each one needing its own absolute
+  offsets.
 */
 .top-corner-icon-btn {
-  position: absolute;
-  top: max(1rem, env(safe-area-inset-top));
   width: 44px;
   height: 44px;
   border-radius: 50%;
@@ -844,12 +842,21 @@ body {
   outline-offset: 2px;
 }
 
-.top-right-config-btn {
-  right: max(1rem, env(safe-area-inset-right));
+/*
+  Vertical stack for the top-corner icon buttons. The wrapper owns
+  the absolute positioning + safe-area insets so adding a third or
+  fourth button doesn't need new per-button offsets.
+*/
+.top-corner-stack {
+  position: absolute;
+  top: max(1rem, env(safe-area-inset-top));
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
-.top-left-share-btn {
-  left: max(1rem, env(safe-area-inset-left));
+.top-right-stack {
+  right: max(1rem, env(safe-area-inset-right));
 }
 
 .wakeup-handle {
@@ -2721,9 +2728,9 @@ body {
 */
 .connection-status {
   /*
-    Top-centre pinned so the pill clears both top-corner icon
-    buttons (share at top-left, settings at top-right) when it
-    becomes visible during a reconnect.
+    Top-centre pinned so the pill clears the top-right stack of
+    corner buttons (config / share / history) when it becomes
+    visible during a reconnect.
   */
   position: fixed;
   top: max(0.5rem, env(safe-area-inset-top));

--- a/frontend/src/components/ControlButtons.tsx
+++ b/frontend/src/components/ControlButtons.tsx
@@ -8,7 +8,6 @@ import {
   UNDO_COLOR,
   PREVIEW_ON_COLOR,
   PREVIEW_OFF_COLOR,
-  SHARE_COLOR,
   HISTORY_COLOR,
 } from '../theme';
 
@@ -40,16 +39,9 @@ export interface ControlButtonsProps {
   onStartMatch: () => void;
   onReset: () => void;
   /**
-   * Opens the share / quick-links dialog. Lives in the secondary
-   * cluster on the right edge of the HUD next to undo, since it's
-   * an in-game ask ("send me the overlay link") rather than a
-   * once-per-session decision like theme or fullscreen.
-   */
-  onOpenShare: () => void;
-  /**
-   * Opens the recent-audit drawer. Sits next to share so the two
-   * "look at the match without leaving the score" affordances
-   * cluster together visually.
+   * Opens the recent-audit drawer. Sits in the bottom HUD cluster
+   * near undo so the operator can confirm "what just happened"
+   * without leaving the scoreboard.
    */
   onOpenHistory: () => void;
 }
@@ -80,7 +72,6 @@ export default function ControlButtons({
   onTogglePreview,
   onStartMatch,
   onReset,
-  onOpenShare,
   onOpenHistory,
 }: ControlButtonsProps) {
   const { t } = useI18n();
@@ -142,17 +133,6 @@ export default function ControlButtons({
         aria-label={t('history.title')}
       >
         <span className="material-icons">history</span>
-      </button>
-
-      <button
-        className="control-btn"
-        style={{ borderColor: SHARE_COLOR, color: SHARE_COLOR }}
-        onClick={onOpenShare}
-        title={t('share.title')}
-        data-testid="share-button"
-        aria-label={t('share.title')}
-      >
-        <span className="material-icons">share</span>
       </button>
 
       <button

--- a/frontend/src/components/ControlButtons.tsx
+++ b/frontend/src/components/ControlButtons.tsx
@@ -8,7 +8,6 @@ import {
   UNDO_COLOR,
   PREVIEW_ON_COLOR,
   PREVIEW_OFF_COLOR,
-  HISTORY_COLOR,
 } from '../theme';
 
 export interface ControlButtonsProps {
@@ -38,12 +37,6 @@ export interface ControlButtonsProps {
   onTogglePreview: () => void;
   onStartMatch: () => void;
   onReset: () => void;
-  /**
-   * Opens the recent-audit drawer. Sits in the bottom HUD cluster
-   * near undo so the operator can confirm "what just happened"
-   * without leaving the scoreboard.
-   */
-  onOpenHistory: () => void;
 }
 
 /**
@@ -72,7 +65,6 @@ export default function ControlButtons({
   onTogglePreview,
   onStartMatch,
   onReset,
-  onOpenHistory,
 }: ControlButtonsProps) {
   const { t } = useI18n();
   // ``matchFinished`` keeps the Reset face up after a match ends —
@@ -122,17 +114,6 @@ export default function ControlButtons({
         data-testid="undo-button"
       >
         <span className="material-icons">undo</span>
-      </button>
-
-      <button
-        className="control-btn"
-        style={{ borderColor: HISTORY_COLOR, color: HISTORY_COLOR }}
-        onClick={onOpenHistory}
-        title={t('history.title')}
-        data-testid="history-button"
-        aria-label={t('history.title')}
-      >
-        <span className="material-icons">history</span>
       </button>
 
       <button

--- a/frontend/src/components/ScoreboardView.tsx
+++ b/frontend/src/components/ScoreboardView.tsx
@@ -177,7 +177,16 @@ export default function ScoreboardView({
 
       <div className={`hud-controls ${!showControls ? 'ui-hidden' : ''}`}>
         <button
-          className="top-right-config-btn"
+          className="top-corner-icon-btn top-left-share-btn"
+          onClick={onOpenShare}
+          title={t('share.title')}
+          aria-label={t('share.title')}
+          data-testid="share-button"
+        >
+          <span className="material-icons" aria-hidden="true">share</span>
+        </button>
+        <button
+          className="top-corner-icon-btn top-right-config-btn"
           onClick={onOpenConfig}
           title={t('ctrl.configHint')}
           aria-label={t('ctrl.config')}
@@ -207,7 +216,6 @@ export default function ScoreboardView({
             onTogglePreview={onTogglePreview}
             onStartMatch={onStartMatch}
             onReset={onReset}
-            onOpenShare={onOpenShare}
             onOpenHistory={onOpenHistory}
           />
         </div>

--- a/frontend/src/components/ScoreboardView.tsx
+++ b/frontend/src/components/ScoreboardView.tsx
@@ -176,24 +176,35 @@ export default function ScoreboardView({
       </div>
 
       <div className={`hud-controls ${!showControls ? 'ui-hidden' : ''}`}>
-        <button
-          className="top-corner-icon-btn top-left-share-btn"
-          onClick={onOpenShare}
-          title={t('share.title')}
-          aria-label={t('share.title')}
-          data-testid="share-button"
-        >
-          <span className="material-icons" aria-hidden="true">share</span>
-        </button>
-        <button
-          className="top-corner-icon-btn top-right-config-btn"
-          onClick={onOpenConfig}
-          title={t('ctrl.configHint')}
-          aria-label={t('ctrl.config')}
-          data-testid="config-tab-button"
-        >
-          <span className="material-icons" aria-hidden="true">settings</span>
-        </button>
+        <div className="top-corner-stack top-right-stack">
+          <button
+            className="top-corner-icon-btn"
+            onClick={onOpenConfig}
+            title={t('ctrl.configHint')}
+            aria-label={t('ctrl.config')}
+            data-testid="config-tab-button"
+          >
+            <span className="material-icons" aria-hidden="true">settings</span>
+          </button>
+          <button
+            className="top-corner-icon-btn"
+            onClick={onOpenShare}
+            title={t('share.title')}
+            aria-label={t('share.title')}
+            data-testid="share-button"
+          >
+            <span className="material-icons" aria-hidden="true">share</span>
+          </button>
+          <button
+            className="top-corner-icon-btn"
+            onClick={onOpenHistory}
+            title={t('history.title')}
+            aria-label={t('history.title')}
+            data-testid="history-button"
+          >
+            <span className="material-icons" aria-hidden="true">history</span>
+          </button>
+        </div>
 
         <div className="control-buttons-wrapper">
           <div
@@ -216,7 +227,6 @@ export default function ScoreboardView({
             onTogglePreview={onTogglePreview}
             onStartMatch={onStartMatch}
             onReset={onReset}
-            onOpenHistory={onOpenHistory}
           />
         </div>
       </div>

--- a/frontend/src/test/ControlButtons.test.tsx
+++ b/frontend/src/test/ControlButtons.test.tsx
@@ -18,7 +18,6 @@ const defaultProps = {
   onTogglePreview: vi.fn(),
   onStartMatch: vi.fn(),
   onReset: vi.fn(),
-  onOpenShare: vi.fn(),
   onOpenHistory: vi.fn(),
 };
 
@@ -71,16 +70,9 @@ describe('ControlButtons', () => {
     expect(defaultProps.onTogglePreview).toHaveBeenCalledOnce();
   });
 
-  it('renders the share button and calls onOpenShare when clicked', () => {
-    const onOpenShare = vi.fn();
-    renderWithI18n(
-      <ControlButtons {...defaultProps} onOpenShare={onOpenShare} />,
-    );
-    const btn = screen.getByTestId('share-button');
-    expect(btn).toBeInTheDocument();
-    expect(btn).toHaveTextContent('share');
-    fireEvent.click(btn);
-    expect(onOpenShare).toHaveBeenCalledOnce();
+  it('does not render a share button — moved to the top-left corner of the scoreboard', () => {
+    renderWithI18n(<ControlButtons {...defaultProps} />);
+    expect(screen.queryByTestId('share-button')).toBeNull();
   });
 
   it('renders the history button and calls onOpenHistory when clicked', () => {

--- a/frontend/src/test/ControlButtons.test.tsx
+++ b/frontend/src/test/ControlButtons.test.tsx
@@ -18,7 +18,6 @@ const defaultProps = {
   onTogglePreview: vi.fn(),
   onStartMatch: vi.fn(),
   onReset: vi.fn(),
-  onOpenHistory: vi.fn(),
 };
 
 describe('ControlButtons', () => {
@@ -70,21 +69,10 @@ describe('ControlButtons', () => {
     expect(defaultProps.onTogglePreview).toHaveBeenCalledOnce();
   });
 
-  it('does not render a share button — moved to the top-left corner of the scoreboard', () => {
+  it('does not render share / history buttons — both moved to the top-right corner stack', () => {
     renderWithI18n(<ControlButtons {...defaultProps} />);
     expect(screen.queryByTestId('share-button')).toBeNull();
-  });
-
-  it('renders the history button and calls onOpenHistory when clicked', () => {
-    const onOpenHistory = vi.fn();
-    renderWithI18n(
-      <ControlButtons {...defaultProps} onOpenHistory={onOpenHistory} />,
-    );
-    const btn = screen.getByTestId('history-button');
-    expect(btn).toBeInTheDocument();
-    expect(btn).toHaveTextContent('history');
-    fireEvent.click(btn);
-    expect(onOpenHistory).toHaveBeenCalledOnce();
+    expect(screen.queryByTestId('history-button')).toBeNull();
   });
 
   it('shows visibility icon based on visible prop', () => {

--- a/frontend/src/test/ScoreboardView.test.tsx
+++ b/frontend/src/test/ScoreboardView.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import ScoreboardView from '../components/ScoreboardView';
+import { renderWithI18n, mockGameState, mockCustomization } from './helpers';
+
+vi.mock('../components/TeamPanel', () => ({
+  default: ({ teamId }: { teamId: number }) => (
+    <div data-testid={`team-panel-${teamId}`} />
+  ),
+}));
+
+vi.mock('../components/CenterPanel', () => ({
+  default: () => <div data-testid="center-panel" />,
+}));
+
+vi.mock('../components/ControlButtons', () => ({
+  default: () => <div data-testid="control-buttons" />,
+}));
+
+const baseProps = {
+  state: mockGameState,
+  customization: mockCustomization,
+  currentSet: 1,
+  setsLimit: 5,
+  isPortrait: false,
+  previewData: null,
+  showPreview: false,
+  recentEvents: [],
+  showControls: true,
+  setShowControls: vi.fn(),
+  canUndo: false,
+  simpleMode: false,
+  btnColorA: '#2196f3',
+  btnTextA: '#ffffff',
+  btnColorB: '#f44336',
+  btnTextB: '#ffffff',
+  iconLogoA: null,
+  iconLogoB: null,
+  onAddPoint: vi.fn(),
+  onAddSet: vi.fn(),
+  onAddTimeout: vi.fn(),
+  onChangeServe: vi.fn(),
+  onDoubleTapScore: vi.fn(),
+  onDoubleTapTimeout: vi.fn(),
+  onLongPressScore: vi.fn(),
+  onLongPressSet: vi.fn(),
+  onToggleVisibility: vi.fn(),
+  onToggleSimpleMode: vi.fn(),
+  onUndoLast: vi.fn(),
+  onTogglePreview: vi.fn(),
+  onStartMatch: vi.fn(),
+  onReset: vi.fn(),
+  onOpenConfig: vi.fn(),
+  onOpenShare: vi.fn(),
+  onOpenHistory: vi.fn(),
+};
+
+describe('ScoreboardView top-right corner stack', () => {
+  it('renders config, share and history buttons in the top-right stack', () => {
+    renderWithI18n(<ScoreboardView {...baseProps} />);
+    const stack = document.querySelector('.top-corner-stack.top-right-stack');
+    expect(stack).not.toBeNull();
+    expect(screen.getByTestId('config-tab-button')).toBeInTheDocument();
+    expect(screen.getByTestId('share-button')).toBeInTheDocument();
+    expect(screen.getByTestId('history-button')).toBeInTheDocument();
+    // Order matters: config on top, history at the bottom — that's
+    // the visual hierarchy the operator scans on a phone in portrait.
+    const buttons = Array.from(
+      stack!.querySelectorAll<HTMLButtonElement>('button[data-testid]'),
+    ).map((b) => b.dataset.testid);
+    expect(buttons).toEqual([
+      'config-tab-button',
+      'share-button',
+      'history-button',
+    ]);
+  });
+
+  it('invokes the matching callback when each top-right button is clicked', () => {
+    const onOpenConfig = vi.fn();
+    const onOpenShare = vi.fn();
+    const onOpenHistory = vi.fn();
+    renderWithI18n(
+      <ScoreboardView
+        {...baseProps}
+        onOpenConfig={onOpenConfig}
+        onOpenShare={onOpenShare}
+        onOpenHistory={onOpenHistory}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('config-tab-button'));
+    fireEvent.click(screen.getByTestId('share-button'));
+    fireEvent.click(screen.getByTestId('history-button'));
+    expect(onOpenConfig).toHaveBeenCalledOnce();
+    expect(onOpenShare).toHaveBeenCalledOnce();
+    expect(onOpenHistory).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -22,7 +22,6 @@ export const SIMPLE_SCOREBOARD_COLOR = '#e65100'; // orange-700
 export const UNDO_COLOR = '#b0bcff'; // light periwinkle, high contrast on dark navy
 export const PREVIEW_ON_COLOR = '#e040fb'; // purple-A200, vivid magenta
 export const PREVIEW_OFF_COLOR = '#ab47bc'; // purple-400, dimmer but still visible on dark
-export const HISTORY_COLOR = '#9575cd'; // deep-purple-300, distinct from undo periwinkle
 
 // Default button colors
 export const DEFAULT_BUTTON_A_COLOR = '#2196f3';

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -22,7 +22,7 @@ export const SIMPLE_SCOREBOARD_COLOR = '#e65100'; // orange-700
 export const UNDO_COLOR = '#b0bcff'; // light periwinkle, high contrast on dark navy
 export const PREVIEW_ON_COLOR = '#e040fb'; // purple-A200, vivid magenta
 export const PREVIEW_OFF_COLOR = '#ab47bc'; // purple-400, dimmer but still visible on dark
-export const HISTORY_COLOR = '#9575cd'; // deep-purple-300, distinct from undo periwinkle and share cyan
+export const HISTORY_COLOR = '#9575cd'; // deep-purple-300, distinct from undo periwinkle
 
 // Default button colors
 export const DEFAULT_BUTTON_A_COLOR = '#2196f3';

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -22,7 +22,6 @@ export const SIMPLE_SCOREBOARD_COLOR = '#e65100'; // orange-700
 export const UNDO_COLOR = '#b0bcff'; // light periwinkle, high contrast on dark navy
 export const PREVIEW_ON_COLOR = '#e040fb'; // purple-A200, vivid magenta
 export const PREVIEW_OFF_COLOR = '#ab47bc'; // purple-400, dimmer but still visible on dark
-export const SHARE_COLOR = '#26c6da'; // cyan-400, distinct from team / preview / visibility palettes
 export const HISTORY_COLOR = '#9575cd'; // deep-purple-300, distinct from undo periwinkle and share cyan
 
 // Default button colors


### PR DESCRIPTION
## Summary

Group the three surface-level navigation actions — **config**, **share**, **history** — into a single vertical column at the top-right of the scoreboard. The bottom HUD cluster keeps only the in-play toggles (start/reset, undo, simple-mode, preview, visibility), so the icons that open dedicated dialogs no longer compete for the same horizontal space.

- Introduce `.top-corner-stack` wrapper that owns the absolute positioning + safe-area insets, with `.top-right-stack` modifier for the horizontal edge. Per-button offsets are gone — the stack uses `flex-direction: column` + `gap`, so adding a fourth icon later is one JSX line.
- `ScoreboardView` renders the stack `config → share → history` and no longer threads `onOpenHistory` through `ControlButtons`.
- `ControlButtons` drops the in-cluster history button + `HISTORY_COLOR` import.
- `HISTORY_COLOR` removed from `theme.ts` (now unused).
- Tests: collapse the share/history negative assertions into one case.

## Evolution
- **cb12d7c** — initial relocation: share moved to top-left, mirroring the config gear top-right.
- **1c032f9** — Gemini review: safe-area insets on the corner buttons.
- **7880d1e** — direction change: stack all three (config / share / history) vertically at the top-right instead of splitting across both corners.

## Test plan
- [x] `cd frontend && npm test` (404 passed)
- [x] `cd frontend && npx tsc --noEmit` (clean)
- [x] `cd frontend && npm run build` (OK)
- [x] `pytest tests/ -v` (1024 passed before, no backend changes since)
- [x] `ruff check app/ tests/` (clean)
- [ ] Manual: open scoreboard in browser → confirm three icons in a vertical column at top-right; expand/collapse the HUD via the wakeup handle; confirm safe-area on a notched mobile viewport.

https://claude.ai/code/session_01CXCBbGyNjxXYDxhXsjCQmj