### PR TITLE
docs(changelog): cut release v5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+## [5.4.0] - 2026-05-17
+
 ### Added
 
 - **Set summary overlay (opt-in).** New operator-toggled overlay that


### PR DESCRIPTION
## Summary

Promotes the existing `[Unreleased]` section in `CHANGELOG.md` to `[5.4.0] - 2026-05-17`, leaving a fresh empty `[Unreleased]` heading above (same pattern used to cut v5.2.0). Docs-only change — no code is modified.

The MINOR bump matches SemVer: this version is dominated by the new opt-in **set-summary overlay** (new endpoints, payload fields, React control button, six visual styles) plus a handful of backwards-compatible UX fixes and quality-of-life tweaks.

### Headline themes

- **Set summary overlay (opt-in).** Between-sets recap panel with six visual styles (`brand_ledger`, `brand_columns`, `bento`, `glass`, `podium`, `bumper`), chart-based variants driven by live `points_by_set` data, WCAG-aware team-colour fallback, end-to-end wiring (new `POST /api/v1/display/set-summary{,-style}` endpoints, `match_info.{show_set_summary,set_summary_style,summary_set_num}` payload fields, React button, i18n in all six locales). Off by default behind `setSummaryEnabled` in Behavior config.
- **Set-summary scaling, cross-fade & live-clock polish.** Variants now scale with the stage (`cqw`/`cqh` + `container-type: size`) instead of the viewport; scoreboard ↔ recap toggle animates via a 450ms opacity cross-fade; recap clock anchors a client-side `setInterval` to the first scoring event so the duration ticks every second on a live set.
- **"Match looks abandoned" prompt.** Confirm dialog on control-UI load when the current set has been live for more than an hour. Backed by a new `current_set_started_at` timestamp on `GameStateResponse`.
- **Quieter INFO log level.** `LOGGING_LEVEL=info` now shows lifecycle events without per-request noise; successful `uvicorn.access` records demoted to DEBUG by `HealthEndpointFilter` (full access log returns at DEBUG).
- **Match-end timer + spectator polish.** Match timer freezes at end-of-match (HUD + `/follow/{id}`); spectator page renders a localized "Match finished" badge and tints the timer pill green; Reset clears the spectator's stats and per-set time history.
- **Set-summary correctness fixes.** Recap no longer pins to an unplayed set after historical `set_score` edits; "Final" pill swaps to an amber "Live" indicator mid-set; dashed away stroke when both teams share a near-identical primary; bumper digits get internal padding.
- **Contrast-safe team-coloured icons.** Timeout dots, timeout button, serve icon, and points-history marker in the React UI run through a WCAG helper so the default indigo accent clears 4.5:1 on dark mode.

### Removed

- Live-stats panel and points-history strip dropped from the in-broadcast overlay (the same stats keep flowing for the spectator page and the set-summary recap via their own markup).

### Dependencies

- `vite` 6.4.2 → 8.0.13 and `@vitejs/plugin-react` 4.7.0 → 6.0.2 in `frontend/` (coupled — the plugin requires `vite@^8` as peer).

## Test plan

- [ ] CI green on this branch (backend pytest + ruff + mypy, frontend vitest + tsc).
- [ ] After merge, tag `v5.4.0` on the merge commit.
- [ ] Spot-check the rendered CHANGELOG on GitHub — `[5.4.0] - 2026-05-17` heading appears directly above the previous `[5.3.0]` block and a fresh empty `[Unreleased]` sits at the top.


---
_Generated by [Claude Code](https://claude.ai/code/session_019unXJDLgMxCgR2TmF7ViHG)_