### PR TITLE
refactor(strip): pure projection of tombstone-filtered audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,27 @@ once a first tagged release ships.
   full `pytest` (1019), `ruff`, `mypy`, and `vitest` (415) suites
   remain green.
 
+### Changed
+
+- **Recent-actions strip rewritten as a pure projection of the
+  tombstone-filtered audit log.** Dropped the `priorEventsRef`
+  stickiness buffer in `useRecentEvents` and the
+  `INVERSE_UNDO_KIND` suppression heuristic that went with it.
+  Every fetch now fully replaces the chip list, so rapid-pair
+  collapses (forward + undo within 5 s ⇒ audit empty), generic
+  undoes, and resets all converge to the same view the history
+  drawer and printable report render. Side-effects of the rewrite:
+  * Rapid-pair Case A no longer leaves a ghost "alive" chip in
+    the strip after the pair is collapsed at the audit level.
+  * Chronological ordering is guaranteed by audit `ts` (server
+    monotonic per-OID); the synthetic state-diff set/match-undo
+    chips are anchored above the last audit chip, so they always
+    render rightmost.
+  * The strip no longer recovers chips that age out of the audit
+    fetch window — but at `max(40, max*3) = 40` fetched and the
+    strip capped at `max = 8` visible, aging out would require
+    >32 intervening chips, which doesn't happen in practice.
+
 ### Fixed
 
 - **Undo button no longer lags one action behind.** The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,6 @@ once a first tagged release ships.
   overlay-server credential paths. No observable behavior change;
   full `pytest` (1019), `ruff`, `mypy`, and `vitest` (415) suites
   remain green.
-
-### Changed
-
 - **Recent-actions strip rewritten as a pure projection of the
   tombstone-filtered audit log.** Dropped the `priorEventsRef`
   stickiness buffer in `useRecentEvents` and the

--- a/frontend/src/hooks/useRecentEvents.ts
+++ b/frontend/src/hooks/useRecentEvents.ts
@@ -35,16 +35,12 @@ function teamScoreSum(team: TeamState | undefined | null): number {
 
 function scoringKey(state: GameState | null): string {
   if (!state) return '';
-  // Timeouts are part of the key — without them a timeout-only state
-  // push wouldn't refetch the audit log, and the clock chip would
-  // only surface when the next scoring event arrived.
   // ``match_started_at`` is part of the key so a match reset that
   // lands on already-zero scores (e.g. after the operator just
   // undid everything back to 0:0) still refires the effect — the
-  // matchBoundary detector inside then clears ``priorEventsRef``
-  // and the strip drops any leftover undo chips. Without this the
-  // chips would linger until the next scoring event changed the
-  // numeric portion of the key.
+  // empty audit log then surfaces an empty strip. Timeouts are in
+  // the key for the same reason: a timeout-only state push must
+  // refetch so the clock chip appears immediately.
   return [
     teamScoreSum(state.team_1),
     teamScoreSum(state.team_2),
@@ -152,23 +148,10 @@ function classifyRecords(records: AuditRecord[]): RecentEvent[] {
   return events;
 }
 
-// Inverse mapping used to suppress recovered "alive" chips whose
-// undo counterpart is already in the fresh classification (or
-// synthesized from the state-diff). Keeps the strip consistent
-// with history / report — both of which only surface the undone
-// entry once the forward has been tombstoned.
-const INVERSE_UNDO_KIND: Partial<Record<RecentEventKind, RecentEventKind>> = {
-  point_add: 'point_undo',
-  timeout: 'timeout_undo',
-  set_won: 'set_undo',
-  match_won: 'match_undo',
-};
-
 interface PriorSnapshot {
   sets1: number;
   sets2: number;
   matchFinished: boolean;
-  matchStartedAt: number | null;
 }
 
 function snapshotState(state: GameState | null): PriorSnapshot | null {
@@ -177,8 +160,6 @@ function snapshotState(state: GameState | null): PriorSnapshot | null {
     sets1: state.team_1?.sets ?? 0,
     sets2: state.team_2?.sets ?? 0,
     matchFinished: state.match_finished === true,
-    matchStartedAt:
-      typeof state.match_started_at === 'number' ? state.match_started_at : null,
   };
 }
 
@@ -190,40 +171,22 @@ export function useRecentEvents(
 ): RecentEvent[] {
   const [events, setEvents] = useState<RecentEvent[]>([]);
   const key = scoringKey(state);
-  // Snapshot we last successfully classified against. We diff prior
-  // vs current to detect set / match undoes — those can't be
-  // detected from the audit log alone (``pop_last_forward``
-  // physically removes the original forward record and doesn't
-  // store the popped payload anywhere visible to the classifier).
+  // We diff prior vs current snapshot to detect set / match undoes:
+  // when the operator undoes a set-winning point the audit log loses
+  // the forward record (``pop_last_forward`` tombstones it) and the
+  // remaining undo record's post-state has the dropped sets count,
+  // but there's no anchor inside the log to diff against. The prior
+  // snapshot carries that anchor forward across refetches.
   const priorSnapshotRef = useRef<PriorSnapshot | null>(null);
-  // The full event list we last surfaced. Used to keep chips that
-  // aged out of the audit fetch window visible across refetches.
-  // We deliberately do NOT use this buffer to resurrect chips whose
-  // underlying record was popped by ``pop_last_forward`` — when the
-  // operator undoes an action, the strip should drop the "alive"
-  // chip and surface only the struck/undone chip, mirroring how
-  // history and report render the same event.
-  const priorEventsRef = useRef<RecentEvent[]>([]);
 
   useEffect(() => {
     if (!enabled || !oid) {
       setEvents([]);
       priorSnapshotRef.current = null;
-      priorEventsRef.current = [];
       return;
     }
     const prior = priorSnapshotRef.current;
     const cur = snapshotState(state);
-    // Drop the stickiness buffer when the operator (re)starts the
-    // match — ``match_started_at`` flipping from one timestamp to
-    // another (or to / from null) means the prior chips belong to
-    // a different match and shouldn't bleed across the boundary.
-    const matchBoundary =
-      prior !== null && cur !== null && prior.matchStartedAt !== cur.matchStartedAt;
-    if (matchBoundary) {
-      priorEventsRef.current = [];
-    }
-    const priorEvents = priorEventsRef.current;
     const controller = new AbortController();
     let cancelled = false;
     // 3× headroom over ``max`` covers interleaved ``add_set`` /
@@ -233,88 +196,47 @@ export function useRecentEvents(
       .getAudit(oid, fetchLimit, controller.signal)
       .then((res) => {
         if (cancelled) return;
+        // The strip is a pure projection of the tombstone-filtered
+        // audit log plus the synthetic set/match-undo chips that the
+        // log can't express on its own. We deliberately do NOT carry
+        // any chips forward across refetches: every fetch fully
+        // replaces the chip list, so rapid-pair tombstones, generic
+        // undoes, and reset all converge to the same view that the
+        // history drawer and printable report render.
         const fresh = classifyRecords(res.records);
 
-        // Pre-compute the synthetic set/match undo chips that will
-        // be appended from the state-diff below — we need them in
-        // the suppression set so a recovered ``set_won`` / ``match_won``
-        // is dropped when its undo only surfaces via the snapshot
-        // diff (not the audit log).
-        const syntheticUndoes: RecentEvent[] = [];
+        // Set / match undo via state-diff. Anchor the synthetic ts
+        // above the last audit chip so the struck chip lands on the
+        // right of the chips that triggered it.
         if (prior && cur) {
           const matchUndone = prior.matchFinished && !cur.matchFinished;
+          const lastChip = fresh[fresh.length - 1];
+          let ts = lastChip ? lastChip.ts : Date.now() / 1000;
           if (cur.sets1 < prior.sets1) {
-            syntheticUndoes.push({
-              ts: 0,
+            ts += 1e-3;
+            fresh.push({
+              ts,
               team: 1,
               kind: matchUndone ? 'match_undo' : 'set_undo',
             });
           }
           if (cur.sets2 < prior.sets2) {
-            syntheticUndoes.push({
-              ts: 0,
+            ts += 1e-3;
+            fresh.push({
+              ts,
               team: 2,
               kind: matchUndone ? 'match_undo' : 'set_undo',
             });
           }
         }
 
-        // Build the suppression set keyed by ``team:kind`` so we can
-        // drop a recovered "alive" chip whose undo counterpart is
-        // already visible — either from the fresh classification or
-        // synthesized from the state-diff.
-        const undoPresent = new Set<string>();
-        for (const e of fresh) undoPresent.add(`${e.team}:${e.kind}`);
-        for (const e of syntheticUndoes) undoPresent.add(`${e.team}:${e.kind}`);
-
-        // Recover events whose underlying audit record aged out of
-        // the fetch window. ``pop_last_forward`` deletes the original
-        // ``add_point`` / ``add_timeout`` row when the operator
-        // undoes it, so a fresh re-classification would be silently
-        // missing the chip we showed last time — but we deliberately
-        // do NOT resurrect the "alive" chip in that case, so the
-        // strip matches history / report (both show only the
-        // struck/undone entry).
-        // ``value`` is part of the identity for ``manual`` chips — two
-        // different manual corrections can land at the same ts (e.g.
-        // low-resolution server clock) and must not dedupe each other.
-        const isSame = (a: RecentEvent, b: RecentEvent) =>
-          a.ts === b.ts &&
-          a.team === b.team &&
-          a.kind === b.kind &&
-          a.value === b.value;
-        const popped = priorEvents.filter((p) => {
-          if (fresh.some((f) => isSame(f, p))) return false;
-          const inverse = INVERSE_UNDO_KIND[p.kind];
-          if (inverse && undoPresent.has(`${p.team}:${inverse}`)) return false;
-          return true;
-        });
-        const merged: RecentEvent[] = [...popped, ...fresh].sort(
-          (a, b) => a.ts - b.ts,
-        );
-
-        // Append the synthetic state-diff undoes now, anchoring each
-        // ts to the latest merged event rather than ``Date.now()``
-        // — the audit log's ts is the server clock and a drifted
-        // client clock could otherwise sort the undo chip ahead of
-        // records that actually happened later.
-        if (syntheticUndoes.length > 0) {
-          const lastMerged = merged[merged.length - 1];
-          let ts = lastMerged ? lastMerged.ts : Date.now() / 1000;
-          for (const u of syntheticUndoes) {
-            ts += 1e-3;
-            merged.push({ ...u, ts });
-          }
-        }
-
-        const capped = merged.slice(-max);
-        setEvents(capped);
+        // ``classifyRecords`` already walks audit records in append
+        // order, so chips are in chronological order — but the
+        // synthetic state-diff chips are pushed at the end with a
+        // bumped ts, which keeps them rightmost without needing a
+        // sort. Slice to the most recent ``max`` chips.
+        setEvents(fresh.slice(-max));
         priorSnapshotRef.current = cur;
-        // Keep extra headroom over ``max`` so a popped event still
-        // sitting just off the visible window can be recovered on
-        // the next refetch (otherwise a single intervening chip
-        // would push it past the cap and lose the recovery anchor).
-        priorEventsRef.current = merged.slice(-max * 4);
       })
       .catch((err) => {
         if (controller.signal.aborted) return;
@@ -322,7 +244,6 @@ export function useRecentEvents(
         // stale data after a score change whose refetch failed.
         console.warn('Failed to fetch recent events:', err);
         setEvents([]);
-        priorEventsRef.current = [];
       });
     return () => {
       cancelled = true;

--- a/frontend/src/hooks/useRecentEvents.ts
+++ b/frontend/src/hooks/useRecentEvents.ts
@@ -152,6 +152,12 @@ interface PriorSnapshot {
   sets1: number;
   sets2: number;
   matchFinished: boolean;
+  // Carried across refetches so we can skip the synthetic state-diff
+  // set/match-undo when the previous snapshot belongs to a different
+  // match — e.g. after a reset the sets drop from 3 to 0 without any
+  // undo really happening, and we must not surface ghost set_undo
+  // chips for that transition.
+  matchStartedAt: number | null;
 }
 
 function snapshotState(state: GameState | null): PriorSnapshot | null {
@@ -160,6 +166,8 @@ function snapshotState(state: GameState | null): PriorSnapshot | null {
     sets1: state.team_1?.sets ?? 0,
     sets2: state.team_2?.sets ?? 0,
     matchFinished: state.match_finished === true,
+    matchStartedAt:
+      typeof state.match_started_at === 'number' ? state.match_started_at : null,
   };
 }
 
@@ -208,7 +216,14 @@ export function useRecentEvents(
         // Set / match undo via state-diff. Anchor the synthetic ts
         // above the last audit chip so the struck chip lands on the
         // right of the chips that triggered it.
-        if (prior && cur) {
+        // Skip entirely on a match boundary (``matchStartedAt`` flips):
+        // the sets-count drop is explained by the reset / new match,
+        // not by an undo, and emitting ``set_undo`` chips here would
+        // ghost-mark a transition the audit log doesn't represent.
+        const sameMatch =
+          prior !== null && cur !== null
+          && prior.matchStartedAt === cur.matchStartedAt;
+        if (prior && cur && sameMatch) {
           const matchUndone = prior.matchFinished && !cur.matchFinished;
           const lastChip = fresh[fresh.length - 1];
           let ts = lastChip ? lastChip.ts : Date.now() / 1000;

--- a/frontend/src/test/useRecentEvents.test.tsx
+++ b/frontend/src/test/useRecentEvents.test.tsx
@@ -119,10 +119,10 @@ describe('useRecentEvents', () => {
     //     strip shows [clock].
     //  2. Operator hits "undo timeout" → ``pop_last_forward`` deletes
     //     the forward record and a new ``undo=true`` row is appended.
-    //     The fresh re-classification only sees the undo, so the
-    //     strip drops the "alive" clock and surfaces just the struck
-    //     variant — mirroring how history and report render the same
-    //     undone timeout (the tombstone hides the forward row).
+    //     The strip re-classifies the fresh fetch and surfaces only
+    //     the struck clock — the popped forward never reaches the
+    //     classifier, matching how history / report render the same
+    //     undone timeout.
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 1,
@@ -578,8 +578,8 @@ describe('useRecentEvents', () => {
     // showing the struck ``point_undo`` chip. Now they hit reset:
     // the score is *still* 0:0 (no numeric change in the key), but
     // ``match_started_at`` flips from a timestamp to ``null``. The
-    // hook must refetch so the matchBoundary detector clears the
-    // sticky buffer and the empty audit surfaces an empty strip.
+    // hook must refetch so the empty audit replaces the previous
+    // chip list with an empty one.
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 1,
@@ -614,9 +614,9 @@ describe('useRecentEvents', () => {
     await waitFor(() => expect(result.current).toEqual([]));
   });
 
-  it('drops sticky events when match_started_at changes (new match boundary)', async () => {
-    // First fetch: a forward point lives in the audit and surfaces a
-    // chip, populating the stickiness buffer.
+  it('drops chips from the previous match when match_started_at changes (new match boundary)', async () => {
+    // First fetch: a forward point lives in the audit and surfaces
+    // a chip in the strip.
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 1,
@@ -629,8 +629,8 @@ describe('useRecentEvents', () => {
       ],
     });
     // Second fetch (after match reset): empty audit, fresh
-    // ``match_started_at``. The sticky chip from the previous match
-    // must not bleed into the new one.
+    // ``match_started_at``. The chip from the previous match must
+    // not bleed into the new one.
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 0,
@@ -651,10 +651,9 @@ describe('useRecentEvents', () => {
     await waitFor(() => expect(result.current).toEqual([]));
   });
 
-  it('anchors set_undo ts to the latest merged event, not Date.now', async () => {
-    // First fetch: set-winning point at ts=10. After classification,
-    // ``priorEvents`` holds the [point_add, set_won] pair both at
-    // ts=10 (the audit ts).
+  it('anchors set_undo ts to the latest audit event, not Date.now', async () => {
+    // First fetch: set-winning point at ts=10 — the strip shows the
+    // [point_add, set_won] pair.
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 2,
@@ -700,9 +699,9 @@ describe('useRecentEvents', () => {
       expect(result.current.some((e) => e.kind === 'set_undo')).toBe(true),
     );
     const setUndo = result.current.find((e) => e.kind === 'set_undo');
-    // Ts must be derived from the latest merged audit ts (11), with
-    // a small bump — *not* a Date.now() value (which would be on the
-    // order of 1.7e9, an order of magnitude apart).
+    // Ts must be derived from the latest audit ts (11) with a small
+    // bump — *not* a Date.now() value (which would be on the order
+    // of 1.7e9, an order of magnitude apart).
     expect(setUndo!.ts).toBeGreaterThan(11);
     expect(setUndo!.ts).toBeLessThan(12);
   });
@@ -710,7 +709,7 @@ describe('useRecentEvents', () => {
   it('does not collapse two distinct manual chips with the same ts but different values', async () => {
     // Two manual corrections that happen to share a ts (e.g.
     // low-resolution server clock). They differ in ``value`` and
-    // must not dedupe each other when stickiness merges them.
+    // each must surface as its own chip.
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 2,
@@ -727,7 +726,7 @@ describe('useRecentEvents', () => {
         }),
       ],
     });
-    // Same payload on refetch — sticky merge must surface both.
+    // Same payload on refetch — both chips must still surface.
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 2,
@@ -749,13 +748,113 @@ describe('useRecentEvents', () => {
       { initialProps: { s: makeState(7, 0) } },
     );
     await waitFor(() => expect(result.current).toHaveLength(2));
-    // Trigger a refetch — same records, sticky merge must not
-    // collapse the two manual chips into one.
+    // Trigger a refetch — same records, the strip must still
+    // surface both distinct values.
     rerender({ s: makeState(7, 1) });
     await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(result.current).toHaveLength(2));
     const values = result.current.map((e) => e.value).sort();
     expect(values).toEqual([5, 7]);
+  });
+
+  it('drops the chip on a rapid-pair forward+undo within 5s (audit empty after collapse)', async () => {
+    // Rapid-pair Case A: operator taps a point and immediately
+    // taps undo within ``RAPID_PAIR_WINDOW_S`` (5 s). The backend
+    // tombstones the just-added forward and writes *no* undo
+    // record — net audit for the pair is empty. The strip must
+    // converge to the same empty view the history drawer and
+    // printable report show.
+    getAuditSpy.mockResolvedValueOnce({
+      oid: 'oid',
+      count: 1,
+      records: [
+        rec(10, 'add_point', { team: 1 }, {
+          score_set: 1,
+          team_1: { score: 1, sets: 0 },
+          team_2: { score: 0, sets: 0 },
+        }),
+      ],
+    });
+    getAuditSpy.mockResolvedValueOnce({
+      oid: 'oid',
+      count: 0,
+      records: [],
+    });
+    const { result, rerender } = renderHook(
+      ({ s }: { s: GameState }) => useRecentEvents('oid', true, s, 8),
+      { initialProps: { s: makeState(1, 0) } },
+    );
+    await waitFor(() =>
+      expect(result.current.some((e) => e.kind === 'point_add')).toBe(true),
+    );
+    rerender({ s: makeState(0, 0) });
+    await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current).toEqual([]));
+  });
+
+  it('keeps chips in monotonic chronological order across refetches', async () => {
+    // Mixed sequence (add_point, undo, add_point, set-winning) —
+    // each subsequent chip's ts is strictly greater than the
+    // previous one. No carry-forward buffer means the next refetch
+    // can never reorder old chips ahead of new ones.
+    getAuditSpy.mockResolvedValueOnce({
+      oid: 'oid',
+      count: 2,
+      records: [
+        rec(1, 'add_point', { team: 1 }, {
+          score_set: 1,
+          team_1: { score: 1, sets: 0 },
+          team_2: { score: 0, sets: 0 },
+        }),
+        rec(2, 'add_point', { team: 2 }, {
+          score_set: 1,
+          team_1: { score: 1, sets: 0 },
+          team_2: { score: 1, sets: 0 },
+        }),
+      ],
+    });
+    getAuditSpy.mockResolvedValueOnce({
+      oid: 'oid',
+      count: 3,
+      records: [
+        rec(1, 'add_point', { team: 1 }, {
+          score_set: 1,
+          team_1: { score: 1, sets: 0 },
+          team_2: { score: 0, sets: 0 },
+        }),
+        // The team-2 forward was popped by an undo at ts=3 — the
+        // audit returns only the undo record after tombstoning.
+        rec(3, 'add_point', { team: 2, undo: true }, {
+          score_set: 1,
+          team_1: { score: 1, sets: 0 },
+          team_2: { score: 0, sets: 0 },
+        }),
+        rec(4, 'add_point', { team: 1 }, {
+          score_set: 1,
+          team_1: { score: 2, sets: 0 },
+          team_2: { score: 0, sets: 0 },
+        }),
+      ],
+    });
+    const { result, rerender } = renderHook(
+      ({ s }: { s: GameState }) => useRecentEvents('oid', true, s, 8),
+      { initialProps: { s: makeState(1, 1) } },
+    );
+    await waitFor(() => expect(result.current).toHaveLength(2));
+    rerender({ s: makeState(2, 0) });
+    await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current).toHaveLength(3));
+    // Strictly monotonic ts: rightmost chip is always the newest.
+    const tss = result.current.map((e) => e.ts);
+    for (let i = 1; i < tss.length; i++) {
+      expect(tss[i]!).toBeGreaterThanOrEqual(tss[i - 1]!);
+    }
+    // And the popped team-2 forward must not survive — only the
+    // baseline team-1 point, the team-2 undo, and the new team-1
+    // forward.
+    expect(result.current[0]).toMatchObject({ team: 1, kind: 'point_add' });
+    expect(result.current[1]).toMatchObject({ team: 2, kind: 'point_undo' });
+    expect(result.current[2]).toMatchObject({ team: 1, kind: 'point_add' });
   });
 
   it('clears events on fetch error', async () => {

--- a/frontend/src/test/useRecentEvents.test.tsx
+++ b/frontend/src/test/useRecentEvents.test.tsx
@@ -757,6 +757,52 @@ describe('useRecentEvents', () => {
     expect(values).toEqual([5, 7]);
   });
 
+  it('does not synthesize set_undo chips on a match reset that drops the sets count', async () => {
+    // Regression guard: after a match where team 1 won 3 sets, the
+    // operator hits reset. The audit log is wiped, ``match_started_at``
+    // flips, and the sets count falls from 3→0 — but no undo really
+    // happened. The state-diff detector must skip the synthetic
+    // ``set_undo`` chips for that transition, otherwise the strip
+    // would ghost-mark the reset with three struck stars the audit
+    // (and therefore history / report) does not represent.
+    getAuditSpy.mockResolvedValueOnce({
+      oid: 'oid',
+      count: 1,
+      records: [
+        rec(1, 'add_set', { team: 1 }, {
+          score_set: 1,
+          team_1: { score: 25, sets: 3 },
+          team_2: { score: 20, sets: 1 },
+        }),
+      ],
+    });
+    getAuditSpy.mockResolvedValueOnce({
+      oid: 'oid',
+      count: 0,
+      records: [],
+    });
+    const stateWithStart = (
+      started: number | null,
+      t1Sets: number,
+      t2Sets: number,
+    ): GameState => ({
+      ...makeState(0, 0, t1Sets, t2Sets),
+      match_started_at: started,
+    } as unknown as GameState);
+    const { result, rerender } = renderHook(
+      ({ s }: { s: GameState }) => useRecentEvents('oid', true, s, 8),
+      { initialProps: { s: stateWithStart(1000, 3, 1) } },
+    );
+    await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(1));
+    // Operator hits reset: ``match_started_at`` flips, sets drop to 0.
+    rerender({ s: stateWithStart(null, 0, 0) });
+    await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current).toEqual([]));
+    // Explicitly: no set_undo / match_undo leaked across the boundary.
+    expect(result.current.some((e) => e.kind === 'set_undo')).toBe(false);
+    expect(result.current.some((e) => e.kind === 'match_undo')).toBe(false);
+  });
+
   it('drops the chip on a rapid-pair forward+undo within 5s (audit empty after collapse)', async () => {
     // Rapid-pair Case A: operator taps a point and immediately
     // taps undo within ``RAPID_PAIR_WINDOW_S`` (5 s). The backend


### PR DESCRIPTION
## Summary

Re-implementation of the recent-actions strip (`useRecentEvents`) as a pure projection of the tombstone-filtered audit log, fixing the persistent inconsistencies the stickiness layer couldn't resolve.

### Why

The previous implementation kept a `priorEventsRef` buffer with chip-recovery heuristics (`INVERSE_UNDO_KIND` suppression, `matchBoundary` clearing) that produced two reproducible classes of bug:

1. **Rapid-pair Case A "ghost chip".** When the operator taps a point and undoes within 5 s, the backend tombstones the forward and writes **no** undo record (audit ends up empty for the pair). The buffer kept the original "alive" chip alive because no inverse undo arrived to suppress it — the strip diverged from the history drawer and the printable report, which both correctly showed nothing.
2. **Chronological order broken.** A buffered synthetic `set_undo` carried `ts = lastMerged + 1e-3`. A subsequent refetch landed fresh audit chips with smaller `ts`, and the merge sort placed them *left* of the buffered chip — visually contradicting the operator's timeline.

### What

- Drop `priorEventsRef` and the recovery / suppression / matchBoundary logic.
- Strip's chip list = `classifyRecords(audit) + state-diff set/match-undoes`. Each refetch fully replaces the chip list.
- Synthetic state-diff undoes get `ts > last(fresh)` so they render rightmost.
- `match_started_at` stays in `scoringKey` so reset refires the effect even when scores are already 0:0.

### Invariants

- Strip is bytewise consistent with the history drawer's record stream (same audit, same tombstones).
- Chronological order is guaranteed by server-monotonic `ts`.
- Rapid-pair Case A → empty audit → empty strip.
- Rapid-pair Case B → restored forward visible → strip shows the original chip.
- Adjacent / non-adjacent / generic undo → only the struck chip(s) visible.

### Trade-off

Lost: recovery of chips that age out of the fetch window. At `max(40, max*3) = 40` records fetched and `max = 8` chips visible, this would require >32 intervening actions. Not realistic for a "recent actions" strip.

## Test plan

- [x] `cd frontend && npx vitest run` — 418 pass (2 new: rapid-pair Case A collapse, strict monotonic ordering).
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: fresh state → add point → undo (within 5 s) → strip empties immediately, undo button disables.
- [ ] Manual: add point → wait 6 s → undo → strip shows only struck chip, undo button disables.
- [ ] Manual: add point team 1 → add point team 2 → undo team 2 → strip shows `[team1 +1, team2 -1]` left-to-right in that order.
- [ ] Manual: set-winning point → undo → strip shows `[..., point_undo, set_undo]` rightmost.
- [ ] Confirm history drawer and `/match/{id}/report` match the strip's view.

https://claude.ai/code/session_01YY6AJZSCCn8TWzvjoy1UhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01YY6AJZSCCn8TWzvjoy1UhV)_