### PR TITLE
fix(strip): align recent-actions strip with history/report on undo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ once a first tagged release ships.
   full `pytest` (1019), `ruff`, `mypy`, and `vitest` (415) suites
   remain green.
 
+### Fixed
+
+- **Recent-actions strip now drops the "alive" chip on undo** so it
+  matches how history (`RecentAuditDrawer`) and the printable
+  `/match/{id}/report` render the same event. Previously, when the
+  preview was hidden and the operator undid an action, the strip
+  surfaced both the original chip *and* the struck/undone chip side
+  by side, even though the audit-backed views only show the undone
+  entry once `pop_last_forward` tombstones the forward record. The
+  classifier no longer synthesizes a forward `timeout` chip from
+  the post-state diff for popped records, and the recovery buffer
+  in `useRecentEvents` now suppresses any prior chip whose undo
+  counterpart (point/timeout/set/match) is present in the fresh
+  fetch or the snapshot diff.
+
 ## [5.2.0] - 2026-05-10
 
 ### Added

--- a/frontend/src/hooks/useRecentEvents.ts
+++ b/frontend/src/hooks/useRecentEvents.ts
@@ -60,13 +60,6 @@ function classifyRecords(records: AuditRecord[]): RecentEvent[] {
   // set-winning ``add_point`` (which the backend doesn't log as
   // ``add_set``).
   let prevSets: { 1: number; 2: number } | null = null;
-  // Last seen post-state timeout counts. Used to detect "popped"
-  // forward timeouts (when a later undo physically removed the
-  // forward record from the audit log via ``pop_last_forward``,
-  // intermediate records still show the bumped count and we can
-  // synthesize the missing chip from the upward diff) and to spot
-  // adjacent vs non-adjacent undoes.
-  let prevTimeouts: { 1: number; 2: number } | null = null;
   // Track match-finished transitions so a set-winning record that
   // also ends the match emits a ``match_won`` chip rather than the
   // regular set-won star.
@@ -79,31 +72,6 @@ function classifyRecords(records: AuditRecord[]): RecentEvent[] {
     const validTeam = team === 1 || team === 2;
     const undo = !!params.undo;
 
-    const t1Tos = (result.team_1 as Record<string, unknown> | undefined)?.timeouts;
-    const t2Tos = (result.team_2 as Record<string, unknown> | undefined)?.timeouts;
-
-    // ── Synthesized forward timeout chips ──────────────────────────
-    // ``pop_last_forward`` physically deletes the original forward
-    // record from the audit log when the operator undoes a timeout,
-    // so we never see it directly. Whenever a record's post-state
-    // shows team_X.timeouts higher than the previous record's, and
-    // the bump isn't accounted for by *this* record being the
-    // forward itself, the bump must come from a record that has
-    // since been popped. Synthesize the missing chip and place it
-    // right before the current record's chip — chronologically
-    // correct since the original happened before the in-between
-    // actions that observed the bumped state.
-    if (prevTimeouts !== null) {
-      const isOurForward = (t: 1 | 2) =>
-        r.action === 'add_timeout' && !undo && team === t;
-      if (typeof t1Tos === 'number' && t1Tos > prevTimeouts[1] && !isOurForward(1)) {
-        events.push({ ts: r.ts - 1e-6, team: 1, kind: 'timeout' });
-      }
-      if (typeof t2Tos === 'number' && t2Tos > prevTimeouts[2] && !isOurForward(2)) {
-        events.push({ ts: r.ts - 1e-6, team: 2, kind: 'timeout' });
-      }
-    }
-
     // ── Action-driven chips ────────────────────────────────────────
     if (validTeam) {
       const t = team as 1 | 2;
@@ -112,14 +80,12 @@ function classifyRecords(records: AuditRecord[]): RecentEvent[] {
           events.push({ ts: r.ts, team: t, kind: undo ? 'point_undo' : 'point_add' });
           break;
         case 'add_timeout': {
-          // Always emit a chip on undo so the operator gets the same
-          // visual signal as for any other undone action. The
-          // synthesized forward chip above only fires when one or
-          // more in-between records observed the bumped count, so:
-          //   - Adjacent undo (no in-betweens): just the struck chip.
-          //   - Non-adjacent undo: synth forward + in-betweens +
-          //     struck — recovers the timeline the operator saw
-          //     before clicking undo.
+          // The forward audit record is physically removed by
+          // ``pop_last_forward`` when the operator undoes a timeout,
+          // so a popped forward never reaches the classifier — only
+          // its undo does. We emit the struck chip on undo to match
+          // history / report (which both surface only the undone
+          // entry once the forward is tombstoned).
           events.push({
             ts: r.ts,
             team: t,
@@ -174,17 +140,21 @@ function classifyRecords(records: AuditRecord[]): RecentEvent[] {
       if (typeof t1 === 'number') lastScore[k(scoreSet, 1)] = t1;
       if (typeof t2 === 'number') lastScore[k(scoreSet, 2)] = t2;
     }
-
-    // ── Timeout state refresh (synthesis baseline) ─────────────────
-    if (typeof t1Tos === 'number' || typeof t2Tos === 'number') {
-      prevTimeouts = {
-        1: typeof t1Tos === 'number' ? t1Tos : prevTimeouts?.[1] ?? 0,
-        2: typeof t2Tos === 'number' ? t2Tos : prevTimeouts?.[2] ?? 0,
-      };
-    }
   }
   return events;
 }
+
+// Inverse mapping used to suppress recovered "alive" chips whose
+// undo counterpart is already in the fresh classification (or
+// synthesized from the state-diff). Keeps the strip consistent
+// with history / report — both of which only surface the undone
+// entry once the forward has been tombstoned.
+const INVERSE_UNDO_KIND: Partial<Record<RecentEventKind, RecentEventKind>> = {
+  point_add: 'point_undo',
+  timeout: 'timeout_undo',
+  set_won: 'set_undo',
+  match_won: 'match_undo',
+};
 
 interface PriorSnapshot {
   sets1: number;
@@ -218,15 +188,13 @@ export function useRecentEvents(
   // physically removes the original forward record and doesn't
   // store the popped payload anywhere visible to the classifier).
   const priorSnapshotRef = useRef<PriorSnapshot | null>(null);
-  // The full event list we last surfaced. Used to keep "popped"
-  // chips visible across refetches: when the operator undoes a
-  // forward action, ``pop_last_forward`` deletes its audit record
-  // entirely, so a fresh classification of the post-undo log is
-  // missing the original chip. We recover it by carrying forward
-  // any prior event that doesn't appear in the new classification
-  // — the original chip stays put and the undo chip lands beside
-  // it, instead of the original silently morphing into a struck
-  // variant.
+  // The full event list we last surfaced. Used to keep chips that
+  // aged out of the audit fetch window visible across refetches.
+  // We deliberately do NOT use this buffer to resurrect chips whose
+  // underlying record was popped by ``pop_last_forward`` — when the
+  // operator undoes an action, the strip should drop the "alive"
+  // chip and surface only the struck/undone chip, mirroring how
+  // history and report render the same event.
   const priorEventsRef = useRef<RecentEvent[]>([]);
 
   useEffect(() => {
@@ -258,14 +226,47 @@ export function useRecentEvents(
       .then((res) => {
         if (cancelled) return;
         const fresh = classifyRecords(res.records);
-        // Recover events whose underlying audit record was popped
-        // between fetches. ``pop_last_forward`` deletes the original
+
+        // Pre-compute the synthetic set/match undo chips that will
+        // be appended from the state-diff below — we need them in
+        // the suppression set so a recovered ``set_won`` / ``match_won``
+        // is dropped when its undo only surfaces via the snapshot
+        // diff (not the audit log).
+        const syntheticUndoes: RecentEvent[] = [];
+        if (prior && cur) {
+          const matchUndone = prior.matchFinished && !cur.matchFinished;
+          if (cur.sets1 < prior.sets1) {
+            syntheticUndoes.push({
+              ts: 0,
+              team: 1,
+              kind: matchUndone ? 'match_undo' : 'set_undo',
+            });
+          }
+          if (cur.sets2 < prior.sets2) {
+            syntheticUndoes.push({
+              ts: 0,
+              team: 2,
+              kind: matchUndone ? 'match_undo' : 'set_undo',
+            });
+          }
+        }
+
+        // Build the suppression set keyed by ``team:kind`` so we can
+        // drop a recovered "alive" chip whose undo counterpart is
+        // already visible — either from the fresh classification or
+        // synthesized from the state-diff.
+        const undoPresent = new Set<string>();
+        for (const e of fresh) undoPresent.add(`${e.team}:${e.kind}`);
+        for (const e of syntheticUndoes) undoPresent.add(`${e.team}:${e.kind}`);
+
+        // Recover events whose underlying audit record aged out of
+        // the fetch window. ``pop_last_forward`` deletes the original
         // ``add_point`` / ``add_timeout`` row when the operator
-        // undoes it, so a fresh re-classification is silently
-        // missing the chip we showed last time. Anything in
-        // ``priorEvents`` that isn't matched by an entry in
-        // ``fresh`` (same ts + team + kind) is treated as popped
-        // and re-added.
+        // undoes it, so a fresh re-classification would be silently
+        // missing the chip we showed last time — but we deliberately
+        // do NOT resurrect the "alive" chip in that case, so the
+        // strip matches history / report (both show only the
+        // struck/undone entry).
         // ``value`` is part of the identity for ``manual`` chips — two
         // different manual corrections can land at the same ts (e.g.
         // low-resolution server clock) and must not dedupe each other.
@@ -274,40 +275,30 @@ export function useRecentEvents(
           a.team === b.team &&
           a.kind === b.kind &&
           a.value === b.value;
-        const popped = priorEvents.filter(
-          (p) => !fresh.some((f) => isSame(f, p)),
-        );
+        const popped = priorEvents.filter((p) => {
+          if (fresh.some((f) => isSame(f, p))) return false;
+          const inverse = INVERSE_UNDO_KIND[p.kind];
+          if (inverse && undoPresent.has(`${p.team}:${inverse}`)) return false;
+          return true;
+        });
         const merged: RecentEvent[] = [...popped, ...fresh].sort(
           (a, b) => a.ts - b.ts,
         );
-        if (prior && cur) {
-          // Set / match undo detection: append a struck-chip when
-          // sets dropped or match_finished flipped back to false
-          // between refetches. Anchor the synthetic ts to the most
-          // recent event we already have rather than ``Date.now()``
-          // — the audit log's ts is the server clock and a drifted
-          // client clock could otherwise sort the undo chip ahead
-          // of records that actually happened later.
-          const matchUndone = prior.matchFinished && !cur.matchFinished;
+
+        // Append the synthetic state-diff undoes now, anchoring each
+        // ts to the latest merged event rather than ``Date.now()``
+        // — the audit log's ts is the server clock and a drifted
+        // client clock could otherwise sort the undo chip ahead of
+        // records that actually happened later.
+        if (syntheticUndoes.length > 0) {
           const lastMerged = merged[merged.length - 1];
           let ts = lastMerged ? lastMerged.ts : Date.now() / 1000;
-          if (cur.sets1 < prior.sets1) {
+          for (const u of syntheticUndoes) {
             ts += 1e-3;
-            merged.push({
-              ts,
-              team: 1,
-              kind: matchUndone ? 'match_undo' : 'set_undo',
-            });
-          }
-          if (cur.sets2 < prior.sets2) {
-            ts += 1e-3;
-            merged.push({
-              ts,
-              team: 2,
-              kind: matchUndone ? 'match_undo' : 'set_undo',
-            });
+            merged.push({ ...u, ts });
           }
         }
+
         const capped = merged.slice(-max);
         setEvents(capped);
         priorSnapshotRef.current = cur;

--- a/frontend/src/test/useRecentEvents.test.tsx
+++ b/frontend/src/test/useRecentEvents.test.tsx
@@ -113,16 +113,16 @@ describe('useRecentEvents', () => {
     expect(result.current[0]).toMatchObject({ team: 2, kind: 'timeout' });
   });
 
-  it('keeps the original timeout chip and appends a struck-clock when the operator undoes an adjacent timeout', async () => {
+  it('drops the original timeout chip when the operator undoes an adjacent timeout (matches history / report)', async () => {
     // Real-life flow across two fetches:
     //  1. Operator hits "+timeout" → audit gets the forward record →
     //     strip shows [clock].
     //  2. Operator hits "undo timeout" → ``pop_last_forward`` deletes
     //     the forward record and a new ``undo=true`` row is appended.
-    //     The fresh re-classification only sees the undo, so without
-    //     stickiness the clock chip would silently morph into the
-    //     struck variant. The hook must instead keep the original
-    //     clock visible *and* append the struck-clock beside it.
+    //     The fresh re-classification only sees the undo, so the
+    //     strip drops the "alive" clock and surfaces just the struck
+    //     variant — mirroring how history and report render the same
+    //     undone timeout (the tombstone hides the forward row).
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 1,
@@ -154,11 +154,11 @@ describe('useRecentEvents', () => {
     );
     rerender({ s: makeState(0, 0, 0, 0, 0, 0) });
     await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(result.current).toHaveLength(2));
-    expect(result.current.map((e) => e.kind)).toEqual(['timeout', 'timeout_undo']);
+    await waitFor(() => expect(result.current).toHaveLength(1));
+    expect(result.current.map((e) => e.kind)).toEqual(['timeout_undo']);
   });
 
-  it('keeps the original set_won chip and surfaces both point_undo and set_undo when the operator undoes a set-winning point', async () => {
+  it('drops the original set_won chip when the operator undoes a set-winning point (matches history / report)', async () => {
     // First fetch: a baseline point (so ``prevSets`` is anchored) and
     // the set-winning ``add_point`` are both in the audit.
     getAuditSpy.mockResolvedValueOnce({
@@ -178,7 +178,9 @@ describe('useRecentEvents', () => {
       ],
     });
     // Second fetch: forward was popped, leaving the baseline point
-    // plus the new ``undo=true`` record.
+    // plus the new ``undo=true`` record. The set_won and the
+    // set-winning point's "alive" chip must both disappear from the
+    // strip — same as the audit-backed history / report views.
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 2,
@@ -208,13 +210,17 @@ describe('useRecentEvents', () => {
       expect(result.current.some((e) => e.kind === 'set_undo')).toBe(true),
     );
     const kinds = result.current.map((e) => e.kind);
-    expect(kinds).toContain('point_add');
-    expect(kinds).toContain('set_won');
+    // Baseline point still visible (it was never undone), and the
+    // undo / set_undo chips replace the popped set-winning pair.
     expect(kinds).toContain('point_undo');
     expect(kinds).toContain('set_undo');
+    expect(kinds).not.toContain('set_won');
+    // Exactly one ``point_add`` — the baseline. The set-winning
+    // forward was popped, so its "alive" chip must not survive.
+    expect(kinds.filter((k) => k === 'point_add')).toHaveLength(1);
   });
 
-  it('keeps the original match_won chip and surfaces both point_undo and match_undo on a match-winning undo', async () => {
+  it('drops the original match_won chip and surfaces point_undo + match_undo on a match-winning undo', async () => {
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 2,
@@ -268,10 +274,12 @@ describe('useRecentEvents', () => {
       expect(result.current.some((e) => e.kind === 'match_undo')).toBe(true),
     );
     const kinds = result.current.map((e) => e.kind);
-    expect(kinds).toContain('point_add');
-    expect(kinds).toContain('match_won');
     expect(kinds).toContain('point_undo');
     expect(kinds).toContain('match_undo');
+    // The popped match-winning forward must not survive in the strip
+    // — same as history / report.
+    expect(kinds).not.toContain('match_won');
+    expect(kinds.filter((k) => k === 'point_add')).toHaveLength(1);
     // Trophy preempts the star — undoing a match-winning point should
     // not also push a struck-star alongside the struck-trophy.
     expect(kinds).not.toContain('set_undo');
@@ -335,26 +343,26 @@ describe('useRecentEvents', () => {
     );
   });
 
-  it('synthesizes the forward chip and emits the struck-clock when an undo is non-adjacent', async () => {
+  it('does not resurrect a popped forward timeout chip when an undo is non-adjacent (matches history / report)', async () => {
     // Operator sequence: point(0→1), [popped timeout(t1: 0→1)],
     // point(1→2), undo timeout(t1: 1→0).
     // After pop_last_forward the audit response is the baseline
     // point + the in-between point (still showing the bumped
-    // timeout count) + the undo. The classifier synthesizes the
-    // missing forward chip right before the in-between record and
-    // emits the struck chip at the undo.
+    // timeout count) + the undo. The strip surfaces only the
+    // records the audit still carries — the popped forward stays
+    // hidden, same as in history / report.
     getAuditSpy.mockResolvedValue({
       oid: 'oid',
       count: 3,
       records: [
-        // Baseline record — anchors prevTimeouts at t1=0.
         rec(1, 'add_point', { team: 1 }, {
           score_set: 1,
           team_1: { score: 1, sets: 0, timeouts: 0 },
           team_2: { score: 0, sets: 0, timeouts: 0 },
         }),
-        // In-between record — observed the bumped count, so
-        // synthesis fires here.
+        // In-between record — its post-state still shows the
+        // bumped timeout count, but we no longer synthesize a
+        // forward chip from that diff.
         rec(2, 'add_point', { team: 1 }, {
           score_set: 1,
           team_1: { score: 2, sets: 0, timeouts: 1 },
@@ -371,11 +379,11 @@ describe('useRecentEvents', () => {
     const { result } = renderHook(() =>
       useRecentEvents('oid', true, makeState(2, 0), 8),
     );
-    await waitFor(() => expect(result.current).toHaveLength(4));
+    await waitFor(() => expect(result.current).toHaveLength(3));
     expect(result.current[0]).toMatchObject({ team: 1, kind: 'point_add' });
-    expect(result.current[1]).toMatchObject({ team: 1, kind: 'timeout' });
-    expect(result.current[2]).toMatchObject({ team: 1, kind: 'point_add' });
-    expect(result.current[3]).toMatchObject({ team: 1, kind: 'timeout_undo' });
+    expect(result.current[1]).toMatchObject({ team: 1, kind: 'point_add' });
+    expect(result.current[2]).toMatchObject({ team: 1, kind: 'timeout_undo' });
+    expect(result.current.some((e) => e.kind === 'timeout')).toBe(false);
   });
 
   it('emits match_won (not set_won) when a sets++ also flips match_finished', async () => {


### PR DESCRIPTION
## Summary

- The strip rendered when the overlay preview is hidden was keeping the original "alive" chip *and* the struck/undone chip side by side after an undo, while the history drawer (`RecentAuditDrawer`) and the printable `/match/{id}/report` only show the struck chip (their views are audit-backed and `pop_last_forward` tombstones the forward).
- `useRecentEvents` recovery logic now suppresses any prior chip whose undo gemelo (`point_undo` / `timeout_undo` / `set_undo` / `match_undo` for the same team) is present in the fresh fetch or in the synthetic state-diff undoes.
- Removed the now-redundant forward-`timeout` synthesis in `classifyRecords` (it existed solely to surface popped forwards, which is the behavior we just removed).
- Four tests in `useRecentEvents.test.tsx` were reoriented to lock in the new semantics; the rest of the suite (415 tests) still passes.

## Test plan

- [x] `cd frontend && npx vitest run` — 40 suites / 415 tests pass.
- [ ] Manual: hide the overlay preview, add a point and undo it — only the struck chip should remain.
- [ ] Manual: same flow with a timeout (adjacent and non-adjacent undo).
- [ ] Manual: undo a set-winning point — strip should show `[baseline_point, point_undo, set_undo]`, no leftover `set_won` / second `point_add`.
- [ ] Confirm the history drawer and `/match/{id}/report` are unchanged.

https://claude.ai/code/session_01YY6AJZSCCn8TWzvjoy1UhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01YY6AJZSCCn8TWzvjoy1UhV)_