### PR TITLE
fix(timer): freeze match clock at end + clear stale spectator stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,41 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Match timer no longer ticks past match end.** The HUD timer in
+  the React control UI and the match/set counters on the
+  `/follow/{id}` spectator page now freeze at the actual end-of-
+  match value as soon as the set-winning point or set lands,
+  instead of continuing to count up until the operator reloads.
+  Backed by a new ``match_finished_at`` timestamp on
+  ``GameStateResponse`` and on the overlay broadcast payload's
+  ``match_info`` block.
+- **Spectator page now shows a "match finished" indicator.** Once
+  the match transitions to finished, the alerts strip renders a
+  localized ``Match finished`` / ``Partido finalizado`` badge and
+  hides the now-stale set-point / match-point / side-switch pills.
+  The match/set timer pill also tints green to make the frozen
+  state visually distinct from a paused-between-rallies live
+  match.
+- **Reset on the operator UI now clears the spectator's stats and
+  time history.** The overlay state-store deep-merge previously
+  left per-set entries in ``overlay_control.points_by_set`` /
+  ``timeouts_by_set`` / ``stats.set_durations`` behind because an
+  empty dict from the post-reset broadcast is a no-op for a deep
+  merge. The store now force-replaces those audit-derived
+  subtrees on every update so a Reset wipes the spectator chart,
+  history, and per-set durations alongside the scoreboard.
+
+### Changed
+
+- **``match_started_at`` is no longer cleared when a match is
+  archived.** The session keeps the start anchor in place after
+  match end so the HUD timer and the spectator page can render the
+  final elapsed duration (``match_finished_at - match_started_at``)
+  until the operator hits Reset — which is now the only path that
+  returns the session to the pre-match idle state.
+
 ## [5.2.1] - 2026-05-12
 
 ### Added

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -123,6 +123,7 @@ class GameService:
             match_point_info=match_point_info,
             can_undo=session.undoable_forward_count > 0,
             match_started_at=session.match_started_at,
+            match_finished_at=session.match_finished_at,
         )
         elapsed_ms = (time.perf_counter() - t0) * 1000
         # Misconfigured env var must not turn every /state call into a 500;
@@ -418,6 +419,20 @@ class GameService:
         if set_won:
             session.current_set = session._compute_current_set()
 
+        # Stamp the match-end timestamp before the broadcast so the
+        # HUD timer and the spectator page receive it together with
+        # the ``match_finished`` flag and can freeze their elapsed
+        # counters at the actual end-of-match value instead of
+        # ticking forward until the next reload.
+        if (
+            not undo
+            and set_won
+            and not was_finished_before
+            and session.game_manager.match_finished(session.sets_limit)
+            and session.match_finished_at is None
+        ):
+            session.match_finished_at = time.time()
+
         # Audit before computing ``state_response`` so the cached
         # ``undoable_forward_count`` (and therefore ``can_undo``) the
         # state response carries is up to date for *this* action.
@@ -492,6 +507,16 @@ class GameService:
             session.undo = False
 
         session.current_set = session._compute_current_set()
+        # Same as add_point: stamp ``match_finished_at`` before the
+        # broadcast so consumers can freeze the elapsed counters at
+        # the actual end-of-match value.
+        if (
+            not undo
+            and not was_finished_before
+            and session.game_manager.match_finished(session.sets_limit)
+            and session.match_finished_at is None
+        ):
+            session.match_finished_at = time.time()
         # Audit before ``get_state`` so the ``can_undo`` flag the
         # broadcast carries reflects the just-bumped counter.
         GameService._audit(
@@ -734,6 +759,10 @@ class GameService:
         if session.match_started_at is None:
             GameService._invalidate_rapid_pair_cache(session)
             session.match_started_at = time.time()
+            # Belt-and-braces: a fresh arm should never carry a stale
+            # finished-at from a prior match still hanging around in
+            # the persisted meta.
+            session.match_finished_at = None
             session.persist_meta()
             GameService._audit(session, "start_match", {})
             GameService._broadcast(session)
@@ -748,8 +777,11 @@ class GameService:
         session.current_set = session._compute_current_set()
         # Reset wipes the match — clear the start clock so the next
         # match begins unarmed (operator hits ``Start match`` or scores
-        # the first point to arm it again).
+        # the first point to arm it again). Also clear the end-of-match
+        # timestamp so the HUD timer / spectator page exit the frozen
+        # post-match display and return to the pre-match idle state.
         session.match_started_at = None
+        session.match_finished_at = None
         # Reset wipes the match — start the audit log fresh too so the
         # archive boundaries align with operator intent. Counter goes
         # to zero alongside the log so ``can_undo`` is correct. Run
@@ -910,9 +942,11 @@ class GameService:
 
         Called from add_point and add_set after the mutation completes.
         Returns the new ``match_id`` (or ``None`` if no archive happened).
-        After a successful archive the session's ``match_started_at`` is
-        cleared so the next match starts unarmed — the operator (or
-        the first point) re-arms it the same way it did at the start.
+        ``match_started_at`` is intentionally left in place so the HUD
+        timer and the spectator page can render the final elapsed
+        duration (``match_finished_at - match_started_at``) until the
+        operator hits Reset — which is the only path that clears both
+        timestamps and returns the session to the pre-match idle state.
 
         Callers that have a fresh post-mutation ``GameStateResponse``
         should pass it via *state_response* to avoid the redundant
@@ -936,7 +970,6 @@ class GameService:
                 points_limit_last_set=session.points_limit_last_set,
                 sets_limit=session.sets_limit,
             )
-            session.match_started_at = None
             session.persist_meta()
             return match_id
         except Exception as exc:

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -236,6 +236,36 @@ class GameService:
             )
 
     @staticmethod
+    def _sync_match_finished_at(session, was_finished_before: bool) -> None:
+        """Stamp / clear ``session.match_finished_at`` to match the
+        current match-finished state.
+
+        Called before every broadcast that follows a mutation that
+        could transition the match-finished flag (``add_point``,
+        ``add_set``, ``set_score``, ``set_sets_value``). Both
+        directions matter:
+
+        * forward transition into finished ⇒ stamp the wall clock so
+          consumers freeze their elapsed counters at the actual end-
+          of-match value.
+        * reverse transition out of finished (undo of a match-winning
+          action, or a manual ``set_score`` / ``set_sets_value`` edit
+          that re-opens the match) ⇒ clear the stamp so the React
+          ``MatchTimer`` (which freezes purely on ``finishedAt !=
+          null``) resumes ticking.
+
+        No-op when the finished state didn't change.
+        """
+        is_finished_now = session.game_manager.match_finished(
+            session.sets_limit,
+        )
+        if not was_finished_before and is_finished_now:
+            if session.match_finished_at is None:
+                session.match_finished_at = time.time()
+        elif was_finished_before and not is_finished_now:
+            session.match_finished_at = None
+
+    @staticmethod
     def _consume_rapid_pair(session, team: int, undo: bool) -> bool:
         """Return ``True`` when the incoming ``add_point`` collapses
         with the most recent opposite-kind action on the same team
@@ -419,22 +449,7 @@ class GameService:
         if set_won:
             session.current_set = session._compute_current_set()
 
-        # Stamp / clear the match-end timestamp before the broadcast
-        # so the HUD timer and the spectator page receive it together
-        # with the ``match_finished`` flag. Both directions matter:
-        #   * forward set-winning point ⇒ stamp ``match_finished_at``
-        #     so consumers freeze their elapsed counters at the actual
-        #     end-of-match value.
-        #   * undo of a match-winning point ⇒ clear ``match_finished_at``
-        #     so the React ``MatchTimer`` (which freezes purely on
-        #     ``finishedAt != null``) resumes ticking now that the
-        #     match is back in progress.
-        is_finished_now = session.game_manager.match_finished(session.sets_limit)
-        if not was_finished_before and is_finished_now:
-            if session.match_finished_at is None:
-                session.match_finished_at = time.time()
-        elif was_finished_before and not is_finished_now:
-            session.match_finished_at = None
+        GameService._sync_match_finished_at(session, was_finished_before)
 
         # Audit before computing ``state_response`` so the cached
         # ``undoable_forward_count`` (and therefore ``can_undo``) the
@@ -510,17 +525,7 @@ class GameService:
             session.undo = False
 
         session.current_set = session._compute_current_set()
-        # Same as add_point: stamp ``match_finished_at`` on the forward
-        # transition that closes the match and clear it on the undo
-        # that reopens it, so the React MatchTimer (which freezes on
-        # ``finishedAt != null``) resumes ticking after a reverted
-        # match-winning set.
-        is_finished_now = session.game_manager.match_finished(session.sets_limit)
-        if not was_finished_before and is_finished_now:
-            if session.match_finished_at is None:
-                session.match_finished_at = time.time()
-        elif was_finished_before and not is_finished_now:
-            session.match_finished_at = None
+        GameService._sync_match_finished_at(session, was_finished_before)
         # Audit before ``get_state`` so the ``can_undo`` flag the
         # broadcast carries reflects the just-bumped counter.
         GameService._audit(
@@ -603,6 +608,7 @@ class GameService:
                 ),
             )
         GameService._invalidate_rapid_pair_cache(session)
+        was_finished_before = session.game_manager.match_finished(session.sets_limit)
         session.game_manager.set_game_value(team, value, set_number)
         set_won = session.game_manager.check_set_won(
             team, set_number,
@@ -614,6 +620,12 @@ class GameService:
         # match_finished guard here is redundant.
         if set_won:
             session.current_set = session._compute_current_set()
+        # A manual ``set_score`` edit can push the match in either
+        # direction (e.g. setting the winning team's score to 25 in
+        # the deciding set finishes the match; setting it back to 23
+        # re-opens it), so keep ``match_finished_at`` in sync with
+        # the current finished state before the broadcast.
+        GameService._sync_match_finished_at(session, was_finished_before)
         state_response = GameService.get_state(session)
         GameService._save_and_broadcast(session, state_response)
         GameService._audit(session, "set_score", {
@@ -624,8 +636,13 @@ class GameService:
     @staticmethod
     def set_sets_value(session, team: int, value: int) -> ActionResponse:
         GameService._invalidate_rapid_pair_cache(session)
+        was_finished_before = session.game_manager.match_finished(session.sets_limit)
         session.game_manager.set_sets_value(team, value)
         session.current_set = session._compute_current_set()
+        # Same as ``set_score``: a direct sets-won edit can transition
+        # the match in either direction; keep ``match_finished_at`` in
+        # sync before the broadcast.
+        GameService._sync_match_finished_at(session, was_finished_before)
         state_response = GameService.get_state(session)
         GameService._save_and_broadcast(session, state_response)
         GameService._audit(session, "set_sets_value", {"team": team, "value": value})

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -419,19 +419,22 @@ class GameService:
         if set_won:
             session.current_set = session._compute_current_set()
 
-        # Stamp the match-end timestamp before the broadcast so the
-        # HUD timer and the spectator page receive it together with
-        # the ``match_finished`` flag and can freeze their elapsed
-        # counters at the actual end-of-match value instead of
-        # ticking forward until the next reload.
-        if (
-            not undo
-            and set_won
-            and not was_finished_before
-            and session.game_manager.match_finished(session.sets_limit)
-            and session.match_finished_at is None
-        ):
-            session.match_finished_at = time.time()
+        # Stamp / clear the match-end timestamp before the broadcast
+        # so the HUD timer and the spectator page receive it together
+        # with the ``match_finished`` flag. Both directions matter:
+        #   * forward set-winning point ⇒ stamp ``match_finished_at``
+        #     so consumers freeze their elapsed counters at the actual
+        #     end-of-match value.
+        #   * undo of a match-winning point ⇒ clear ``match_finished_at``
+        #     so the React ``MatchTimer`` (which freezes purely on
+        #     ``finishedAt != null``) resumes ticking now that the
+        #     match is back in progress.
+        is_finished_now = session.game_manager.match_finished(session.sets_limit)
+        if not was_finished_before and is_finished_now:
+            if session.match_finished_at is None:
+                session.match_finished_at = time.time()
+        elif was_finished_before and not is_finished_now:
+            session.match_finished_at = None
 
         # Audit before computing ``state_response`` so the cached
         # ``undoable_forward_count`` (and therefore ``can_undo``) the
@@ -507,16 +510,17 @@ class GameService:
             session.undo = False
 
         session.current_set = session._compute_current_set()
-        # Same as add_point: stamp ``match_finished_at`` before the
-        # broadcast so consumers can freeze the elapsed counters at
-        # the actual end-of-match value.
-        if (
-            not undo
-            and not was_finished_before
-            and session.game_manager.match_finished(session.sets_limit)
-            and session.match_finished_at is None
-        ):
-            session.match_finished_at = time.time()
+        # Same as add_point: stamp ``match_finished_at`` on the forward
+        # transition that closes the match and clear it on the undo
+        # that reopens it, so the React MatchTimer (which freezes on
+        # ``finishedAt != null``) resumes ticking after a reverted
+        # match-winning set.
+        is_finished_now = session.game_manager.match_finished(session.sets_limit)
+        if not was_finished_before and is_finished_now:
+            if session.match_finished_at is None:
+                session.match_finished_at = time.time()
+        elif was_finished_before and not is_finished_now:
+            session.match_finished_at = None
         # Audit before ``get_state`` so the ``can_undo`` flag the
         # broadcast carries reflects the just-bumped counter.
         GameService._audit(

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -185,6 +185,12 @@ class GameStateResponse(BaseModel):
     # match timer in the HUD and toggles the Start-match / Reset
     # button in the control bar.
     match_started_at: float | None = None
+    # Wall-clock seconds at which the match transitioned to finished,
+    # or ``None`` while the match is still in progress (or pending).
+    # Lets clients freeze the match timer at the actual end-of-match
+    # value instead of letting it keep ticking after match end.
+    # Cleared on reset and on ``start_match``.
+    match_finished_at: float | None = None
 
 
 class ActionResponse(BaseModel):

--- a/app/api/session_manager.py
+++ b/app/api/session_manager.py
@@ -49,6 +49,15 @@ class GameSession:
         # actual whistle. ``GameService.reset`` clears it back to
         # ``None``. Persisted via session_meta so it survives restarts.
         self.match_started_at: float | None = None
+        # Wall-clock seconds at which the match transitioned from
+        # in-progress to finished (the set-winning add_point/add_set
+        # that closes the match), or ``None`` while the match is still
+        # in progress. Used by the HUD timer and the spectator page to
+        # freeze the elapsed counters at the actual end-of-match value
+        # instead of letting them keep ticking after match end.
+        # ``GameService.reset`` and ``GameService.start_match`` clear
+        # it back to ``None``. Persisted via session_meta.
+        self.match_finished_at: float | None = None
         # Match-rule preset (``'indoor'`` or ``'beach'``). Persisted in
         # session_meta. Drives the beach side-switch indicator and the
         # "reset to defaults" affordance in the new MatchRulesSection.
@@ -114,6 +123,10 @@ class GameSession:
                 float(self.match_started_at)
                 if self.match_started_at is not None else None
             ),
+            "match_finished_at": (
+                float(self.match_finished_at)
+                if self.match_finished_at is not None else None
+            ),
         }
 
     def touch(self):
@@ -136,6 +149,10 @@ class GameSession:
             "match_started_at": (
                 float(self.match_started_at)
                 if self.match_started_at is not None else None
+            ),
+            "match_finished_at": (
+                float(self.match_finished_at)
+                if self.match_finished_at is not None else None
             ),
             "mode": str(self.mode),
         }
@@ -168,6 +185,15 @@ class GameSession:
             else:
                 try:
                     self.match_started_at = float(raw)
+                except (TypeError, ValueError):
+                    pass
+        if "match_finished_at" in meta:
+            raw = meta["match_finished_at"]
+            if raw is None:
+                self.match_finished_at = None
+            else:
+                try:
+                    self.match_finished_at = float(raw)
                 except (TypeError, ValueError):
                     pass
         if "mode" in meta and is_valid_mode(meta["mode"]):

--- a/app/backend.py
+++ b/app/backend.py
@@ -241,6 +241,7 @@ class Backend:
         sets_limit = int(self.conf.sets)
         match_finished_flag = False
         match_started_at: float | None = None
+        match_finished_at: float | None = None
         getter = self._rule_overrides_getter
         if callable(getter):
             try:
@@ -261,6 +262,9 @@ class Backend:
             raw_started = overrides.get("match_started_at")
             if isinstance(raw_started, (int, float)):
                 match_started_at = float(raw_started)
+            raw_finished = overrides.get("match_finished_at")
+            if isinstance(raw_finished, (int, float)):
+                match_finished_at = float(raw_finished)
 
         payload = {
             "match_info": {
@@ -279,6 +283,16 @@ class Backend:
                 # this to tick a live match-elapsed counter; the OBS
                 # templates ignore it.
                 "match_started_at": match_started_at,
+                # Wall-clock seconds at which the match transitioned
+                # to finished (or ``None`` while it's still in
+                # progress). Lets the spectator freeze its match
+                # timer at the actual end-of-match value instead of
+                # ticking forward indefinitely after match end.
+                "match_finished_at": match_finished_at,
+                # Mirror of ``match_finished_flag`` so the spectator
+                # can render a "match finished" indicator without
+                # having to re-derive it from the per-team set counts.
+                "match_finished": match_finished_flag,
             },
             "team_home": {
                 "name": cust.get_team_name(1),

--- a/app/overlay/state_store.py
+++ b/app/overlay/state_store.py
@@ -43,6 +43,50 @@ def deep_merge(base: dict, update: dict) -> dict:
     return base
 
 
+# Paths in the broadcast payload whose nested-dict values must FULLY
+# REPLACE the corresponding subtree in the merged state instead of
+# being deep-merged into it. These fields are derived from the per-OID
+# audit log on every broadcast — a deep-merge would leave stale per-set
+# entries behind after ``GameService.reset`` clears the audit, so a
+# fresh empty payload would never overwrite e.g. ``points_by_set``
+# entries from the previous match. The spectator page would then keep
+# rendering the stale chart / time history even after the operator
+# reset the scoreboard.
+_REPLACE_SUBTREES: tuple[tuple[str, ...], ...] = (
+    ("overlay_control", "points_by_set"),
+    ("overlay_control", "timeouts_by_set"),
+    ("overlay_control", "stats", "set_durations"),
+    ("overlay_control", "stats", "services"),
+    ("overlay_control", "stats", "points_history"),
+)
+
+
+def _replace_subtrees(state: dict, payload: dict) -> None:
+    """Force-replace specific subtrees on *state* with values from *payload*.
+
+    Run after :func:`deep_merge` so any audit-derived dict whose keys
+    can disappear between broadcasts (e.g. per-set buckets after a
+    reset) gets the fresh value, not a stale-key union.
+    """
+    for path in _REPLACE_SUBTREES:
+        node_p: object = payload
+        for key in path:
+            if not isinstance(node_p, dict) or key not in node_p:
+                node_p = None
+                break
+            node_p = node_p[key]
+        if node_p is None:
+            continue
+        node_s: object = state
+        for key in path[:-1]:
+            if not isinstance(node_s, dict):
+                node_s = None
+                break
+            node_s = node_s.setdefault(key, {})
+        if isinstance(node_s, dict):
+            node_s[path[-1]] = node_p
+
+
 def normalize_state(state: dict) -> None:
     """Enforce business rules on the merged state in place.
 
@@ -557,6 +601,7 @@ class OverlayStateStore:
         with self._lock:
             ctx = self.get_overlay_context(overlay_id)
             deep_merge(ctx["state"], payload)
+            _replace_subtrees(ctx["state"], payload)
             normalize_state(ctx["state"])
             snapshot = copy.deepcopy(ctx["state"])
         await self.save_persisted_state_async(overlay_id, snapshot)
@@ -568,6 +613,7 @@ class OverlayStateStore:
         with self._lock:
             ctx = self.get_overlay_context(overlay_id)
             deep_merge(ctx["state"], payload)
+            _replace_subtrees(ctx["state"], payload)
             normalize_state(ctx["state"])
             snapshot = copy.deepcopy(ctx["state"])
         self.save_persisted_state(overlay_id, snapshot)

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -296,6 +296,17 @@
             "title": "Match Finished",
             "type": "boolean"
           },
+          "match_finished_at": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Match Finished At"
+          },
           "match_point_info": {
             "anyOf": [
               {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -968,6 +968,16 @@ body {
   font-size: 1rem;
 }
 
+/* Once the match transitions to finished the timer freezes at the
+   end-of-match value; the green tint lets the operator see at a
+   glance that the clock is no longer ticking. */
+.match-timer-finished {
+  color: #4caf50;
+}
+.match-timer-finished .material-icons {
+  color: #4caf50;
+}
+
 .control-btn-logout {
   border-color: #f44336;
   color: #f44336;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1322,6 +1322,8 @@ export interface components {
             current_set: number;
             /** Match Finished */
             match_finished: boolean;
+            /** Match Finished At */
+            match_finished_at?: number | null;
             match_point_info?: components["schemas"]["MatchPointInfo"] | null;
             /** Match Started At */
             match_started_at?: number | null;

--- a/frontend/src/components/ControlButtons.tsx
+++ b/frontend/src/components/ControlButtons.tsx
@@ -22,13 +22,18 @@ export interface ControlButtonsProps {
    */
   matchStartedAt: number | null | undefined;
   /**
-   * ``true`` once the match transitions to finished. Combined with
-   * ``matchStartedAt`` to decide which side of the Start/Reset
-   * toggle to render: the archive path clears
-   * ``matchStartedAt`` to prep the next match, but the operator
-   * still sees the just-played scoreboard and needs to hit Reset
-   * before the next start can be armed — so a finished match
-   * forces the Reset face regardless of the timer field.
+   * Match end timestamp (Unix seconds), or ``null`` while the match
+   * is still in progress. Forwarded to ``MatchTimer`` so the live
+   * counter freezes at the actual end-of-match value once the
+   * match transitions to finished.
+   */
+  matchFinishedAt?: number | null | undefined;
+  /**
+   * ``true`` once the match transitions to finished. Drives one half
+   * of the Start-match / Reset toggle so the operator's next step is
+   * Reset, not Start. ``matchStartedAt`` stays in place after match
+   * end (so the timer can render the final duration); Reset is the
+   * only path that clears it back to ``null``.
    */
   matchFinished: boolean;
   onToggleVisibility: () => void;
@@ -58,6 +63,7 @@ export default function ControlButtons({
   canUndo,
   showPreview,
   matchStartedAt,
+  matchFinishedAt,
   matchFinished,
   onToggleVisibility,
   onToggleSimpleMode,
@@ -67,10 +73,10 @@ export default function ControlButtons({
   onReset,
 }: ControlButtonsProps) {
   const { t } = useI18n();
-  // ``matchFinished`` keeps the Reset face up after a match ends —
-  // ``_archive_if_finished`` zeroes ``matchStartedAt`` to prep the
-  // next match but the operator still sees the just-played
-  // scoreboard, so the next required action is Reset, not Start.
+  // The Reset face stays up while the match is in progress, and
+  // while a finished match is still being shown — only an explicit
+  // Reset returns the operator to the pre-match idle state where
+  // Start match is armable again.
   const showReset = matchStartedAt != null || matchFinished;
 
   return (
@@ -98,7 +104,7 @@ export default function ControlButtons({
       )}
 
       <div className="spacer">
-        <MatchTimer startedAt={matchStartedAt} />
+        <MatchTimer startedAt={matchStartedAt} finishedAt={matchFinishedAt} />
       </div>
 
       <button

--- a/frontend/src/components/MatchTimer.tsx
+++ b/frontend/src/components/MatchTimer.tsx
@@ -8,35 +8,47 @@ export interface MatchTimerProps {
    * or hits Start match.
    */
   startedAt: number | null | undefined;
+  /**
+   * Match end timestamp (Unix seconds), or ``null`` while the match
+   * is still in progress. When set, the counter freezes at
+   * ``finishedAt - startedAt`` and the per-second tick is suspended
+   * so the timer no longer creeps forward after match end.
+   */
+  finishedAt?: number | null | undefined;
 }
 
 /**
  * Live MM:SS counter relative to ``startedAt``. Updates once per
- * second via ``setInterval``; pauses when the prop goes to ``null``.
+ * second via ``setInterval`` while the match is running; freezes at
+ * ``finishedAt - startedAt`` once the match ends; renders nothing
+ * before the match is armed.
  *
  * Shown in the HUD control bar so the operator and the match report
  * agree on "match duration so far". Negative deltas (clock skew
  * between server and client) clamp to ``0:00`` rather than render a
  * minus sign.
  */
-export default function MatchTimer({ startedAt }: MatchTimerProps) {
+export default function MatchTimer({ startedAt, finishedAt }: MatchTimerProps) {
   const [now, setNow] = useState<number>(() => Date.now() / 1000);
+  const isFinished = finishedAt != null;
 
   useEffect(() => {
     if (startedAt == null) return;
+    if (isFinished) return;
     const id = setInterval(() => setNow(Date.now() / 1000), 1000);
     return () => clearInterval(id);
-  }, [startedAt]);
+  }, [startedAt, isFinished]);
 
   if (startedAt == null) return null;
-  const elapsed = Math.max(0, Math.floor(now - startedAt));
+  const reference = isFinished ? finishedAt! : now;
+  const elapsed = Math.max(0, Math.floor(reference - startedAt));
   const minutes = Math.floor(elapsed / 60);
   const seconds = elapsed % 60;
   const label = `${minutes}:${String(seconds).padStart(2, '0')}`;
 
   return (
     <div
-      className="match-timer"
+      className={`match-timer${isFinished ? ' match-timer-finished' : ''}`}
       role="timer"
       aria-live="off"
       data-testid="match-timer"

--- a/frontend/src/components/ScoreboardView.tsx
+++ b/frontend/src/components/ScoreboardView.tsx
@@ -220,6 +220,7 @@ export default function ScoreboardView({
             canUndo={canUndo}
             showPreview={showPreview}
             matchStartedAt={state.match_started_at}
+            matchFinishedAt={state.match_finished_at}
             matchFinished={state.match_finished}
             onToggleVisibility={onToggleVisibility}
             onToggleSimpleMode={onToggleSimpleMode}

--- a/frontend/src/test/ControlButtons.test.tsx
+++ b/frontend/src/test/ControlButtons.test.tsx
@@ -146,12 +146,12 @@ describe('ControlButtons', () => {
   });
 
   it('shows Reset (not Start) once the match is finished, even if matchStartedAt is null', () => {
-    // Regression: ``_archive_if_finished`` clears
-    // ``match_started_at`` to prep the next match, but the
-    // operator still sees the just-played scoreboard. The next
-    // required action is Reset, not Start — otherwise clicking
-    // Start would arm a fresh timer over the visible (finished)
-    // scores.
+    // ``match_started_at`` would normally still be set after match
+    // end (so the timer can render the final duration), but a meta
+    // file from a pre-fix deployment can land in this state on
+    // restart. The Reset face must still win over Start so the
+    // operator does not accidentally arm a new timer over the
+    // visible just-finished scoreboard.
     renderWithI18n(
       <ControlButtons
         {...defaultProps}

--- a/frontend/src/test/MatchTimer.test.tsx
+++ b/frontend/src/test/MatchTimer.test.tsx
@@ -49,4 +49,18 @@ describe('MatchTimer', () => {
     renderWithI18n(<MatchTimer startedAt={now / 1000 + 30} />);
     expect(screen.getByTestId('match-timer')).toHaveTextContent('0:00');
   });
+
+  it('freezes at finishedAt - startedAt once the match ends', () => {
+    const start = 1_700_000_000;
+    // Wall clock has advanced past the match end — timer must show
+    // the *frozen* end-of-match value, not the larger live elapsed.
+    vi.setSystemTime(new Date(start * 1000 + 600_000));
+    renderWithI18n(
+      <MatchTimer startedAt={start} finishedAt={start + 75} />,
+    );
+    expect(screen.getByTestId('match-timer')).toHaveTextContent('1:15');
+    expect(screen.getByTestId('match-timer')).toHaveClass(
+      'match-timer-finished',
+    );
+  });
 });

--- a/overlay_static/css/spectator.css
+++ b/overlay_static/css/spectator.css
@@ -121,6 +121,20 @@ html, body {
     border-color: rgba(251, 191, 36, 0.55);
     color: #fbbf24;
 }
+/*
+  Match-finished badge spans the full alert strip and sits in the
+  centre column so it doesn't compete with the per-team set/match-
+  point pills (which are hidden once the match ends anyway). Using
+  a calmer green reads as "this is a steady terminal state" instead
+  of the red-pulse "act now" semantic of match point.
+*/
+.alert-match-finished {
+    grid-column: 1 / -1;
+    justify-self: center;
+    background: rgba(16, 185, 129, 0.18);
+    border-color: rgba(16, 185, 129, 0.55);
+    color: #6ee7b7;
+}
 .alert-side-switch.pending {
     background: #fbbf24;
     color: #1f1300;
@@ -373,6 +387,18 @@ html, body {
     letter-spacing: 0.06em;
 }
 .match-times[hidden] { display: none; }
+/*
+  Once the match transitions to finished the timer values stop
+  ticking; tint the pill so the viewer can tell at a glance the
+  clock is frozen rather than just stuck between rallies.
+*/
+.match-times.match-times-finished {
+    background: rgba(16, 185, 129, 0.12);
+    color: #6ee7b7;
+}
+.match-times.match-times-finished .match-time-value {
+    color: #6ee7b7;
+}
 .match-time-row {
     display: inline-flex;
     align-items: baseline;

--- a/overlay_static/js/spectator.js
+++ b/overlay_static/js/spectator.js
@@ -31,6 +31,7 @@
             'rules.bestOf': 'Best of {n}',
             'rules.points': '{regular} · {last} in deciding set',
             'rules.switchEvery': 'Side switch every {n} pts',
+            'alert.matchFinished': 'Match finished',
             'alert.setPoint': 'Set point',
             'alert.matchPoint': 'Match point',
             'alert.switchIn': 'Switch in {n} pt',
@@ -68,6 +69,7 @@
             'rules.bestOf': 'Al mejor de {n}',
             'rules.points': '{regular} · {last} en set decisivo',
             'rules.switchEvery': 'Cambio cada {n} pts',
+            'alert.matchFinished': 'Partido finalizado',
             'alert.setPoint': 'Punto de set',
             'alert.matchPoint': 'Punto de partido',
             'alert.switchIn': 'Cambio en {n} pt',
@@ -105,6 +107,7 @@
             'rules.bestOf': 'À melhor de {n}',
             'rules.points': '{regular} · {last} no set decisivo',
             'rules.switchEvery': 'Mudança cada {n} pts',
+            'alert.matchFinished': 'Partida terminada',
             'alert.setPoint': 'Ponto de set',
             'alert.matchPoint': 'Ponto de partida',
             'alert.switchIn': 'Mudança em {n} pt',
@@ -142,6 +145,7 @@
             'rules.bestOf': 'Al meglio dei {n}',
             'rules.points': '{regular} · {last} nel set decisivo',
             'rules.switchEvery': 'Cambio campo ogni {n} pt',
+            'alert.matchFinished': 'Partita terminata',
             'alert.setPoint': 'Set point',
             'alert.matchPoint': 'Match point',
             'alert.switchIn': 'Cambio tra {n} pt',
@@ -179,6 +183,7 @@
             'rules.bestOf': 'Au meilleur des {n}',
             'rules.points': '{regular} · {last} dans le set décisif',
             'rules.switchEvery': 'Changement tous les {n} pts',
+            'alert.matchFinished': 'Match terminé',
             'alert.setPoint': 'Balle de set',
             'alert.matchPoint': 'Balle de match',
             'alert.switchIn': 'Changement dans {n} pt',
@@ -216,6 +221,7 @@
             'rules.bestOf': 'Best of {n}',
             'rules.points': '{regular} · {last} im Entscheidungssatz',
             'rules.switchEvery': 'Seitenwechsel alle {n} Pkt',
+            'alert.matchFinished': 'Spiel beendet',
             'alert.setPoint': 'Satzball',
             'alert.matchPoint': 'Matchball',
             'alert.switchIn': 'Wechsel in {n} Pkt',
@@ -508,6 +514,14 @@
         const setNum = effectiveSet();
         const currentSet = match.current_set || 1;
         const isLiveSet = setNum === currentSet;
+        // Once the match transitions to finished, freeze every elapsed
+        // counter at the actual end-of-match value instead of letting
+        // them keep ticking. Use ``match_finished_at`` (when present)
+        // as the wall-clock anchor for the last set's elapsed time so
+        // it agrees with the match-level counter.
+        const matchFinished = match.match_finished === true;
+        const finishedAt = (typeof match.match_finished_at === 'number')
+            ? match.match_finished_at : null;
 
         const bySet = oc.points_by_set || {};
         const setEvents = bySet[String(setNum)] || bySet[setNum] || [];
@@ -519,10 +533,15 @@
         if (setStamps.length >= 2) {
             // Past sets: use the audit-derived duration (frozen).
             // Live set: extend with the wall-clock delta since the
-            // last scoring event so the counter ticks between rallies.
+            // last scoring event so the counter ticks between rallies,
+            // unless the match has just finished — in which case the
+            // counter freezes at ``match_finished_at - first`` (or the
+            // first/last span when ``match_finished_at`` is missing).
             const first = Math.min.apply(null, setStamps);
             const last = Math.max.apply(null, setStamps);
-            if (isLiveSet) {
+            if (isLiveSet && matchFinished) {
+                setSeconds = (finishedAt != null ? finishedAt : last) - first;
+            } else if (isLiveSet) {
                 setSeconds = (Date.now() / 1000) - first;
             } else {
                 setSeconds = last - first;
@@ -533,7 +552,10 @@
 
         let matchSeconds = null;
         if (typeof match.match_started_at === 'number') {
-            matchSeconds = (Date.now() / 1000) - match.match_started_at;
+            const reference = matchFinished && finishedAt != null
+                ? finishedAt
+                : (Date.now() / 1000);
+            matchSeconds = reference - match.match_started_at;
         } else {
             // Fallback: sum the per-set durations.
             let total = 0;
@@ -549,14 +571,36 @@
             return;
         }
         wrap.removeAttribute('hidden');
+        if (matchFinished) wrap.classList.add('match-times-finished');
+        else wrap.classList.remove('match-times-finished');
         setEl.textContent = setSeconds != null ? formatTime(setSeconds) : '—';
         matchEl.textContent = matchSeconds != null ? formatTime(matchSeconds) : '—';
     }
 
     function renderAlerts(broadcast) {
         const oc = broadcast.overlay_control || {};
+        const match = broadcast.match_info || {};
         const info = oc.match_point_info || {};
         const switchInfo = oc.beach_side_switch || null;
+        const matchFinished = match.match_finished === true;
+
+        // Once the match is finished, the only badge that should be
+        // visible is the "Match finished" indicator. Set-point and
+        // match-point pills are stale by definition and the side-
+        // switch badge is no longer actionable.
+        setHidden('alert-match-finished', !matchFinished);
+        if (matchFinished) {
+            setHidden('alert-team1-match-point', true);
+            setHidden('alert-team2-match-point', true);
+            setHidden('alert-team1-set-point', true);
+            setHidden('alert-team2-set-point', true);
+            const switchBadge = $('alert-side-switch');
+            if (switchBadge) {
+                switchBadge.setAttribute('hidden', 'hidden');
+                switchBadge.classList.remove('pending');
+            }
+            return;
+        }
 
         // Match point takes visual priority over set point on each
         // side, mirroring the React control UI rule. The spectator

--- a/overlay_templates/_spectator.html
+++ b/overlay_templates/_spectator.html
@@ -28,6 +28,9 @@
 
     <main class="spectator-main">
         <div class="spectator-alerts" aria-live="polite">
+            <div class="alert-badge alert-match-finished" id="alert-match-finished" hidden>
+                <span data-i18n="alert.matchFinished"></span>
+            </div>
             <div class="alert-badge alert-set-point alert-home" id="alert-team1-set-point" hidden>
                 <span data-i18n="alert.setPoint"></span>
             </div>

--- a/tests/test_match_archive.py
+++ b/tests/test_match_archive.py
@@ -374,6 +374,53 @@ class TestArchiveTrigger:
         assert session.game_manager.match_finished(session.sets_limit) is False
         assert session.match_finished_at is None
 
+    def test_set_score_to_winning_value_stamps_match_finished_at(
+            self, mock_conf, api_backend):
+        # Regression: a manual ``set_score`` edit that pushes the
+        # match across the finish line is just as much an end-of-
+        # match transition as the natural add_point/add_set path, and
+        # must stamp ``match_finished_at`` so the HUD timer freezes.
+        session = SessionManager.get_or_create(
+            "arch-setscore-finish", mock_conf, api_backend,
+        )
+        # Drive 2 sets to team 1 via add_set, then edit the deciding
+        # set's score to the winning total directly.
+        for _ in range(2):
+            GameService.add_set(session, team=1)
+        assert session.match_finished_at is None
+        before = time.time()
+        GameService.set_score(
+            session, team=1, set_number=session.current_set, value=25,
+        )
+        after = time.time()
+        assert session.game_manager.match_finished(session.sets_limit)
+        assert session.match_finished_at is not None
+        assert before <= session.match_finished_at <= after
+
+    def test_set_sets_value_to_winning_count_stamps_match_finished_at(
+            self, mock_conf, api_backend):
+        session = SessionManager.get_or_create(
+            "arch-setsvalue-finish", mock_conf, api_backend,
+        )
+        before = time.time()
+        # sets_limit=5 → soft limit 3 wins the match.
+        GameService.set_sets_value(session, team=1, value=3)
+        after = time.time()
+        assert session.game_manager.match_finished(session.sets_limit)
+        assert session.match_finished_at is not None
+        assert before <= session.match_finished_at <= after
+
+    def test_set_sets_value_back_down_clears_match_finished_at(
+            self, mock_conf, api_backend):
+        session = SessionManager.get_or_create(
+            "arch-setsvalue-revert", mock_conf, api_backend,
+        )
+        GameService.set_sets_value(session, team=1, value=3)
+        assert session.match_finished_at is not None
+        GameService.set_sets_value(session, team=1, value=2)
+        assert session.game_manager.match_finished(session.sets_limit) is False
+        assert session.match_finished_at is None
+
     def test_re_winning_after_undo_re_stamps_match_finished_at(
             self, mock_conf, api_backend):
         # After an undo + a fresh winning point the timestamp must

--- a/tests/test_match_archive.py
+++ b/tests/test_match_archive.py
@@ -293,3 +293,55 @@ class TestArchiveTrigger:
         time.sleep(0.01)
         GameService.start_match(session)
         assert session.match_started_at == first_anchor
+
+    def test_match_finished_at_stamped_on_match_end_via_add_set(
+            self, mock_conf, api_backend):
+        # The set-winning ``add_set`` that closes the match must
+        # stamp ``match_finished_at`` *before* the broadcast so the
+        # spectator/HUD timer can freeze at the actual end-of-match
+        # value instead of ticking forward indefinitely.
+        session = SessionManager.get_or_create(
+            "arch-finished-set", mock_conf, api_backend,
+        )
+        GameService.start_match(session)
+        before = time.time()
+        self._drive_to_match_end(session, via_set=True)
+        after = time.time()
+        assert session.match_finished_at is not None
+        assert before <= session.match_finished_at <= after
+        # ``match_started_at`` survives the archive so the elapsed
+        # duration is computable until the operator hits Reset.
+        assert session.match_started_at is not None
+
+    def test_match_finished_at_stamped_on_match_end_via_add_point(
+            self, mock_conf, api_backend):
+        session = SessionManager.get_or_create(
+            "arch-finished-pt", mock_conf, api_backend,
+        )
+        before = time.time()
+        self._drive_to_match_end(session, via_set=False)
+        after = time.time()
+        assert session.match_finished_at is not None
+        assert before <= session.match_finished_at <= after
+        assert session.match_started_at is not None
+
+    def test_reset_clears_match_finished_at(self, mock_conf, api_backend):
+        session = SessionManager.get_or_create(
+            "arch-finished-reset", mock_conf, api_backend,
+        )
+        self._drive_to_match_end(session, via_set=True)
+        assert session.match_finished_at is not None
+        GameService.reset(session)
+        assert session.match_finished_at is None
+        assert session.match_started_at is None
+
+    def test_match_finished_at_in_state_response(self, mock_conf, api_backend):
+        session = SessionManager.get_or_create(
+            "arch-finished-state", mock_conf, api_backend,
+        )
+        assert GameService.get_state(session).match_finished_at is None
+        self._drive_to_match_end(session, via_set=True)
+        state = GameService.get_state(session)
+        assert state.match_finished is True
+        assert state.match_finished_at is not None
+        assert state.match_finished_at == session.match_finished_at

--- a/tests/test_match_archive.py
+++ b/tests/test_match_archive.py
@@ -345,3 +345,49 @@ class TestArchiveTrigger:
         assert state.match_finished is True
         assert state.match_finished_at is not None
         assert state.match_finished_at == session.match_finished_at
+
+    def test_undo_of_match_winning_set_clears_match_finished_at(
+            self, mock_conf, api_backend):
+        # Regression: the React MatchTimer freezes purely on
+        # ``finishedAt != null``, so leaving ``match_finished_at`` set
+        # after an undo that reopens the match would keep the HUD
+        # clock stuck on the old end-of-match value. The undo path
+        # must clear the timestamp atomically with the match-finished
+        # transition reversing.
+        session = SessionManager.get_or_create(
+            "arch-undo-set", mock_conf, api_backend,
+        )
+        self._drive_to_match_end(session, via_set=True)
+        assert session.match_finished_at is not None
+        GameService.add_set(session, team=1, undo=True)
+        assert session.game_manager.match_finished(session.sets_limit) is False
+        assert session.match_finished_at is None
+
+    def test_undo_of_match_winning_point_clears_match_finished_at(
+            self, mock_conf, api_backend):
+        session = SessionManager.get_or_create(
+            "arch-undo-pt", mock_conf, api_backend,
+        )
+        self._drive_to_match_end(session, via_set=False)
+        assert session.match_finished_at is not None
+        GameService.add_point(session, team=1, undo=True)
+        assert session.game_manager.match_finished(session.sets_limit) is False
+        assert session.match_finished_at is None
+
+    def test_re_winning_after_undo_re_stamps_match_finished_at(
+            self, mock_conf, api_backend):
+        # After an undo + a fresh winning point the timestamp must
+        # update to the *new* end-of-match wall clock, not bleed
+        # through from the first attempt.
+        session = SessionManager.get_or_create(
+            "arch-undo-redo", mock_conf, api_backend,
+        )
+        self._drive_to_match_end(session, via_set=True)
+        first_finished = session.match_finished_at
+        assert first_finished is not None
+        GameService.add_set(session, team=1, undo=True)
+        assert session.match_finished_at is None
+        time.sleep(0.01)
+        GameService.add_set(session, team=1)
+        assert session.match_finished_at is not None
+        assert session.match_finished_at > first_finished

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -88,6 +88,7 @@ class TestGameSessionMeta:
             "points_limit_last_set": session.points_limit_last_set,
             "sets_limit": session.sets_limit,
             "match_started_at": session.match_started_at,
+            "match_finished_at": session.match_finished_at,
             "mode": session.mode,
         }
 

--- a/tests/test_state_store_replace.py
+++ b/tests/test_state_store_replace.py
@@ -1,0 +1,106 @@
+"""Tests for the audit-derived subtree replacement in OverlayStateStore.
+
+When :func:`GameService.reset` clears the per-OID audit log, the next
+broadcast carries empty ``points_by_set`` / ``timeouts_by_set`` /
+``stats.set_durations`` dicts. Without explicit replacement the
+state-store deep-merge would leave per-set entries from the previous
+match in place, so the spectator (follow) page would keep rendering
+stale stats / time history after the operator hit Reset.
+"""
+
+import pytest
+
+# Imports must go through ``app.api`` first to avoid the partial-init
+# cycle: importing :mod:`app.overlay.state_store` directly triggers
+# :mod:`app.overlay.__init__` which re-imports this module, while
+# :mod:`app.api.routes` already wired up the resolution order in the
+# rest of the test suite.
+from app.api import action_log  # noqa: F401  (load order)
+from app.overlay.state_store import OverlayStateStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return OverlayStateStore(
+        data_dir=str(tmp_path / "data"),
+        templates_dir=str(tmp_path / "tpl"),
+    )
+
+
+def _seed_with_per_set_stats(store, oid):
+    """Drop a payload representing a multi-set match in progress."""
+    store.update_state_sync(oid, {
+        "overlay_control": {
+            "points_by_set": {
+                "1": [{"team": 1, "ts": 1.0, "score": [1, 0]}],
+                "2": [{"team": 2, "ts": 5.0, "score": [0, 1]}],
+            },
+            "timeouts_by_set": {
+                "1": [{"team": 1, "ts": 2.0}],
+            },
+            "stats": {
+                "set_durations": {"1": 90.0, "2": 60.0},
+                "services": {"1": {"served": 5, "won": 3}},
+                "points_history": [{"team": 1, "ts": 1.0, "score": [1, 0]}],
+            },
+        },
+    })
+
+
+def test_reset_clears_per_set_buckets(store):
+    """Empty per-set dicts in a fresh broadcast must wipe stale keys.
+
+    The pre-fix deep_merge behaviour would treat ``{}`` as a no-op
+    against the existing dict and leave ``set_1``/``set_2`` in place,
+    which is exactly the bug the spectator page surfaces (stats and
+    time-history stuck at the previous match's values after Reset).
+    """
+    oid = "reset-buckets"
+    assert store.create_overlay(oid) is True
+    _seed_with_per_set_stats(store, oid)
+    seeded = store.get_state(oid)
+    assert seeded["overlay_control"]["points_by_set"] != {}
+    assert seeded["overlay_control"]["timeouts_by_set"] != {}
+    assert seeded["overlay_control"]["stats"]["set_durations"] != {}
+
+    # Simulate the broadcast that follows GameService.reset (audit log
+    # is empty, so every audit-derived bucket is empty).
+    store.update_state_sync(oid, {
+        "overlay_control": {
+            "points_by_set": {},
+            "timeouts_by_set": {},
+            "stats": {
+                "set_durations": {},
+                "services": {
+                    "1": {"served": 0, "won": 0},
+                    "2": {"served": 0, "won": 0},
+                },
+                "points_history": [],
+            },
+        },
+    })
+    cleared = store.get_state(oid)
+    assert cleared["overlay_control"]["points_by_set"] == {}
+    assert cleared["overlay_control"]["timeouts_by_set"] == {}
+    assert cleared["overlay_control"]["stats"]["set_durations"] == {}
+    # Services is replaced wholesale too — both teams reset to 0/0.
+    assert cleared["overlay_control"]["stats"]["services"] == {
+        "1": {"served": 0, "won": 0},
+        "2": {"served": 0, "won": 0},
+    }
+
+
+def test_partial_payload_does_not_touch_unrelated_subtrees(store):
+    """Theme / admin updates that only carry colours must not blow
+    away the audit-derived subtrees."""
+    oid = "partial"
+    assert store.create_overlay(oid) is True
+    _seed_with_per_set_stats(store, oid)
+    store.update_state_sync(oid, {
+        "overlay_control": {
+            "colors": {"set_bg": "#000"},
+        },
+    })
+    state = store.get_state(oid)
+    assert state["overlay_control"]["points_by_set"] != {}
+    assert state["overlay_control"]["stats"]["set_durations"] != {}


### PR DESCRIPTION
## Summary

Three related fixes to the post-match-end UX on the operator scoreboard and the `/follow/{id}` spectator page.

- **HUD / spectator match timer no longer ticks past match end.** Backend now stamps a `match_finished_at` timestamp before the broadcast that closes the match; `MatchTimer` (React) and the spectator's match/set counters freeze at `match_finished_at - match_started_at` instead of continuing to count up until the operator reloads. `match_started_at` is no longer cleared on archive — Reset is the sole path that returns the session to the pre-match idle state.
- **Spectator now shows a "Match finished" indicator.** The alerts strip renders a localized badge in all six supported locales (en/es/pt/it/fr/de) and suppresses the now-stale set-point / match-point / side-switch pills. The timer pill tints green so the frozen state reads as distinct from a paused-between-rallies live match.
- **Reset on the operator UI now clears the spectator's stats and time history.** `OverlayStateStore.update_state{_sync}` previously deep-merged the post-reset broadcast, leaving per-set entries in `overlay_control.points_by_set` / `timeouts_by_set` / `stats.set_durations` / `stats.services` / `stats.points_history` behind because empty dicts are no-ops for a deep merge. Those audit-derived subtrees are now force-replaced after the merge so a Reset wipes the spectator chart, history, and per-set durations alongside the scoreboard.

## Test plan

- [x] `pytest tests/` — 1053 passed (added per-feature tests in `tests/test_match_archive.py` and a new `tests/test_state_store_replace.py`).
- [x] `npm test` in `frontend/` — 435 passed (added a freeze-on-finish test to `MatchTimer.test.tsx`).
- [x] `tsc --noEmit` clean.
- [x] `ruff check` clean.
- [x] OpenAPI schema + frontend `schema.d.ts` regenerated.
- [ ] Manual: drive a match to completion in the operator UI, confirm the HUD timer freezes and the `/follow` page shows the badge and stops ticking.
- [ ] Manual: hit Reset and confirm the spectator stats / chart / per-set time history all clear (not just the scoreboard).

https://claude.ai/code/session_017nyGRHo6mWSXUoPvsB9Fcn

---
_Generated by [Claude Code](https://claude.ai/code/session_017nyGRHo6mWSXUoPvsB9Fcn)_