### PR TITLE
chore(manage): drop env-var name from unauthenticated /manage views

### DIFF
--- a/app/admin/static/overlays.html
+++ b/app/admin/static/overlays.html
@@ -451,15 +451,14 @@
   <div id="disabledView" class="card hidden">
     <h2>Overlay management disabled</h2>
     <p class="muted">
-      Set the <code>OVERLAY_MANAGER_PASSWORD</code> environment variable and
-      restart the server to enable this page.
+      This server has overlay management disabled. Contact the administrator
+      to enable it.
     </p>
   </div>
 
   <div id="loginView" class="card hidden">
     <h2>Enter admin password</h2>
-    <p class="muted">This page is protected. Enter the password configured in
-      <code>OVERLAY_MANAGER_PASSWORD</code> to continue.</p>
+    <p class="muted">This page is protected. Enter the admin password to continue.</p>
     <form id="loginForm">
       <div class="field">
         <label for="password">Password</label>


### PR DESCRIPTION
## Summary

The unauthenticated `/manage` views (login form + disabled-mode card) leaked the literal `OVERLAY_MANAGER_PASSWORD` env-var name to anyone hitting the page. That's information the operator user doesn't need (they should ask the admin) and that hands a probing visitor a free hint about the server's configuration surface.

Replace both copies with neutral prose:
- Login: "Enter the admin password to continue."
- Disabled card: "Contact the administrator to enable it."

## Out of scope

- The post-auth "Authenticated / Log out" banner (only seen by authenticated callers).
- Backend `Set OVERLAY_MANAGER_PASSWORD` strings in code comments / the match-report-signing 503 detail (server-side messages, not surfaced to the unauthenticated UI).

## Test plan
- [x] `pytest tests/ -v` — 1009 passed, no regressions.
- [ ] Manual: open `/manage` without a session — confirm the login card no longer mentions `OVERLAY_MANAGER_PASSWORD`. With the env var unset, confirm the disabled card shows the new "contact the administrator" copy.

https://claude.ai/code/session_01CXCBbGyNjxXYDxhXsjCQmj

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXCBbGyNjxXYDxhXsjCQmj)_