### PR TITLE
refactor(strip): drop undo chips entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ once a first tagged release ships.
 
 ### Changed
 
+- **Recent-actions strip now skips all undo records.** The strip is
+  redefined as a pure "current state activity" indicator: it only
+  renders chips for actions that still contribute to the live
+  score (`point_add`, `set_won`, `match_won`, `timeout`, `manual`).
+  Undo records (`point_undo`, `timeout_undo`) and the synthetic
+  state-diff undoes (`set_undo`, `match_undo`) no longer surface,
+  because the matching forward chip was tombstoned by
+  `pop_last_forward` and a floating struck chip has no visible
+  counterpart to invalidate. Operators can still consult the
+  history drawer and the printable `/match/{id}/report` for the
+  full forensic timeline, which keep showing undone actions as
+  struck rows. As a consequence: clicking team A, then team B,
+  then double-tap-undo on team A (>5 s after the click) now leaves
+  the strip showing only `[+1 B]` — no orphan `-1` chip.
 - **Internal cleanup.** Removed unused legacy `Backend` pass-through
   methods and the unreferenced `PasswordAuthenticator.compose_output`
   helper. Consolidated four duplicated truthy-env parsers into

--- a/frontend/src/components/PointsHistoryStrip.tsx
+++ b/frontend/src/components/PointsHistoryStrip.tsx
@@ -14,7 +14,7 @@ export interface PointsHistoryStripProps {
 
 const ICON_VIEWBOX = '0 0 24 24';
 
-function ClockIcon({ struck }: { struck?: boolean }) {
+function ClockIcon() {
   return (
     <svg viewBox={ICON_VIEWBOX} className="phs-icon" aria-hidden="true">
       <circle cx="12" cy="12" r="8" fill="none" stroke="currentColor" strokeWidth="2" />
@@ -25,55 +25,28 @@ function ClockIcon({ struck }: { struck?: boolean }) {
         strokeWidth="2"
         strokeLinecap="round"
       />
-      {struck && (
-        <line
-          x1="4"
-          y1="20"
-          x2="20"
-          y2="4"
-          stroke="currentColor"
-          strokeWidth="2.5"
-          strokeLinecap="round"
-        />
-      )}
     </svg>
   );
 }
 
-function StrikeLine() {
-  return (
-    <line
-      x1="4"
-      y1="20"
-      x2="20"
-      y2="4"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-    />
-  );
-}
-
-function TrophyIcon({ struck }: { struck?: boolean }) {
+function TrophyIcon() {
   return (
     <svg viewBox={ICON_VIEWBOX} className="phs-icon" aria-hidden="true">
       <path
         d="M7 4h10v3a5 5 0 0 1-10 0V4zm-4 1h2v2a3 3 0 0 0 3 3v-2H4V5zm16 0h2v2a3 3 0 0 1-3 3v-2h2V5zM10 13h4v3h2v3H8v-3h2v-3z"
         fill="currentColor"
       />
-      {struck && <StrikeLine />}
     </svg>
   );
 }
 
-function StarIcon({ struck }: { struck?: boolean }) {
+function StarIcon() {
   return (
     <svg viewBox={ICON_VIEWBOX} className="phs-icon" aria-hidden="true">
       <path
         d="M12 2.5l2.6 6.8 7.4.5-5.6 4.8 1.8 7.2L12 17.9 5.8 21.8l1.8-7.2L2 9.8l7.4-.5L12 2.5z"
         fill="currentColor"
       />
-      {struck && <StrikeLine />}
     </svg>
   );
 }
@@ -93,20 +66,12 @@ function chipContent(ev: RecentEvent) {
   switch (ev.kind) {
     case 'point_add':
       return <span className="phs-chip-text">+1</span>;
-    case 'point_undo':
-      return <span className="phs-chip-text">−1</span>;
     case 'set_won':
       return <StarIcon />;
-    case 'set_undo':
-      return <StarIcon struck />;
     case 'match_won':
       return <TrophyIcon />;
-    case 'match_undo':
-      return <TrophyIcon struck />;
     case 'timeout':
       return <ClockIcon />;
-    case 'timeout_undo':
-      return <ClockIcon struck />;
     case 'manual': {
       const v = ev.value ?? 0;
       return (
@@ -123,20 +88,12 @@ function chipAriaLabel(ev: RecentEvent, teamName: string): string {
   switch (ev.kind) {
     case 'point_add':
       return `${teamName}: +1`;
-    case 'point_undo':
-      return `${teamName}: undo point`;
     case 'set_won':
       return `${teamName}: set won`;
-    case 'set_undo':
-      return `${teamName}: undo set`;
     case 'match_won':
       return `${teamName}: match won`;
-    case 'match_undo':
-      return `${teamName}: undo match`;
     case 'timeout':
       return `${teamName}: timeout`;
-    case 'timeout_undo':
-      return `${teamName}: undo timeout`;
     case 'manual':
       return `${teamName}: manual ${ev.value ?? 0}`;
   }

--- a/frontend/src/hooks/useRecentEvents.ts
+++ b/frontend/src/hooks/useRecentEvents.ts
@@ -1,16 +1,12 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as api from '../api/client';
 import type { GameState, AuditRecord, TeamState } from '../api/client';
 
 export type RecentEventKind =
   | 'point_add'
-  | 'point_undo'
   | 'set_won'
-  | 'set_undo'
   | 'match_won'
-  | 'match_undo'
   | 'timeout'
-  | 'timeout_undo'
   | 'manual';
 
 export interface RecentEvent {
@@ -76,27 +72,27 @@ function classifyRecords(records: AuditRecord[]): RecentEvent[] {
     const validTeam = team === 1 || team === 2;
     const undo = !!params.undo;
 
+    // The strip is a "current state activity" indicator — undo
+    // records have no on-screen counterpart (the matching forward
+    // was tombstoned by ``pop_last_forward``), so surfacing the
+    // struck chip alone would float without context. Skip them
+    // entirely and let the history drawer / printable report keep
+    // their forensic timeline. The ``prevSets`` / ``prevMatchFinished``
+    // trackers below also stay frozen on undo records, so an undone
+    // set-winning point does not inject a leftover ``set_won`` chip
+    // on the next refetch.
+    if (undo) continue;
+
     // ── Action-driven chips ────────────────────────────────────────
     if (validTeam) {
       const t = team as 1 | 2;
       switch (r.action) {
         case 'add_point':
-          events.push({ ts: r.ts, team: t, kind: undo ? 'point_undo' : 'point_add' });
+          events.push({ ts: r.ts, team: t, kind: 'point_add' });
           break;
-        case 'add_timeout': {
-          // The forward audit record is physically removed by
-          // ``pop_last_forward`` when the operator undoes a timeout,
-          // so a popped forward never reaches the classifier — only
-          // its undo does. We emit the struck chip on undo to match
-          // history / report (which both surface only the undone
-          // entry once the forward is tombstoned).
-          events.push({
-            ts: r.ts,
-            team: t,
-            kind: undo ? 'timeout_undo' : 'timeout',
-          });
+        case 'add_timeout':
+          events.push({ ts: r.ts, team: t, kind: 'timeout' });
           break;
-        }
         case 'set_score': {
           const setNum = params.set_number;
           const newVal = params.value;
@@ -148,29 +144,6 @@ function classifyRecords(records: AuditRecord[]): RecentEvent[] {
   return events;
 }
 
-interface PriorSnapshot {
-  sets1: number;
-  sets2: number;
-  matchFinished: boolean;
-  // Carried across refetches so we can skip the synthetic state-diff
-  // set/match-undo when the previous snapshot belongs to a different
-  // match — e.g. after a reset the sets drop from 3 to 0 without any
-  // undo really happening, and we must not surface ghost set_undo
-  // chips for that transition.
-  matchStartedAt: number | null;
-}
-
-function snapshotState(state: GameState | null): PriorSnapshot | null {
-  if (!state) return null;
-  return {
-    sets1: state.team_1?.sets ?? 0,
-    sets2: state.team_2?.sets ?? 0,
-    matchFinished: state.match_finished === true,
-    matchStartedAt:
-      typeof state.match_started_at === 'number' ? state.match_started_at : null,
-  };
-}
-
 export function useRecentEvents(
   oid: string | null,
   enabled: boolean,
@@ -179,22 +152,12 @@ export function useRecentEvents(
 ): RecentEvent[] {
   const [events, setEvents] = useState<RecentEvent[]>([]);
   const key = scoringKey(state);
-  // We diff prior vs current snapshot to detect set / match undoes:
-  // when the operator undoes a set-winning point the audit log loses
-  // the forward record (``pop_last_forward`` tombstones it) and the
-  // remaining undo record's post-state has the dropped sets count,
-  // but there's no anchor inside the log to diff against. The prior
-  // snapshot carries that anchor forward across refetches.
-  const priorSnapshotRef = useRef<PriorSnapshot | null>(null);
 
   useEffect(() => {
     if (!enabled || !oid) {
       setEvents([]);
-      priorSnapshotRef.current = null;
       return;
     }
-    const prior = priorSnapshotRef.current;
-    const cur = snapshotState(state);
     const controller = new AbortController();
     let cancelled = false;
     // 3× headroom over ``max`` covers interleaved ``add_set`` /
@@ -205,53 +168,14 @@ export function useRecentEvents(
       .then((res) => {
         if (cancelled) return;
         // The strip is a pure projection of the tombstone-filtered
-        // audit log plus the synthetic set/match-undo chips that the
-        // log can't express on its own. We deliberately do NOT carry
-        // any chips forward across refetches: every fetch fully
-        // replaces the chip list, so rapid-pair tombstones, generic
-        // undoes, and reset all converge to the same view that the
-        // history drawer and printable report render.
+        // audit log. Every fetch fully replaces the chip list, so
+        // rapid-pair tombstones, generic undoes, and reset all
+        // converge to a deterministic "current state activity" view.
+        // Undo records contribute nothing to the strip (see the
+        // ``if (undo) continue`` in ``classifyRecords``) — they live
+        // only in the history drawer and the printable report.
         const fresh = classifyRecords(res.records);
-
-        // Set / match undo via state-diff. Anchor the synthetic ts
-        // above the last audit chip so the struck chip lands on the
-        // right of the chips that triggered it.
-        // Skip entirely on a match boundary (``matchStartedAt`` flips):
-        // the sets-count drop is explained by the reset / new match,
-        // not by an undo, and emitting ``set_undo`` chips here would
-        // ghost-mark a transition the audit log doesn't represent.
-        const sameMatch =
-          prior !== null && cur !== null
-          && prior.matchStartedAt === cur.matchStartedAt;
-        if (prior && cur && sameMatch) {
-          const matchUndone = prior.matchFinished && !cur.matchFinished;
-          const lastChip = fresh[fresh.length - 1];
-          let ts = lastChip ? lastChip.ts : Date.now() / 1000;
-          if (cur.sets1 < prior.sets1) {
-            ts += 1e-3;
-            fresh.push({
-              ts,
-              team: 1,
-              kind: matchUndone ? 'match_undo' : 'set_undo',
-            });
-          }
-          if (cur.sets2 < prior.sets2) {
-            ts += 1e-3;
-            fresh.push({
-              ts,
-              team: 2,
-              kind: matchUndone ? 'match_undo' : 'set_undo',
-            });
-          }
-        }
-
-        // ``classifyRecords`` already walks audit records in append
-        // order, so chips are in chronological order — but the
-        // synthetic state-diff chips are pushed at the end with a
-        // bumped ts, which keeps them rightmost without needing a
-        // sort. Slice to the most recent ``max`` chips.
         setEvents(fresh.slice(-max));
-        priorSnapshotRef.current = cur;
       })
       .catch((err) => {
         if (controller.signal.aborted) return;

--- a/frontend/src/hooks/useRecentEvents.ts
+++ b/frontend/src/hooks/useRecentEvents.ts
@@ -75,16 +75,16 @@ function classifyRecords(records: AuditRecord[]): RecentEvent[] {
     // The strip is a "current state activity" indicator — undo
     // records have no on-screen counterpart (the matching forward
     // was tombstoned by ``pop_last_forward``), so surfacing the
-    // struck chip alone would float without context. Skip them
-    // entirely and let the history drawer / printable report keep
-    // their forensic timeline. The ``prevSets`` / ``prevMatchFinished``
-    // trackers below also stay frozen on undo records, so an undone
-    // set-winning point does not inject a leftover ``set_won`` chip
-    // on the next refetch.
-    if (undo) continue;
+    // struck chip alone would float without context. Skip emitting
+    // a chip but still let the state trackers (``prevSets``,
+    // ``prevMatchFinished``, ``lastScore``) advance below — if we
+    // bailed out of the iteration entirely, a subsequent forward
+    // would diff against a stale baseline and silently lose its
+    // chip (e.g. an undone set-winning point followed by a fresh
+    // set-winning point would no longer emit the trophy).
 
     // ── Action-driven chips ────────────────────────────────────────
-    if (validTeam) {
+    if (validTeam && !undo) {
       const t = team as 1 | 2;
       switch (r.action) {
         case 'add_point':

--- a/frontend/src/test/PointsHistoryStrip.test.tsx
+++ b/frontend/src/test/PointsHistoryStrip.test.tsx
@@ -56,11 +56,6 @@ describe('PointsHistoryStrip', () => {
     expect(screen.queryByTestId('phs-chip-1-1')).not.toBeInTheDocument();
   });
 
-  it('renders point_undo as -1 (using a true minus sign)', () => {
-    render(strip([{ ts: 1, team: 1, kind: 'point_undo' }]));
-    expect(screen.getByTestId('phs-chip-1-0')).toHaveTextContent('−1');
-  });
-
   it('renders manual chips with the absolute value (no sign)', () => {
     render(
       strip([
@@ -111,21 +106,19 @@ describe('PointsHistoryStrip', () => {
     );
   });
 
-  it('renders an SVG icon for set_won, match_won, timeout, timeout_undo and manual chips', () => {
+  it('renders an SVG icon for set_won, match_won, timeout and manual chips', () => {
     render(
       strip([
         { ts: 1, team: 1, kind: 'set_won' },
         { ts: 2, team: 2, kind: 'timeout' },
-        { ts: 3, team: 1, kind: 'timeout_undo' },
-        { ts: 4, team: 2, kind: 'manual', value: 4 },
-        { ts: 5, team: 1, kind: 'match_won' },
+        { ts: 3, team: 2, kind: 'manual', value: 4 },
+        { ts: 4, team: 1, kind: 'match_won' },
       ]),
     );
     expect(screen.getByTestId('phs-chip-1-0').querySelector('svg')).not.toBeNull();
     expect(screen.getByTestId('phs-chip-2-1').querySelector('svg')).not.toBeNull();
-    expect(screen.getByTestId('phs-chip-1-2').querySelector('svg')).not.toBeNull();
-    expect(screen.getByTestId('phs-chip-2-3').querySelector('svg')).not.toBeNull();
-    expect(screen.getByTestId('phs-chip-1-4').querySelector('svg')).not.toBeNull();
+    expect(screen.getByTestId('phs-chip-2-2').querySelector('svg')).not.toBeNull();
+    expect(screen.getByTestId('phs-chip-1-3').querySelector('svg')).not.toBeNull();
   });
 
   it('uses a different aria-label for match_won than set_won', () => {

--- a/frontend/src/test/useRecentEvents.test.tsx
+++ b/frontend/src/test/useRecentEvents.test.tsx
@@ -73,7 +73,11 @@ describe('useRecentEvents', () => {
     expect(getAuditSpy).not.toHaveBeenCalled();
   });
 
-  it('classifies add_point forward and undo into point_add / point_undo', async () => {
+  it('classifies add_point forwards into point_add chips and skips undo records', async () => {
+    // The visible audit contains two forwards and one undo; the
+    // strip skips the undo so the operator only sees chips that
+    // still contribute to the live score. The undone action lives
+    // on in the history drawer and the printable report.
     getAuditSpy.mockResolvedValue({
       oid: 'oid',
       count: 3,
@@ -86,10 +90,9 @@ describe('useRecentEvents', () => {
     const { result } = renderHook(() =>
       useRecentEvents('oid', true, makeState(2, 0), 8),
     );
-    await waitFor(() => expect(result.current).toHaveLength(3));
+    await waitFor(() => expect(result.current).toHaveLength(2));
     expect(result.current).toEqual([
       { ts: 1, team: 1, kind: 'point_add' },
-      { ts: 2, team: 2, kind: 'point_undo' },
       { ts: 3, team: 1, kind: 'point_add' },
     ]);
   });
@@ -113,16 +116,15 @@ describe('useRecentEvents', () => {
     expect(result.current[0]).toMatchObject({ team: 2, kind: 'timeout' });
   });
 
-  it('drops the original timeout chip when the operator undoes an adjacent timeout (matches history / report)', async () => {
+  it('drops the original timeout chip when the operator undoes an adjacent timeout (and emits no struck chip)', async () => {
     // Real-life flow across two fetches:
     //  1. Operator hits "+timeout" → audit gets the forward record →
     //     strip shows [clock].
     //  2. Operator hits "undo timeout" → ``pop_last_forward`` deletes
     //     the forward record and a new ``undo=true`` row is appended.
-    //     The strip re-classifies the fresh fetch and surfaces only
-    //     the struck clock — the popped forward never reaches the
-    //     classifier, matching how history / report render the same
-    //     undone timeout.
+    //     The strip drops the undo record entirely so the operator
+    //     sees an empty strip — the floating struck clock would
+    //     have no visible counterpart to invalidate.
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 1,
@@ -154,11 +156,10 @@ describe('useRecentEvents', () => {
     );
     rerender({ s: makeState(0, 0, 0, 0, 0, 0) });
     await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(result.current).toHaveLength(1));
-    expect(result.current.map((e) => e.kind)).toEqual(['timeout_undo']);
+    await waitFor(() => expect(result.current).toEqual([]));
   });
 
-  it('drops the original set_won chip when the operator undoes a set-winning point (matches history / report)', async () => {
+  it('drops the set_won chip when the operator undoes a set-winning point (no surviving struck chip)', async () => {
     // First fetch: a baseline point (so ``prevSets`` is anchored) and
     // the set-winning ``add_point`` are both in the audit.
     getAuditSpy.mockResolvedValueOnce({
@@ -178,9 +179,9 @@ describe('useRecentEvents', () => {
       ],
     });
     // Second fetch: forward was popped, leaving the baseline point
-    // plus the new ``undo=true`` record. The set_won and the
-    // set-winning point's "alive" chip must both disappear from the
-    // strip — same as the audit-backed history / report views.
+    // plus the new ``undo=true`` record. The strip drops the undo
+    // chip and keeps only the baseline — no leftover star or struck
+    // chip survives the undo.
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 2,
@@ -206,21 +207,11 @@ describe('useRecentEvents', () => {
     );
     rerender({ s: makeState(24, 20, 0, 0) });
     await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(2));
-    await waitFor(() =>
-      expect(result.current.some((e) => e.kind === 'set_undo')).toBe(true),
-    );
-    const kinds = result.current.map((e) => e.kind);
-    // Baseline point still visible (it was never undone), and the
-    // undo / set_undo chips replace the popped set-winning pair.
-    expect(kinds).toContain('point_undo');
-    expect(kinds).toContain('set_undo');
-    expect(kinds).not.toContain('set_won');
-    // Exactly one ``point_add`` — the baseline. The set-winning
-    // forward was popped, so its "alive" chip must not survive.
-    expect(kinds.filter((k) => k === 'point_add')).toHaveLength(1);
+    await waitFor(() => expect(result.current).toHaveLength(1));
+    expect(result.current[0]).toMatchObject({ ts: 9, team: 1, kind: 'point_add' });
   });
 
-  it('drops the original match_won chip and surfaces point_undo + match_undo on a match-winning undo', async () => {
+  it('drops the match_won chip on a match-winning undo (no surviving struck chip)', async () => {
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 2,
@@ -270,27 +261,15 @@ describe('useRecentEvents', () => {
     );
     rerender({ s: makeState(24, 20, 2, 1) });
     await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(2));
-    await waitFor(() =>
-      expect(result.current.some((e) => e.kind === 'match_undo')).toBe(true),
-    );
-    const kinds = result.current.map((e) => e.kind);
-    expect(kinds).toContain('point_undo');
-    expect(kinds).toContain('match_undo');
-    // The popped match-winning forward must not survive in the strip
-    // — same as history / report.
-    expect(kinds).not.toContain('match_won');
-    expect(kinds.filter((k) => k === 'point_add')).toHaveLength(1);
-    // Trophy preempts the star — undoing a match-winning point should
-    // not also push a struck-star alongside the struck-trophy.
-    expect(kinds).not.toContain('set_undo');
+    await waitFor(() => expect(result.current).toHaveLength(1));
+    expect(result.current[0]).toMatchObject({ ts: 9, team: 1, kind: 'point_add' });
   });
 
-  it('always emits a struck-clock chip on timeout undo (adjacent case → just struck)', async () => {
-    // After ``pop_last_forward`` the original forward record is gone,
-    // so the audit response only contains the undo entry. We always
-    // emit the struck chip — consistent with point_undo's behaviour —
-    // and skip synthesizing the forward (no in-between record carries
-    // the bumped count to anchor it).
+  it('drops a stand-alone timeout undo record (no struck-clock surfaces)', async () => {
+    // After ``pop_last_forward`` the original forward record is gone
+    // and the audit response only contains the undo entry. The strip
+    // surfaces nothing — the undo would float without a visible
+    // counterpart to invalidate.
     getAuditSpy.mockResolvedValue({
       oid: 'oid',
       count: 1,
@@ -305,42 +284,25 @@ describe('useRecentEvents', () => {
     const { result } = renderHook(() =>
       useRecentEvents('oid', true, makeState(0, 0), 8),
     );
-    await waitFor(() => expect(result.current).toHaveLength(1));
-    expect(result.current[0]).toMatchObject({ team: 1, kind: 'timeout_undo' });
+    await waitFor(() => expect(getAuditSpy).toHaveBeenCalled());
+    expect(result.current).toEqual([]);
   });
 
-  it('injects a struck-star chip when a team\'s sets count drops between refetches', async () => {
+  it('does not synthesize set/match undo chips from a sets-count drop between refetches', async () => {
+    // The strip is a pure projection of the audit log — it does NOT
+    // try to surface set/match undoes via a snapshot diff. The undo
+    // record is invisible (its forward was tombstoned) so the strip
+    // simply forgets the previously-emitted ``set_won`` chip on the
+    // next fetch.
     getAuditSpy.mockResolvedValue({ oid: 'oid', count: 0, records: [] });
     const { result, rerender } = renderHook(
       ({ s }: { s: GameState }) => useRecentEvents('oid', true, s, 8),
       { initialProps: { s: makeState(0, 0, 1, 0) } },
     );
     await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(1));
-    // Operator clicks undo on the set-winning point — sets drops.
     rerender({ s: makeState(24, 20, 0, 0) });
     await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(2));
-    await waitFor(() =>
-      expect(result.current.some((e) => e.kind === 'set_undo' && e.team === 1)).toBe(true),
-    );
-  });
-
-  it('injects a struck-trophy chip when match_finished flips back to false with a sets drop', async () => {
-    getAuditSpy.mockResolvedValue({ oid: 'oid', count: 0, records: [] });
-    const finishedState = (): GameState => ({
-      ...makeState(0, 0, 3, 0),
-      match_finished: true,
-    } as unknown as GameState);
-    const { result, rerender } = renderHook(
-      ({ s }: { s: GameState }) => useRecentEvents('oid', true, s, 8),
-      { initialProps: { s: finishedState() } },
-    );
-    await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(1));
-    // Operator undoes the match-winning point.
-    rerender({ s: makeState(24, 20, 2, 0) });
-    await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(2));
-    await waitFor(() =>
-      expect(result.current.some((e) => e.kind === 'match_undo' && e.team === 1)).toBe(true),
-    );
+    await waitFor(() => expect(result.current).toEqual([]));
   });
 
   it('does not resurrect a popped forward timeout chip when an undo is non-adjacent (matches history / report)', async () => {
@@ -349,8 +311,8 @@ describe('useRecentEvents', () => {
     // After pop_last_forward the audit response is the baseline
     // point + the in-between point (still showing the bumped
     // timeout count) + the undo. The strip surfaces only the
-    // records the audit still carries — the popped forward stays
-    // hidden, same as in history / report.
+    // forward chips — the popped timeout forward stays hidden,
+    // and the standalone undo record is dropped too.
     getAuditSpy.mockResolvedValue({
       oid: 'oid',
       count: 3,
@@ -360,15 +322,11 @@ describe('useRecentEvents', () => {
           team_1: { score: 1, sets: 0, timeouts: 0 },
           team_2: { score: 0, sets: 0, timeouts: 0 },
         }),
-        // In-between record — its post-state still shows the
-        // bumped timeout count, but we no longer synthesize a
-        // forward chip from that diff.
         rec(2, 'add_point', { team: 1 }, {
           score_set: 1,
           team_1: { score: 2, sets: 0, timeouts: 1 },
           team_2: { score: 0, sets: 0, timeouts: 0 },
         }),
-        // Undo brings the count back down.
         rec(3, 'add_timeout', { team: 1, undo: true }, {
           score_set: 1,
           team_1: { score: 2, sets: 0, timeouts: 0 },
@@ -379,11 +337,9 @@ describe('useRecentEvents', () => {
     const { result } = renderHook(() =>
       useRecentEvents('oid', true, makeState(2, 0), 8),
     );
-    await waitFor(() => expect(result.current).toHaveLength(3));
+    await waitFor(() => expect(result.current).toHaveLength(2));
     expect(result.current[0]).toMatchObject({ team: 1, kind: 'point_add' });
     expect(result.current[1]).toMatchObject({ team: 1, kind: 'point_add' });
-    expect(result.current[2]).toMatchObject({ team: 1, kind: 'timeout_undo' });
-    expect(result.current.some((e) => e.kind === 'timeout')).toBe(false);
   });
 
   it('emits match_won (not set_won) when a sets++ also flips match_finished', async () => {
@@ -397,7 +353,6 @@ describe('useRecentEvents', () => {
           team_2: { score: 20, sets: 0 },
           match_finished: false,
         }),
-        // Match-winning point: sets++ AND match_finished flips true.
         rec(2, 'add_point', { team: 1 }, {
           score_set: 1,
           team_1: { score: 25, sets: 3 },
@@ -418,9 +373,6 @@ describe('useRecentEvents', () => {
     getAuditSpy.mockResolvedValue({
       oid: 'oid',
       count: 2,
-      // First record anchors the prevSets baseline; second record bumps
-      // team_1.sets so the diff fires. The explicit add_set itself
-      // produces no action chip — only the trophy from the diff.
       records: [
         rec(1, 'add_point', { team: 1 }, {
           score_set: 1, team_1: { score: 1, sets: 0 }, team_2: { score: 0, sets: 0 },
@@ -446,7 +398,6 @@ describe('useRecentEvents', () => {
         rec(1, 'add_point', { team: 1 }, {
           score_set: 1, team_1: { score: 24, sets: 0 }, team_2: { score: 20, sets: 0 },
         }),
-        // Set-winning add_point — backend logs add_point, NOT add_set.
         rec(2, 'add_point', { team: 1 }, {
           score_set: 1, team_1: { score: 25, sets: 1 }, team_2: { score: 20, sets: 0 },
         }),
@@ -573,13 +524,12 @@ describe('useRecentEvents', () => {
     await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(2));
   });
 
-  it('refetches and clears chips on reset when scores stayed at zero', async () => {
+  it('refetches and stays empty on reset when scores stayed at zero', async () => {
     // Operator added a point then undid it back to 0:0 — strip is
-    // showing the struck ``point_undo`` chip. Now they hit reset:
-    // the score is *still* 0:0 (no numeric change in the key), but
-    // ``match_started_at`` flips from a timestamp to ``null``. The
-    // hook must refetch so the empty audit replaces the previous
-    // chip list with an empty one.
+    // already empty because we drop undo records. Now they hit
+    // reset: the score is *still* 0:0 (no numeric change in the key),
+    // but ``match_started_at`` flips. The hook refetches and the
+    // empty audit keeps the strip empty.
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 1,
@@ -604,11 +554,10 @@ describe('useRecentEvents', () => {
       ({ s }: { s: GameState }) => useRecentEvents('oid', true, s, 8),
       { initialProps: { s: stateWithStart(1000) } },
     );
-    await waitFor(() =>
-      expect(result.current.some((e) => e.kind === 'point_undo')).toBe(true),
-    );
-    // Operator hits reset: scores stayed at 0:0 but
-    // ``match_started_at`` becomes null. The effect must re-run.
+    await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current).toEqual([]));
+    // Operator hits reset: ``match_started_at`` becomes null. The
+    // effect must re-run even though scores didn't change.
     rerender({ s: stateWithStart(null) });
     await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(result.current).toEqual([]));
@@ -651,120 +600,11 @@ describe('useRecentEvents', () => {
     await waitFor(() => expect(result.current).toEqual([]));
   });
 
-  it('anchors set_undo ts to the latest audit event, not Date.now', async () => {
-    // First fetch: set-winning point at ts=10 — the strip shows the
-    // [point_add, set_won] pair.
-    getAuditSpy.mockResolvedValueOnce({
-      oid: 'oid',
-      count: 2,
-      records: [
-        rec(9, 'add_point', { team: 1 }, {
-          score_set: 1,
-          team_1: { score: 24, sets: 0 },
-          team_2: { score: 20, sets: 0 },
-        }),
-        rec(10, 'add_point', { team: 1 }, {
-          score_set: 1,
-          team_1: { score: 25, sets: 1 },
-          team_2: { score: 20, sets: 0 },
-        }),
-      ],
-    });
-    // Second fetch: forward popped, undo at ts=11.
-    getAuditSpy.mockResolvedValueOnce({
-      oid: 'oid',
-      count: 2,
-      records: [
-        rec(9, 'add_point', { team: 1 }, {
-          score_set: 1,
-          team_1: { score: 24, sets: 0 },
-          team_2: { score: 20, sets: 0 },
-        }),
-        rec(11, 'add_point', { team: 1, undo: true }, {
-          score_set: 1,
-          team_1: { score: 24, sets: 0 },
-          team_2: { score: 20, sets: 0 },
-        }),
-      ],
-    });
-    const { result, rerender } = renderHook(
-      ({ s }: { s: GameState }) => useRecentEvents('oid', true, s, 8),
-      { initialProps: { s: makeState(25, 20, 1, 0) } },
-    );
-    await waitFor(() =>
-      expect(result.current.some((e) => e.kind === 'set_won')).toBe(true),
-    );
-    rerender({ s: makeState(24, 20, 0, 0) });
-    await waitFor(() =>
-      expect(result.current.some((e) => e.kind === 'set_undo')).toBe(true),
-    );
-    const setUndo = result.current.find((e) => e.kind === 'set_undo');
-    // Ts must be derived from the latest audit ts (11) with a small
-    // bump — *not* a Date.now() value (which would be on the order
-    // of 1.7e9, an order of magnitude apart).
-    expect(setUndo!.ts).toBeGreaterThan(11);
-    expect(setUndo!.ts).toBeLessThan(12);
-  });
-
-  it('does not collapse two distinct manual chips with the same ts but different values', async () => {
-    // Two manual corrections that happen to share a ts (e.g.
-    // low-resolution server clock). They differ in ``value`` and
-    // each must surface as its own chip.
-    getAuditSpy.mockResolvedValueOnce({
-      oid: 'oid',
-      count: 2,
-      records: [
-        rec(10, 'set_score', { team: 1, set_number: 1, value: 5 }, {
-          score_set: 1,
-          team_1: { score: 5, sets: 0 },
-          team_2: { score: 0, sets: 0 },
-        }),
-        rec(10, 'set_score', { team: 1, set_number: 1, value: 7 }, {
-          score_set: 1,
-          team_1: { score: 7, sets: 0 },
-          team_2: { score: 0, sets: 0 },
-        }),
-      ],
-    });
-    // Same payload on refetch — both chips must still surface.
-    getAuditSpy.mockResolvedValueOnce({
-      oid: 'oid',
-      count: 2,
-      records: [
-        rec(10, 'set_score', { team: 1, set_number: 1, value: 5 }, {
-          score_set: 1,
-          team_1: { score: 5, sets: 0 },
-          team_2: { score: 0, sets: 0 },
-        }),
-        rec(10, 'set_score', { team: 1, set_number: 1, value: 7 }, {
-          score_set: 1,
-          team_1: { score: 7, sets: 0 },
-          team_2: { score: 0, sets: 0 },
-        }),
-      ],
-    });
-    const { result, rerender } = renderHook(
-      ({ s }: { s: GameState }) => useRecentEvents('oid', true, s, 8),
-      { initialProps: { s: makeState(7, 0) } },
-    );
-    await waitFor(() => expect(result.current).toHaveLength(2));
-    // Trigger a refetch — same records, the strip must still
-    // surface both distinct values.
-    rerender({ s: makeState(7, 1) });
-    await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(result.current).toHaveLength(2));
-    const values = result.current.map((e) => e.value).sort();
-    expect(values).toEqual([5, 7]);
-  });
-
-  it('does not synthesize set_undo chips on a match reset that drops the sets count', async () => {
+  it('does not regenerate chips on a match reset that drops the sets count', async () => {
     // Regression guard: after a match where team 1 won 3 sets, the
-    // operator hits reset. The audit log is wiped, ``match_started_at``
-    // flips, and the sets count falls from 3→0 — but no undo really
-    // happened. The state-diff detector must skip the synthetic
-    // ``set_undo`` chips for that transition, otherwise the strip
-    // would ghost-mark the reset with three struck stars the audit
-    // (and therefore history / report) does not represent.
+    // operator hits reset. Sets count falls from 3→0 without any
+    // undo. The strip stays empty — no synthetic set_undo chips
+    // are emitted (we never derive chips from snapshot diffs now).
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 1,
@@ -794,21 +634,17 @@ describe('useRecentEvents', () => {
       { initialProps: { s: stateWithStart(1000, 3, 1) } },
     );
     await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(1));
-    // Operator hits reset: ``match_started_at`` flips, sets drop to 0.
     rerender({ s: stateWithStart(null, 0, 0) });
     await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(result.current).toEqual([]));
-    // Explicitly: no set_undo / match_undo leaked across the boundary.
-    expect(result.current.some((e) => e.kind === 'set_undo')).toBe(false);
-    expect(result.current.some((e) => e.kind === 'match_undo')).toBe(false);
   });
 
   it('drops the chip on a rapid-pair forward+undo within 5s (audit empty after collapse)', async () => {
     // Rapid-pair Case A: operator taps a point and immediately
     // taps undo within ``RAPID_PAIR_WINDOW_S`` (5 s). The backend
     // tombstones the just-added forward and writes *no* undo
-    // record — net audit for the pair is empty. The strip must
-    // converge to the same empty view the history drawer and
+    // record — net audit for the pair is empty. The strip
+    // converges to the same empty view the history drawer and
     // printable report show.
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
@@ -839,10 +675,12 @@ describe('useRecentEvents', () => {
   });
 
   it('keeps chips in monotonic chronological order across refetches', async () => {
-    // Mixed sequence (add_point, undo, add_point, set-winning) —
-    // each subsequent chip's ts is strictly greater than the
-    // previous one. No carry-forward buffer means the next refetch
-    // can never reorder old chips ahead of new ones.
+    // Mixed sequence (add_point, undo, add_point) — each subsequent
+    // forward chip's ts is strictly greater than the previous one.
+    // No carry-forward buffer means the next refetch can never
+    // reorder old chips ahead of new ones; the undo record is
+    // dropped entirely so the surviving chips are just the
+    // forwards.
     getAuditSpy.mockResolvedValueOnce({
       oid: 'oid',
       count: 2,
@@ -868,8 +706,6 @@ describe('useRecentEvents', () => {
           team_1: { score: 1, sets: 0 },
           team_2: { score: 0, sets: 0 },
         }),
-        // The team-2 forward was popped by an undo at ts=3 — the
-        // audit returns only the undo record after tombstoning.
         rec(3, 'add_point', { team: 2, undo: true }, {
           score_set: 1,
           team_1: { score: 1, sets: 0 },
@@ -889,18 +725,13 @@ describe('useRecentEvents', () => {
     await waitFor(() => expect(result.current).toHaveLength(2));
     rerender({ s: makeState(2, 0) });
     await waitFor(() => expect(getAuditSpy).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(result.current).toHaveLength(3));
-    // Strictly monotonic ts: rightmost chip is always the newest.
+    await waitFor(() => expect(result.current).toHaveLength(2));
     const tss = result.current.map((e) => e.ts);
     for (let i = 1; i < tss.length; i++) {
       expect(tss[i]!).toBeGreaterThanOrEqual(tss[i - 1]!);
     }
-    // And the popped team-2 forward must not survive — only the
-    // baseline team-1 point, the team-2 undo, and the new team-1
-    // forward.
-    expect(result.current[0]).toMatchObject({ team: 1, kind: 'point_add' });
-    expect(result.current[1]).toMatchObject({ team: 2, kind: 'point_undo' });
-    expect(result.current[2]).toMatchObject({ team: 1, kind: 'point_add' });
+    expect(result.current[0]).toMatchObject({ ts: 1, team: 1, kind: 'point_add' });
+    expect(result.current[1]).toMatchObject({ ts: 4, team: 1, kind: 'point_add' });
   });
 
   it('clears events on fetch error', async () => {

--- a/frontend/src/test/useRecentEvents.test.tsx
+++ b/frontend/src/test/useRecentEvents.test.tsx
@@ -734,6 +734,86 @@ describe('useRecentEvents', () => {
     expect(result.current[1]).toMatchObject({ ts: 4, team: 1, kind: 'point_add' });
   });
 
+  it('still emits set_won for a forward after an interposed undo (state trackers stay in sync)', async () => {
+    // Regression guard: an undo record between two set-winning
+    // forwards must update the ``prevSets`` baseline so the
+    // *second* forward's diff fires. If undo records short-circuit
+    // the loop, the second forward would diff against the stale
+    // pre-undo baseline (same sets count) and lose its star chip.
+    getAuditSpy.mockResolvedValue({
+      oid: 'oid',
+      count: 3,
+      records: [
+        // Set-winning point — anchors prevSets to {1: 1}.
+        rec(1, 'add_point', { team: 1 }, {
+          score_set: 1,
+          team_1: { score: 25, sets: 1 },
+          team_2: { score: 20, sets: 0 },
+        }),
+        // Undo that set win — post-state sets back to 0. Must
+        // update prevSets even though no chip is emitted.
+        rec(2, 'add_point', { team: 1, undo: true }, {
+          score_set: 1,
+          team_1: { score: 24, sets: 0 },
+          team_2: { score: 20, sets: 0 },
+        }),
+        // Fresh set-winning point — diff vs prevSets {1: 0} must
+        // fire the trophy.
+        rec(3, 'add_point', { team: 1 }, {
+          score_set: 1,
+          team_1: { score: 25, sets: 1 },
+          team_2: { score: 20, sets: 0 },
+        }),
+      ],
+    });
+    const { result } = renderHook(() =>
+      useRecentEvents('oid', true, makeState(25, 20, 1, 0), 8),
+    );
+    await waitFor(() => expect(result.current).toHaveLength(3));
+    expect(result.current[0]).toMatchObject({ ts: 1, team: 1, kind: 'point_add' });
+    expect(result.current[1]).toMatchObject({ ts: 3, team: 1, kind: 'point_add' });
+    expect(result.current[2]).toMatchObject({ ts: 3, team: 1, kind: 'set_won' });
+  });
+
+  it('still emits manual chips for a forward after an interposed undo (lastScore tracker stays in sync)', async () => {
+    // Companion to the set_won regression test: ``lastScore`` must
+    // also advance through undo records so a follow-up ``set_score``
+    // chip fires when the typed value differs from the current
+    // (post-undo) score.
+    getAuditSpy.mockResolvedValue({
+      oid: 'oid',
+      count: 3,
+      records: [
+        // Operator types 5 → manual chip.
+        rec(1, 'set_score', { team: 1, set_number: 1, value: 5 }, {
+          score_set: 1,
+          team_1: { score: 5, sets: 0 },
+          team_2: { score: 0, sets: 0 },
+        }),
+        // Undo the point that took them to 5 — post-state 4.
+        // Tracker must advance to 4 so the next set_score's diff
+        // is computed against 4, not against the stale 5.
+        rec(2, 'add_point', { team: 1, undo: true }, {
+          score_set: 1,
+          team_1: { score: 4, sets: 0 },
+          team_2: { score: 0, sets: 0 },
+        }),
+        // Operator types 7 — differs from the post-undo 4 → chip.
+        rec(3, 'set_score', { team: 1, set_number: 1, value: 7 }, {
+          score_set: 1,
+          team_1: { score: 7, sets: 0 },
+          team_2: { score: 0, sets: 0 },
+        }),
+      ],
+    });
+    const { result } = renderHook(() =>
+      useRecentEvents('oid', true, makeState(7, 0), 8),
+    );
+    await waitFor(() => expect(result.current).toHaveLength(2));
+    expect(result.current[0]).toMatchObject({ team: 1, kind: 'manual', value: 5 });
+    expect(result.current[1]).toMatchObject({ team: 1, kind: 'manual', value: 7 });
+  });
+
   it('clears events on fetch error', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     getAuditSpy.mockRejectedValue(new Error('boom'));


### PR DESCRIPTION
## Summary

Operator reported that after a non-rapid-pair undo, the strip showed a struck `-1` chip with no visible `+1` to invalidate (the matching forward was tombstoned by `pop_last_forward`). The floating struck chip is confusing because, unlike the history drawer / report, the strip's chips don't carry text labels — the visual pair was the only context.

This PR redefines the strip as a pure "current state activity" indicator: only chips that still contribute to the live score are rendered.

### What changes

- `classifyRecords` skips every record with `params.undo === true`. No `point_undo` / `timeout_undo` chips are emitted.
- The snapshot-diff `set_undo` / `match_undo` synthesis is removed entirely; `priorSnapshotRef` is gone.
- `RecentEventKind` shrinks to `point_add | set_won | match_won | timeout | manual`.
- `PointsHistoryStrip` drops the struck-icon branches and the `struck` prop on its icon helpers.

### What stays

- The history drawer (`RecentAuditDrawer`) and the printable `/match/{id}/report` keep surfacing undo records as struck rows — they're the forensic timeline.
- The strip's `scoringKey` still includes `match_started_at`, so reset still forces a refetch.

### User-facing example

Click team A → click team B → wait >5 s → double-tap-undo team A. Before: strip showed `[+1 B, -1 A]` with a floating `-1`. After: strip shows `[+1 B]` only. The drawer / report still show the undone team A point as a struck row.

## Test plan

- [x] `cd frontend && npx vitest run` — 415 pass.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: click A → click B → wait 6 s → double-tap-undo A → strip shows `[+1 B]`, drawer shows `[+1 A, +1 B, undo A]`.
- [ ] Manual: rapid-pair (<5 s) forward+undo on team A → strip empties, undo button disables.
- [ ] Manual: set-winning point → undo → strip drops the star (no struck-star surfaces).
- [ ] Manual: reset mid-match → strip empties.

https://claude.ai/code/session_01YY6AJZSCCn8TWzvjoy1UhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01YY6AJZSCCn8TWzvjoy1UhV)_