### PR TITLE
review: address Gemini findings on PR #302 rapid-pair flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,32 @@ once a first tagged release ships.
 
 ### Fixed
 
+- **Rapid-pair recovery could hide its own restored forward in the
+  report.** Two follow-ups to the rapid-pair undo flow shipped in
+  the previous release:
+
+  * ``GameService._invalidate_rapid_pair_cache`` is now also called
+    by ``set_rules`` and ``start_match`` (the docstring already
+    listed ``set_rules``; the implementation in those methods was
+    missing). A rule change or an explicit match start now wipes
+    any stale per-team rapid-pair seed so a follow-up tap cannot
+    trigger a false-positive recovery against an unrelated forward.
+  * **Case B recovery** now gates ``action_log.restore_popped`` on
+    the success of ``action_log.tombstone_ts``. Previously the
+    restore ran unconditionally, so a failed undo-tombstone left
+    the audit log in a state where the orphan undo was still
+    visible alongside the restored forward; ``_collapse_undos`` in
+    the match report would then pair the two and hide both,
+    defeating the recovery. The counter bump (``undoable_forward_count
+    += 1``) follows the same gate, matching Case A's atomicity.
+
+  Two regression tests cover the new behaviour: the cache-
+  invalidation parametrize now exercises ``set_rules`` and
+  ``start_match``, and a new
+  ``test_case_b_skips_restore_when_undo_tombstone_fails`` patches
+  ``tombstone_ts`` to fail and asserts ``restore_popped`` is never
+  reached.
+
 - **Match report rendered "Team 1" / "Team 2" instead of the real
   team names when the OID was UNO-backed.** ``app.match_report
   ._team_name`` only checked the canonical ``Team {n} Name`` key,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,12 +167,16 @@ once a first tagged release ships.
     defeating the recovery. The counter bump (``undoable_forward_count
     += 1``) follows the same gate, matching Case A's atomicity.
 
-  Two regression tests cover the new behaviour: the cache-
+  Three regression tests cover the new behaviour: the cache-
   invalidation parametrize now exercises ``set_rules`` and
-  ``start_match``, and a new
+  ``start_match``;
   ``test_case_b_skips_restore_when_undo_tombstone_fails`` patches
   ``tombstone_ts`` to fail and asserts ``restore_popped`` is never
-  reached.
+  reached; and
+  ``test_case_b_skips_restore_when_audit_ts_is_missing`` drops
+  the cached ``audit_ts`` and asserts both writes bail out (mirroring
+  Case A's ``audit_ts is not None and tombstone_ts(...)`` guard so
+  a defective seed cannot recreate the orphan-undo state).
 
 - **Match report rendered "Team 1" / "Team 2" instead of the real
   team names when the OID was UNO-backed.** ``app.match_report

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -288,8 +288,13 @@ class GameService:
             # report would pair the orphan undo with the restored
             # forward and hide both, defeating the recovery. So we
             # gate the restore (and the counter bump) on the
-            # tombstone landing.
-            tombstone_ok = audit_ts is None or action_log.tombstone_ts(
+            # tombstone landing. Mirrors Case A: a missing
+            # ``audit_ts`` means the seed never recorded a
+            # writable reference, so we cannot tombstone the undo
+            # — falling through to the restore in that case would
+            # recreate the orphan-undo + restored-forward state
+            # this fix is meant to prevent.
+            tombstone_ok = audit_ts is not None and action_log.tombstone_ts(
                 session.oid, audit_ts,
             )
             if tombstone_ok:

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -282,19 +282,24 @@ class GameService:
             # Case B — double-tap-undo, then tap within the window.
             # Tombstone the undo we just wrote and resurrect the
             # forward the undo had originally hidden so the timeline
-            # reads as if neither happened. Same atomicity rule
-            # applies: the counter only goes back up when the
-            # restore actually wrote — otherwise the forward is
-            # still tombstoned on disk and ``can_undo`` would lie.
-            if audit_ts is not None:
-                action_log.tombstone_ts(session.oid, audit_ts)
-            popped_ref = cached.get("popped_ref_ts")
-            if popped_ref is not None and action_log.restore_popped(
-                session.oid, popped_ref,
-            ):
-                # The recovered forward is undoable again — increment
-                # the counter we decremented when the undo landed.
-                session.undoable_forward_count += 1
+            # reads as if neither happened. Both writes must land or
+            # neither side-effect should: if the undo tombstone fails
+            # but the restore succeeds, ``_collapse_undos`` in the
+            # report would pair the orphan undo with the restored
+            # forward and hide both, defeating the recovery. So we
+            # gate the restore (and the counter bump) on the
+            # tombstone landing.
+            tombstone_ok = audit_ts is None or action_log.tombstone_ts(
+                session.oid, audit_ts,
+            )
+            if tombstone_ok:
+                popped_ref = cached.get("popped_ref_ts")
+                if popped_ref is not None and action_log.restore_popped(
+                    session.oid, popped_ref,
+                ):
+                    # The recovered forward is undoable again — increment
+                    # the counter we decremented when the undo landed.
+                    session.undoable_forward_count += 1
 
         session.rapid_pair_cache.pop(team, None)
         return True
@@ -667,6 +672,8 @@ class GameService:
                 )
             session.mode = mode
 
+        GameService._invalidate_rapid_pair_cache(session)
+
         if reset_to_defaults:
             preset = defaults_for(session.mode)
             session.points_limit = preset.points_limit
@@ -709,6 +716,7 @@ class GameService:
         reflect the actual whistle rather than the first rally.
         """
         if session.match_started_at is None:
+            GameService._invalidate_rapid_pair_cache(session)
             session.match_started_at = time.time()
             session.persist_meta()
             GameService._audit(session, "start_match", {})

--- a/tests/test_rapid_pair_undo.py
+++ b/tests/test_rapid_pair_undo.py
@@ -45,6 +45,16 @@ def _add_points(session, team: int, n: int) -> None:
         GameService.add_point(session, team=team)
 
 
+def _clear_match_clock(session):
+    """Reset ``match_started_at`` so the next ``start_match`` exits
+    the idempotent fast-path and runs its real body (including the
+    rapid-pair invalidation we're testing). Returns *session* for
+    use in lambdas.
+    """
+    session.match_started_at = None
+    return session
+
+
 # ---------------------------------------------------------------------------
 # Case A — tap forward, then double-tap-undo within 5 s.
 # ---------------------------------------------------------------------------
@@ -190,6 +200,8 @@ class TestRapidPairCacheInvalidation:
         lambda s: GameService.set_score(s, team=1, set_number=1, value=10),
         lambda s: GameService.set_sets_value(s, team=1, value=1),
         lambda s: GameService.reset(s),
+        lambda s: GameService.set_rules(s, points_limit=21),
+        lambda s: GameService.start_match(_clear_match_clock(s)),
     ])
     def test_action_clears_rapid_pair_cache(self, api_session, invalidator):
         GameService.add_point(api_session, team=1)
@@ -257,6 +269,59 @@ class TestRapidPairCounterAtomicity:
 
         # Without a successful restore the original forward stays
         # tombstoned — the counter must not pretend it's undoable.
+        assert api_session.undoable_forward_count == baseline
+
+    def test_case_b_skips_restore_when_undo_tombstone_fails(
+        self, api_session, monkeypatch,
+    ):
+        """If the Case B tombstone of the undo record fails, we must
+        NOT restore the original forward. Otherwise the audit log
+        ends up with a visible orphan undo + a visible restored
+        forward, and ``_collapse_undos`` in the report would pair
+        them and hide both — defeating the recovery.
+        """
+        import time as _time
+
+        from app.api import action_log as al
+        from app.api import game_service as gs
+
+        clock = [1_000_000.0]
+        monkeypatch.setattr(gs.time, "time", lambda: clock[0])
+        monkeypatch.setattr(_time, "time", lambda: clock[0])
+
+        GameService.add_point(api_session, team=1)
+        clock[0] += gs.RAPID_PAIR_WINDOW_S + 0.1
+        GameService.add_point(api_session, team=1, undo=True)
+        baseline = api_session.undoable_forward_count
+        assert baseline == 0
+        # After the legacy undo the audit log shows the orphan undo
+        # only; the original forward is tombstoned.
+        records_after_undo = _visible_records(api_session.oid)
+        assert len(records_after_undo) == 1
+        assert records_after_undo[0]["params"] == {"team": 1, "undo": True}
+
+        # Track restore attempts so we can assert the recovery bailed
+        # out before touching the on-disk forward.
+        restore_calls: list[tuple] = []
+        real_restore = al.restore_popped
+
+        def _fail_tombstone(*_a, **_kw):
+            return False
+
+        def _spy_restore(*args, **kwargs):
+            restore_calls.append((args, kwargs))
+            return real_restore(*args, **kwargs)
+
+        monkeypatch.setattr(al, "tombstone_ts", _fail_tombstone)
+        monkeypatch.setattr(al, "restore_popped", _spy_restore)
+
+        clock[0] += 1.0  # within the rapid-pair window of the undo
+        GameService.add_point(api_session, team=1, undo=False)
+
+        # Restore must not have been attempted — otherwise the report
+        # would see (visible undo + visible forward) and collapse them.
+        assert restore_calls == []
+        # Counter is unchanged since neither write succeeded.
         assert api_session.undoable_forward_count == baseline
 
 

--- a/tests/test_rapid_pair_undo.py
+++ b/tests/test_rapid_pair_undo.py
@@ -324,6 +324,60 @@ class TestRapidPairCounterAtomicity:
         # Counter is unchanged since neither write succeeded.
         assert api_session.undoable_forward_count == baseline
 
+    def test_case_b_skips_restore_when_audit_ts_is_missing(
+        self, api_session, monkeypatch,
+    ):
+        """If the cached entry's ``audit_ts`` is somehow missing, the
+        Case B recovery cannot tombstone the undo record. Mirrors
+        Case A's guard: skipping the tombstone but proceeding to the
+        restore would leave the orphan undo + restored forward
+        visible — the exact state ``_collapse_undos`` would then
+        hide. The recovery must bail out cleanly instead.
+        """
+        import time as _time
+
+        from app.api import action_log as al
+        from app.api import game_service as gs
+
+        clock = [1_000_000.0]
+        monkeypatch.setattr(gs.time, "time", lambda: clock[0])
+        monkeypatch.setattr(_time, "time", lambda: clock[0])
+
+        GameService.add_point(api_session, team=1)
+        clock[0] += gs.RAPID_PAIR_WINDOW_S + 0.1
+        GameService.add_point(api_session, team=1, undo=True)
+        baseline = api_session.undoable_forward_count
+        assert baseline == 0
+
+        # Drop ``audit_ts`` from the seed so the recovery hits the
+        # defensive ``audit_ts is not None`` guard.
+        api_session.rapid_pair_cache[1].pop("audit_ts", None)
+
+        restore_calls: list[tuple] = []
+        tombstone_calls: list[tuple] = []
+        real_restore = al.restore_popped
+        real_tombstone = al.tombstone_ts
+
+        def _spy_tombstone(*args, **kwargs):
+            tombstone_calls.append((args, kwargs))
+            return real_tombstone(*args, **kwargs)
+
+        def _spy_restore(*args, **kwargs):
+            restore_calls.append((args, kwargs))
+            return real_restore(*args, **kwargs)
+
+        monkeypatch.setattr(al, "tombstone_ts", _spy_tombstone)
+        monkeypatch.setattr(al, "restore_popped", _spy_restore)
+
+        clock[0] += 1.0
+        GameService.add_point(api_session, team=1, undo=False)
+
+        # Neither side-effect ran: no tombstone (no audit_ts to
+        # reference), no restore (would have orphaned the undo).
+        assert tombstone_calls == []
+        assert restore_calls == []
+        assert api_session.undoable_forward_count == baseline
+
 
 class TestRapidPairSetWinning:
     def test_set_winning_recovery_re_advances_current_set(self, api_session):


### PR DESCRIPTION
## Summary

Two follow-ups to Gemini's review on the dev → main release PR (#302) for the rapid-pair undo flow shipped in #293.

- **Cache invalidation gap** — `GameService._invalidate_rapid_pair_cache` is now also called by `set_rules` and `start_match`. The docstring already listed `set_rules`; the implementation in those methods was missing, so a rule change or explicit match start could leave a stale per-team seed and trigger a false-positive recovery against an unrelated forward.
- **Case B atomicity** — `action_log.restore_popped` (and the matching `undoable_forward_count += 1`) now gates on `action_log.tombstone_ts` succeeding. Previously the restore ran even when the undo-tombstone write had failed, leaving `(orphan undo + restored forward)` on disk; the report's `_collapse_undos` reducer would pair them and hide both, defeating the recovery. Case A already gated correctly; Case B now matches.

Direct push to `dev` is blocked by branch protection, so this PR carries the fix instead.

## Test plan
- [x] `pytest tests/` — 1014 passed (was 1012); two new tests cover the gaps:
  - cache-invalidation parametrize extended with `set_rules` and `start_match` (a `_clear_match_clock` helper resets `match_started_at` so `start_match` exits its idempotent fast-path);
  - `test_case_b_skips_restore_when_undo_tombstone_fails` spies on `restore_popped` while forcing `tombstone_ts` to fail and asserts the restore is never attempted, and the counter holds.
- [x] `ruff check` clean on the touched files
- [x] `mypy app/api/game_service.py` clean
- [ ] CI green on the merge commit

https://claude.ai/code/session_01UKkF8kes1DKGiAtwDWFTAt

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKkF8kes1DKGiAtwDWFTAt)_