### PR TITLE
fix(ui): keep team-coloured icons readable on the panel surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ once a first tagged release ships.
   until the operator hits Reset — which is now the only path that
   returns the session to the pre-match idle state.
 
-## [5.2.1] - 2026-05-12
+## [5.3.0] - 2026-05-13
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ once a first tagged release ships.
 
 ### Fixed
 
+- **Team-coloured icons stay readable on the panel surface.** The
+  timeout dots, timeout button, serve icon, and points-history
+  marker in the React control UI now run their colours through a
+  WCAG-aware helper that lifts (or lowers) the HSL lightness only
+  when the contrast against the current ``--surface`` falls below
+  the threshold (4.5:1 for text/icons, 3:1 for UI shapes). The
+  hue and saturation are preserved so the two teams remain
+  visually distinct, and the helper re-evaluates automatically on
+  light/dark theme toggles. The default indigo accent
+  (``#5c6bc0``) — which only reached 3.27:1 against the dark
+  navy panel — is now lifted to a tone that clears 4.5:1 on dark
+  mode while staying recognisably indigo.
 - **Match timer no longer ticks past match end.** The HUD timer in
   the React control UI and the match/set counters on the
   `/follow/{id}` spectator page now freeze at the actual end-of-

--- a/frontend/src/components/PointsHistoryStrip.tsx
+++ b/frontend/src/components/PointsHistoryStrip.tsx
@@ -1,4 +1,9 @@
 import type { RecentEvent } from '../hooks/useRecentEvents';
+import { getReadableOnSurface } from '../utils/contrast';
+import { useSurfaceColor } from '../hooks/useSurfaceColor';
+
+// Markers are non-text UI shapes — WCAG AA only requires 3:1 here.
+const MARKER_MIN_RATIO = 3;
 
 export interface PointsHistoryStripProps {
   events: RecentEvent[];
@@ -108,12 +113,13 @@ interface RowProps {
   name: string;
 }
 
-function Row({ team, events, color, textColor, logo, name }: RowProps) {
+function Row({ team, events, color, textColor, logo, name, surface }: RowProps & { surface: string }) {
+  const markerColor = getReadableOnSurface(color, surface, MARKER_MIN_RATIO);
   return (
     <div className="phs-row" data-testid={`phs-row-${team}`}>
       <span
         className="phs-marker"
-        style={{ backgroundColor: color }}
+        style={{ backgroundColor: markerColor }}
         role="img"
         aria-label={name}
       >
@@ -155,6 +161,7 @@ export default function PointsHistoryStrip({
   team2Logo,
   team2Name,
 }: PointsHistoryStripProps) {
+  const surface = useSurfaceColor();
   if (events.length === 0) return null;
   return (
     <div
@@ -169,6 +176,7 @@ export default function PointsHistoryStrip({
         textColor={team1TextColor}
         logo={team1Logo}
         name={team1Name}
+        surface={surface}
       />
       <Row
         team={2}
@@ -177,6 +185,7 @@ export default function PointsHistoryStrip({
         textColor={team2TextColor}
         logo={team2Logo}
         name={team2Name}
+        surface={surface}
       />
     </div>
   );

--- a/frontend/src/components/TeamPanel.tsx
+++ b/frontend/src/components/TeamPanel.tsx
@@ -4,7 +4,9 @@ import ScoreTable from './ScoreTable';
 import type { GameState, TeamState } from '../api/client';
 import type { ConfigModel } from './TeamCard';
 import { toNumber, asString } from '../utils/coerce';
+import { getReadableOnSurface } from '../utils/contrast';
 import { useDoubleTap } from '../hooks/useDoubleTap';
+import { useSurfaceColor } from '../hooks/useSurfaceColor';
 
 export interface TeamPanelProps {
   teamId: 1 | 2;
@@ -70,6 +72,13 @@ function TeamPanel({
   const timeouts = teamState?.timeouts ?? 0;
   const isServing = teamState?.serving ?? false;
 
+  // Lift the lightness of foreground colours that fail WCAG AA against
+  // the current panel surface so dark team colours stay legible without
+  // losing their hue.
+  const surface = useSurfaceColor();
+  const readableTimeoutColor = getReadableOnSurface(timeoutColor, surface);
+  const readableServeColor = getReadableOnSurface(serveColor, surface);
+
   const handleAddPoint = useCallback(() => onAddPoint(teamId), [onAddPoint, teamId]);
   const handleAddTimeout = useCallback(() => onAddTimeout(teamId), [onAddTimeout, teamId]);
   const handleDoubleTap = useCallback(() => onDoubleTapScore(teamId), [onDoubleTapScore, teamId]);
@@ -103,7 +112,7 @@ function TeamPanel({
       <span
         key={i}
         className="material-icons timeout-dot"
-        style={{ color: timeoutColor, fontSize: '12px' }}
+        style={{ color: readableTimeoutColor, fontSize: '12px' }}
         data-testid={`timeout-${teamId}-number-${i}`}
       >
         radio_button_unchecked
@@ -172,7 +181,7 @@ function TeamPanel({
           <div className={isPortrait ? 'team-side-group-col' : 'team-side-group-row'}>
             <button
               className="timeout-button"
-              style={{ borderColor: timeoutColor, color: timeoutColor }}
+              style={{ borderColor: readableTimeoutColor, color: readableTimeoutColor }}
               {...timeoutHandlers}
               aria-label={`Team ${teamId} timeout`}
               aria-describedby={`team-${teamId}-timeout-help`}
@@ -192,7 +201,7 @@ function TeamPanel({
           <span
             className="material-icons serve-icon"
             style={{
-              color: serveColor,
+              color: readableServeColor,
               opacity: isServing ? 1 : 0.4,
               cursor: 'pointer',
               fontSize: '2rem',

--- a/frontend/src/hooks/useSurfaceColor.ts
+++ b/frontend/src/hooks/useSurfaceColor.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Read a CSS custom property from ``:root`` and re-read it whenever the
+ * documentElement's class list changes (i.e. on theme toggles). The
+ * value is normalised to a 6-digit hex string when possible, so the
+ * contrast helpers can consume it directly.
+ *
+ * Falls back to ``fallback`` during SSR or when the variable is unset.
+ */
+export function useCssVariableColor(varName: string, fallback: string): string {
+  const read = (): string => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return fallback;
+    }
+    const raw = getComputedStyle(document.documentElement)
+      .getPropertyValue(varName)
+      .trim();
+    return raw || fallback;
+  };
+
+  const [value, setValue] = useState<string>(read);
+
+  useEffect(() => {
+    if (typeof MutationObserver === 'undefined') return;
+    const update = () => setValue(read());
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'style'],
+    });
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [varName, fallback]);
+
+  return value;
+}
+
+/**
+ * Current value of ``--surface`` — the background colour underneath the
+ * team panel. Used to derive readable variants of team colors.
+ */
+export function useSurfaceColor(): string {
+  return useCssVariableColor('--surface', '#16213e');
+}

--- a/frontend/src/test/contrast.test.ts
+++ b/frontend/src/test/contrast.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  contrastRatio,
+  getReadableOnSurface,
+  hslToRgb,
+  parseHexColor,
+  relativeLuminance,
+  rgbToHex,
+  rgbToHsl,
+} from '../utils/contrast';
+
+describe('parseHexColor', () => {
+  it('parses 6-digit hex strings', () => {
+    expect(parseHexColor('#1a73e8')).toEqual({ r: 26, g: 115, b: 232 });
+  });
+
+  it('parses 3-digit shorthand', () => {
+    expect(parseHexColor('#abc')).toEqual({ r: 170, g: 187, b: 204 });
+  });
+
+  it('accepts hex without leading #', () => {
+    expect(parseHexColor('ff8800')).toEqual({ r: 255, g: 136, b: 0 });
+  });
+
+  it('returns null for invalid input', () => {
+    expect(parseHexColor('not-a-color')).toBeNull();
+    expect(parseHexColor('#12345')).toBeNull();
+    expect(parseHexColor('#zzzzzz')).toBeNull();
+  });
+});
+
+describe('relativeLuminance & contrastRatio', () => {
+  it('returns 0 for black and 1 for white', () => {
+    expect(relativeLuminance({ r: 0, g: 0, b: 0 })).toBeCloseTo(0, 4);
+    expect(relativeLuminance({ r: 255, g: 255, b: 255 })).toBeCloseTo(1, 4);
+  });
+
+  it('returns 21 for black on white (WCAG max)', () => {
+    const ratio = contrastRatio({ r: 0, g: 0, b: 0 }, { r: 255, g: 255, b: 255 });
+    expect(ratio).toBeCloseTo(21, 1);
+  });
+
+  it('is symmetric', () => {
+    const a = { r: 26, g: 115, b: 232 };
+    const b = { r: 22, g: 33, b: 62 };
+    expect(contrastRatio(a, b)).toBeCloseTo(contrastRatio(b, a), 6);
+  });
+});
+
+describe('rgbToHsl / hslToRgb round-trip', () => {
+  it.each([
+    [{ r: 26, g: 115, b: 232 }],
+    [{ r: 244, g: 67, b: 54 }],
+    [{ r: 92, g: 107, b: 192 }],
+    [{ r: 22, g: 33, b: 62 }],
+    [{ r: 0, g: 0, b: 0 }],
+    [{ r: 255, g: 255, b: 255 }],
+  ])('preserves %j within rounding', (rgb) => {
+    const hsl = rgbToHsl(rgb);
+    const back = hslToRgb(hsl);
+    expect(Math.abs(back.r - rgb.r)).toBeLessThanOrEqual(1);
+    expect(Math.abs(back.g - rgb.g)).toBeLessThanOrEqual(1);
+    expect(Math.abs(back.b - rgb.b)).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('getReadableOnSurface', () => {
+  const darkSurface = '#16213e';
+  const lightSurface = '#ffffff';
+
+  it('returns the original colour when contrast already meets the threshold', () => {
+    // White on dark navy is well above 4.5:1.
+    const fg = '#ffffff';
+    expect(getReadableOnSurface(fg, darkSurface)).toBe(fg);
+  });
+
+  it('lifts the default indigo theme colour above the AA threshold on dark navy', () => {
+    // Spot-checks the theme.ts TEAM_*_LIGHT / SERVE constants used by
+    // TeamPanel — they fall just below 4.5:1 against --surface in dark
+    // mode (~3.27:1) and the helper should rescue them.
+    const adjusted = getReadableOnSurface('#5c6bc0', darkSurface);
+    const ratio = contrastRatio(parseHexColor(adjusted)!, parseHexColor(darkSurface)!);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('lifts a dark team colour against a dark surface to meet AA', () => {
+    const fg = '#1a1f3a'; // close to the surface — invisible blob
+    const adjusted = getReadableOnSurface(fg, darkSurface);
+    const ratio = contrastRatio(parseHexColor(adjusted)!, parseHexColor(darkSurface)!);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('lowers a light team colour against a light surface to meet AA', () => {
+    const fg = '#fff2cc'; // pale yellow on white
+    const adjusted = getReadableOnSurface(fg, lightSurface);
+    const ratio = contrastRatio(parseHexColor(adjusted)!, parseHexColor(lightSurface)!);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('preserves the original hue when shifting lightness', () => {
+    const fg = '#1a1f3a';
+    const adjusted = getReadableOnSurface(fg, darkSurface);
+    const hueOrig = rgbToHsl(parseHexColor(fg)!).h;
+    const hueAdj = rgbToHsl(parseHexColor(adjusted)!).h;
+    // Allow small drift from rounding when L is near extremes.
+    expect(Math.abs(hueAdj - hueOrig)).toBeLessThan(10);
+  });
+
+  it('honours a custom minimum ratio (e.g. 3:1 for non-text UI)', () => {
+    const fg = '#15203c';
+    const adjusted = getReadableOnSurface(fg, darkSurface, 3);
+    const ratio = contrastRatio(parseHexColor(adjusted)!, parseHexColor(darkSurface)!);
+    expect(ratio).toBeGreaterThanOrEqual(3);
+  });
+
+  it('returns the input unchanged when either colour is malformed', () => {
+    expect(getReadableOnSurface('not-a-color', darkSurface)).toBe('not-a-color');
+    expect(getReadableOnSurface('#123456', 'nope')).toBe('#123456');
+  });
+});
+
+describe('rgbToHex', () => {
+  it('clamps and pads channels', () => {
+    expect(rgbToHex({ r: 0, g: 0, b: 0 })).toBe('#000000');
+    expect(rgbToHex({ r: 255, g: 255, b: 255 })).toBe('#ffffff');
+    expect(rgbToHex({ r: 300, g: -5, b: 16 })).toBe('#ff0010');
+  });
+});

--- a/frontend/src/test/useSurfaceColor.test.tsx
+++ b/frontend/src/test/useSurfaceColor.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useCssVariableColor, useSurfaceColor } from '../hooks/useSurfaceColor';
+
+afterEach(() => {
+  document.documentElement.style.removeProperty('--surface');
+  document.documentElement.style.removeProperty('--test-var');
+  document.documentElement.className = '';
+});
+
+describe('useCssVariableColor', () => {
+  it('returns the fallback when the variable is unset', () => {
+    const { result } = renderHook(() => useCssVariableColor('--test-var', '#abcdef'));
+    expect(result.current).toBe('#abcdef');
+  });
+
+  it('reads the current value of the variable from :root', () => {
+    document.documentElement.style.setProperty('--test-var', '#112233');
+    const { result } = renderHook(() => useCssVariableColor('--test-var', '#ffffff'));
+    expect(result.current).toBe('#112233');
+  });
+
+  it('updates when the documentElement class changes (theme toggle)', async () => {
+    document.documentElement.style.setProperty('--test-var', '#111111');
+    const { result } = renderHook(() => useCssVariableColor('--test-var', '#000000'));
+    expect(result.current).toBe('#111111');
+
+    act(() => {
+      document.documentElement.style.setProperty('--test-var', '#eeeeee');
+      // Trigger the mutation observer with a class change.
+      document.documentElement.classList.add('light');
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe('#eeeeee');
+    });
+  });
+});
+
+describe('useSurfaceColor', () => {
+  it('reads --surface from the root element', () => {
+    document.documentElement.style.setProperty('--surface', '#16213e');
+    const { result } = renderHook(() => useSurfaceColor());
+    expect(result.current).toBe('#16213e');
+  });
+
+  it('falls back when --surface is missing', () => {
+    const { result } = renderHook(() => useSurfaceColor());
+    expect(result.current).toBe('#16213e');
+  });
+});

--- a/frontend/src/utils/contrast.ts
+++ b/frontend/src/utils/contrast.ts
@@ -148,7 +148,7 @@ export function getReadableOnSurface(
   let best: Rgb = fgRgb;
   let bestRatio = contrastRatio(fgRgb, bgRgb);
 
-  for (let i = 0; i < 18; i++) {
+  for (let i = 0; i < 10; i++) {
     const mid = (lo + hi) / 2;
     const candidate = hslToRgb({ h: hsl.h, s: hsl.s, l: mid });
     const ratio = contrastRatio(candidate, bgRgb);

--- a/frontend/src/utils/contrast.ts
+++ b/frontend/src/utils/contrast.ts
@@ -1,0 +1,176 @@
+/**
+ * Contrast helpers for adjusting team colors so they remain readable
+ * on the current surface while preserving the team's hue.
+ *
+ * The strategy is: keep the original hue and saturation, and only nudge
+ * the HSL lightness toward the side that increases contrast against the
+ * background until the WCAG AA threshold (4.5:1 for normal text) is met.
+ * If the surface itself is mid-grey or the color cannot reach the target
+ * without losing all chroma, the best-effort value is returned.
+ */
+
+const WCAG_AA_NORMAL = 4.5;
+
+export interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+export function parseHexColor(hex: string): Rgb | null {
+  if (typeof hex !== 'string') return null;
+  let s = hex.trim().replace(/^#/, '');
+  if (s.length === 3) {
+    s = s.split('').map((c) => c + c).join('');
+  }
+  if (s.length !== 6 || !/^[0-9a-fA-F]{6}$/.test(s)) return null;
+  return {
+    r: parseInt(s.slice(0, 2), 16),
+    g: parseInt(s.slice(2, 4), 16),
+    b: parseInt(s.slice(4, 6), 16),
+  };
+}
+
+function toHex2(n: number): string {
+  const clamped = Math.max(0, Math.min(255, Math.round(n)));
+  return clamped.toString(16).padStart(2, '0');
+}
+
+export function rgbToHex({ r, g, b }: Rgb): string {
+  return `#${toHex2(r)}${toHex2(g)}${toHex2(b)}`;
+}
+
+function channelLuminance(c: number): number {
+  const s = c / 255;
+  return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+
+export function relativeLuminance({ r, g, b }: Rgb): number {
+  return (
+    0.2126 * channelLuminance(r) +
+    0.7152 * channelLuminance(g) +
+    0.0722 * channelLuminance(b)
+  );
+}
+
+export function contrastRatio(a: Rgb, b: Rgb): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+export interface Hsl {
+  h: number;
+  s: number;
+  l: number;
+}
+
+export function rgbToHsl({ r, g, b }: Rgb): Hsl {
+  const r1 = r / 255;
+  const g1 = g / 255;
+  const b1 = b / 255;
+  const max = Math.max(r1, g1, b1);
+  const min = Math.min(r1, g1, b1);
+  const l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r1:
+        h = (g1 - b1) / d + (g1 < b1 ? 6 : 0);
+        break;
+      case g1:
+        h = (b1 - r1) / d + 2;
+        break;
+      default:
+        h = (r1 - g1) / d + 4;
+    }
+    h *= 60;
+  }
+  return { h, s, l };
+}
+
+function hueToRgb(p: number, q: number, t: number): number {
+  let tt = t;
+  if (tt < 0) tt += 1;
+  if (tt > 1) tt -= 1;
+  if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+  if (tt < 1 / 2) return q;
+  if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+  return p;
+}
+
+export function hslToRgb({ h, s, l }: Hsl): Rgb {
+  const hn = ((h % 360) + 360) % 360 / 360;
+  if (s === 0) {
+    const v = Math.round(l * 255);
+    return { r: v, g: v, b: v };
+  }
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  return {
+    r: Math.round(hueToRgb(p, q, hn + 1 / 3) * 255),
+    g: Math.round(hueToRgb(p, q, hn) * 255),
+    b: Math.round(hueToRgb(p, q, hn - 1 / 3) * 255),
+  };
+}
+
+/**
+ * Return a version of ``fg`` that meets ``minRatio`` contrast against
+ * ``bg`` by shifting only the HSL lightness. Hue and saturation are
+ * preserved so the team identity stays recognisable. If the threshold
+ * cannot be reached (e.g. the surface is mid-grey), the closest
+ * approximation is returned.
+ */
+export function getReadableOnSurface(
+  fg: string,
+  bg: string,
+  minRatio: number = WCAG_AA_NORMAL,
+): string {
+  const fgRgb = parseHexColor(fg);
+  const bgRgb = parseHexColor(bg);
+  if (!fgRgb || !bgRgb) return fg;
+
+  if (contrastRatio(fgRgb, bgRgb) >= minRatio) return fg;
+
+  const bgLum = relativeLuminance(bgRgb);
+  const hsl = rgbToHsl(fgRgb);
+  // If the surface is dark, lifting lightness raises contrast; if it is
+  // light, lowering lightness does. Mid-grey surfaces are ambiguous —
+  // pick the direction with more headroom.
+  const goLighter = bgLum < 0.5 ? true : bgLum > 0.5 ? false : hsl.l < 0.5;
+
+  let lo = hsl.l;
+  let hi = goLighter ? 1 : 0;
+  let best: Rgb = fgRgb;
+  let bestRatio = contrastRatio(fgRgb, bgRgb);
+
+  for (let i = 0; i < 18; i++) {
+    const mid = (lo + hi) / 2;
+    const candidate = hslToRgb({ h: hsl.h, s: hsl.s, l: mid });
+    const ratio = contrastRatio(candidate, bgRgb);
+    if (ratio >= bestRatio) {
+      best = candidate;
+      bestRatio = ratio;
+    }
+    if (ratio >= minRatio) {
+      // Try to come back closer to the original lightness while still
+      // meeting the threshold, so the team identity drifts as little as
+      // possible.
+      hi = mid;
+    } else {
+      lo = mid;
+    }
+  }
+
+  // Final pick: prefer the lightness closest to the original that still
+  // clears ``minRatio``. ``hi`` is that boundary after the search.
+  const finalCandidate = hslToRgb({ h: hsl.h, s: hsl.s, l: hi });
+  if (contrastRatio(finalCandidate, bgRgb) >= minRatio) {
+    return rgbToHex(finalCandidate);
+  }
+  return rgbToHex(best);
+}


### PR DESCRIPTION
## Summary

- Adds a WCAG-aware `getReadableOnSurface(fg, bg, minRatio)` helper that nudges only the HSL lightness of a colour until it meets the contrast threshold against the current surface, preserving hue/saturation so the two teams stay visually distinct.
- Wraps the timeout dots, timeout button, serve icon (`TeamPanel`) and the points-history marker (`PointsHistoryStrip`) through that helper. Markers use the 3:1 UI-shape threshold; text/icons use 4.5:1.
- New `useSurfaceColor` hook reads `--surface` from `:root` and re-reads via `MutationObserver` on light/dark theme toggles.

## Why

Dark team colours (and even the default indigo accent `#5c6bc0`, which only reaches **3.27:1** against the dark navy panel) were rendering icons/markers with sub-AA contrast. The helper lifts that indigo to ~`#7784cb` (**4.50:1**) while keeping it recognisably indigo — same approach applies to any user-chosen dark team colour. Chip backgrounds are left untouched so the operator-set text/background pair on the chip remains under user control.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 461 tests pass (43 files), including new `contrast.test.ts` (parsing, luminance, ratio, HSL round-trip, AA lift in both directions, hue preservation) and `useSurfaceColor.test.tsx` (read, fallback, theme-toggle observer)
- [x] `npm run lint` — no new warnings
- [ ] Visual: open the control UI in dark mode with a near-`#16213e` team colour and confirm the timeout dots/button border/serve icon and the points-history marker remain visible without losing their hue
- [ ] Visual: toggle to light mode and confirm light-on-light team colours are darkened to meet AA instead

https://claude.ai/code/session_01AbQJ4cjjM4FTe9totg2HtE

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbQJ4cjjM4FTe9totg2HtE)_