### PR TITLE
fix(overlay): sync operator locale to set-summary via customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Added
+
+- **Set-summary overlay follows the operator's UI language live.** The
+  OBS browser-source URL is fixed in the streaming app, so the
+  ``?lang=`` strategy used by the spectator (follow) page cannot
+  reach an embedded overlay once OBS is configured. The control UI
+  now syncs the operator's locale onto the overlay's
+  ``raw_remote_customization.locale`` whenever it changes, and
+  ``set_summary.js`` re-reads ``window.OVERLAY_LOCALE`` on each
+  WebSocket update — so the recap re-renders in the operator's
+  chosen language without touching OBS. ``locale`` is also seeded
+  into the served overlay HTML so the first render boots in the
+  right language before any WS message arrives.
+
 ## [5.4.2] - 2026-05-20
 
 ### Added

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -16,6 +16,7 @@ from app.api.schemas import (
     LOGO_KEYS,
     MAX_CUSTOMIZATION_KEYS,
     MAX_STRING_VALUE_LENGTH,
+    SUPPORTED_OVERLAY_LOCALES,
     ActionResponse,
     BeachSideSwitch,
     GameStateResponse,
@@ -901,6 +902,21 @@ class GameService:
                         message=(
                             f"Logo URL for '{key}' must use http(s) or "
                             f"data:image scheme."
+                        ),
+                    )
+            elif key == 'locale':
+                if value is None:
+                    continue
+                if (
+                    not isinstance(value, str)
+                    or value.strip().lower() not in SUPPORTED_OVERLAY_LOCALES
+                ):
+                    return ActionResponse(
+                        success=False,
+                        state=GameService.get_state(session),
+                        message=(
+                            f"Value for 'locale' must be one of "
+                            f"{sorted(SUPPORTED_OVERLAY_LOCALES)}."
                         ),
                     )
             elif isinstance(value, str):

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -16,7 +16,6 @@ from app.api.schemas import (
     LOGO_KEYS,
     MAX_CUSTOMIZATION_KEYS,
     MAX_STRING_VALUE_LENGTH,
-    SUPPORTED_OVERLAY_LOCALES,
     ActionResponse,
     BeachSideSwitch,
     GameStateResponse,
@@ -26,6 +25,7 @@ from app.api.schemas import (
 )
 from app.customization_cache_ttl import customization_cache_ttl_seconds
 from app.env_vars_manager import EnvVarsManager
+from app.match_report_i18n import SUPPORTED_LOCALES as _SUPPORTED_LOCALES
 from app.state import State
 
 logger = logging.getLogger(__name__)
@@ -909,14 +909,14 @@ class GameService:
                     continue
                 if (
                     not isinstance(value, str)
-                    or value.strip().lower() not in SUPPORTED_OVERLAY_LOCALES
+                    or value.strip().lower() not in _SUPPORTED_LOCALES
                 ):
                     return ActionResponse(
                         success=False,
                         state=GameService.get_state(session),
                         message=(
                             f"Value for 'locale' must be one of "
-                            f"{sorted(SUPPORTED_OVERLAY_LOCALES)}."
+                            f"{list(_SUPPORTED_LOCALES)}."
                         ),
                     )
             elif isinstance(value, str):

--- a/app/api/preset_categories.py
+++ b/app/api/preset_categories.py
@@ -55,6 +55,14 @@ _KEYS_BY_CATEGORY: dict[str, tuple[str, ...]] = {
         "Color 2",
         "Text Color 1",
         "Text Color 2",
+        # Operator UI language, propagated to OBS-embedded overlays so
+        # the set-summary recap renders in the operator's chosen
+        # language even though the overlay URL is fixed in OBS and
+        # cannot carry ``?lang=``. Captured under ``style`` so it
+        # round-trips through the preset model; the control UI's
+        # locale-sync effect re-asserts the operator's choice if a
+        # preset import overwrote it.
+        "locale",
     ),
 }
 

--- a/app/api/preset_categories.py
+++ b/app/api/preset_categories.py
@@ -55,26 +55,29 @@ _KEYS_BY_CATEGORY: dict[str, tuple[str, ...]] = {
         "Color 2",
         "Text Color 1",
         "Text Color 2",
-        # Operator UI language, propagated to OBS-embedded overlays so
-        # the set-summary recap renders in the operator's chosen
-        # language even though the overlay URL is fixed in OBS and
-        # cannot carry ``?lang=``. Captured under ``style`` so it
-        # round-trips through the preset model; the control UI's
-        # locale-sync effect re-asserts the operator's choice if a
-        # preset import overwrote it.
-        "locale",
     ),
 }
+
+
+# Allow-listed customization keys that intentionally do NOT belong to
+# any preset category — they're per-operator/per-session knobs whose
+# round-trip through a saved preset would surprise the operator that
+# loads it. ``locale`` (the operator's UI language, pushed onto the
+# overlay so OBS browser sources follow language changes) is the only
+# such key today.
+_NON_PRESET_KEYS: frozenset[str] = frozenset({"locale"})
 
 
 def _validate_partition() -> dict[str, str]:
     """Build (and check) the reverse ``key → category`` map.
 
     Raises ``RuntimeError`` if the categories don't partition
-    ``ALLOWED_CUSTOMIZATION_KEYS`` exactly. The check runs once at
-    import time, so adding a new allow-listed key without slotting it
-    into a category fails fast in the test suite rather than silently
-    producing un-categorised presets in production.
+    ``ALLOWED_CUSTOMIZATION_KEYS`` exactly (minus the explicit
+    :data:`_NON_PRESET_KEYS` exemption). The check runs once at import
+    time, so adding a new allow-listed key without slotting it into a
+    category — or into the non-preset opt-out — fails fast in the
+    test suite rather than silently producing un-categorised presets
+    in production.
     """
     reverse: dict[str, str] = {}
     for cat, keys in _KEYS_BY_CATEGORY.items():
@@ -84,14 +87,19 @@ def _validate_partition() -> dict[str, str]:
                     f"Customization key '{key}' is in both "
                     f"'{reverse[key]}' and '{cat}' categories.",
                 )
+            if key in _NON_PRESET_KEYS:
+                raise RuntimeError(
+                    f"Customization key '{key}' is both in category "
+                    f"'{cat}' and in ``_NON_PRESET_KEYS``.",
+                )
             reverse[key] = cat
-    leftover = set(ALLOWED_CUSTOMIZATION_KEYS) - set(reverse)
+    leftover = set(ALLOWED_CUSTOMIZATION_KEYS) - set(reverse) - _NON_PRESET_KEYS
     if leftover:
         raise RuntimeError(
             "ALLOWED_CUSTOMIZATION_KEYS members not assigned to any "
             f"preset category: {sorted(leftover)}. Either slot them "
-            "into ``_KEYS_BY_CATEGORY`` or remove them from the "
-            "allow-list.",
+            "into ``_KEYS_BY_CATEGORY`` or list them in "
+            "``_NON_PRESET_KEYS``.",
         )
     extra = set(reverse) - set(ALLOWED_CUSTOMIZATION_KEYS)
     if extra:

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -109,17 +109,10 @@ ALLOWED_CUSTOMIZATION_KEYS = {
     'Logos', 'Gradient',
     'Height', 'Width', 'Left-Right', 'Up-Down',
     'preferredStyle',
-    # Operator-chosen locale propagated through the overlay's
-    # ``raw_remote_customization`` so OBS-embedded overlays (whose URL
-    # is fixed in the streaming app and cannot carry ``?lang=``) pick
-    # up the operator's language change live.
+    # Operator UI locale, broadcast to OBS-embedded overlays (whose URL
+    # is fixed in the streaming app and cannot carry ``?lang=``).
     'locale',
 }
-
-# Locale codes the set-summary overlay knows how to render. Keep in
-# sync with the LABELS dictionaries in ``overlay_static/js/set_summary.js``
-# and with ``_resolve_overlay_locale`` in ``app/overlay/routes.py``.
-SUPPORTED_OVERLAY_LOCALES = frozenset({'en', 'es', 'pt', 'it', 'fr', 'de'})
 
 # Per-value bounds for ``PUT /customization``. Logos can hold base64
 # data URLs so they get a much larger budget than the rest. Everything

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -109,7 +109,17 @@ ALLOWED_CUSTOMIZATION_KEYS = {
     'Logos', 'Gradient',
     'Height', 'Width', 'Left-Right', 'Up-Down',
     'preferredStyle',
+    # Operator-chosen locale propagated through the overlay's
+    # ``raw_remote_customization`` so OBS-embedded overlays (whose URL
+    # is fixed in the streaming app and cannot carry ``?lang=``) pick
+    # up the operator's language change live.
+    'locale',
 }
+
+# Locale codes the set-summary overlay knows how to render. Keep in
+# sync with the LABELS dictionaries in ``overlay_static/js/set_summary.js``
+# and with ``_resolve_overlay_locale`` in ``app/overlay/routes.py``.
+SUPPORTED_OVERLAY_LOCALES = frozenset({'en', 'es', 'pt', 'it', 'fr', 'de'})
 
 # Per-value bounds for ``PUT /customization``. Logos can hold base64
 # data URLs so they get a much larger budget than the rest. Everything

--- a/app/overlay/routes.py
+++ b/app/overlay/routes.py
@@ -30,17 +30,28 @@ logger = logging.getLogger(__name__)
 _SUPPORTED_OVERLAY_LOCALES = {"en", "es", "pt", "it", "fr", "de"}
 
 
-def _resolve_overlay_locale(query_lang: str | None, request: Request) -> str:
+def _resolve_overlay_locale(
+    query_lang: str | None,
+    request: Request,
+    persisted_locale: str | None = None,
+) -> str:
     """Pick the locale tag the overlay templates / JS will use.
 
     Resolution order: ``?lang=<code>`` query param (operator override
-    when embedding the overlay in OBS) → ``OVERLAY_LOCALE`` env var →
-    the first acceptable language from ``Accept-Language`` →
+    when embedding the overlay in OBS) → ``raw_remote_customization.locale``
+    persisted with the overlay (operator's UI language, pushed live by
+    the control app so OBS browser sources whose URL is fixed in the
+    streaming app still follow language changes) → ``OVERLAY_LOCALE``
+    env var → the first acceptable language from ``Accept-Language`` →
     ``"en"`` as a final fallback. Anything we don't recognise as a
     supported 2-letter code is ignored.
     """
     if query_lang:
         candidate = query_lang.strip().lower()[:2]
+        if candidate in _SUPPORTED_OVERLAY_LOCALES:
+            return candidate
+    if persisted_locale:
+        candidate = persisted_locale.strip().lower()[:2]
         if candidate in _SUPPORTED_OVERLAY_LOCALES:
             return candidate
     env_lang = (os.environ.get("OVERLAY_LOCALE") or "").strip().lower()[:2]
@@ -211,11 +222,16 @@ def create_overlay_router(
         available = await run_in_threadpool(store.get_available_styles_list)
         renderable = await run_in_threadpool(store.get_renderable_styles)
 
+        # Always load the persisted state — both ``preferredStyle`` and
+        # the operator-chosen ``locale`` live on
+        # ``raw_remote_customization`` and we want to honour the locale
+        # on the initial HTML render so the page boots in the correct
+        # language before any WebSocket update arrives.
+        state = await store.load_persisted_state_async(overlay_id)
+        customization = state.get("raw_remote_customization") or {}
+
         if not style:
-            state = await store.load_persisted_state_async(overlay_id)
-            preferred = state.get("raw_remote_customization", {}).get(
-                "preferredStyle"
-            )
+            preferred = customization.get("preferredStyle")
             if preferred and preferred in available:
                 style = preferred
             else:
@@ -232,6 +248,8 @@ def create_overlay_router(
 
         template_name = "index.html" if style == "default" else f"{style}.html"
 
+        persisted_locale = customization.get("locale")
+
         return templates.TemplateResponse(
             request=request,
             name=template_name,
@@ -241,7 +259,9 @@ def create_overlay_router(
                 "style": style,
                 "available_styles": available,
                 "v": int(time.time()),
-                "locale": _resolve_overlay_locale(lang, request),
+                "locale": _resolve_overlay_locale(
+                    lang, request, persisted_locale,
+                ),
             },
         )
 

--- a/app/overlay/routes.py
+++ b/app/overlay/routes.py
@@ -20,6 +20,12 @@ from pydantic import BaseModel, ConfigDict
 from starlette.concurrency import run_in_threadpool
 
 from app.auth_utils import get_hashed_or_plaintext_env, require_admin
+from app.match_report_i18n import (
+    SUPPORTED_LOCALES,
+)
+from app.match_report_i18n import (
+    resolve_locale as _resolve_accept_language,
+)
 from app.overlay.state_store import OverlayStateStore
 from app.overlay.themes import PRESET_THEMES, get_theme_names
 from app.password_hash import verify_password
@@ -27,7 +33,11 @@ from app.password_hash import verify_password
 logger = logging.getLogger(__name__)
 
 
-_SUPPORTED_OVERLAY_LOCALES = {"en", "es", "pt", "it", "fr", "de"}
+def _normalise_locale(raw: str | None) -> str | None:
+    if not raw or not isinstance(raw, str):
+        return None
+    candidate = raw.strip().lower()[:2]
+    return candidate if candidate in SUPPORTED_LOCALES else None
 
 
 def _resolve_overlay_locale(
@@ -42,27 +52,14 @@ def _resolve_overlay_locale(
     persisted with the overlay (operator's UI language, pushed live by
     the control app so OBS browser sources whose URL is fixed in the
     streaming app still follow language changes) → ``OVERLAY_LOCALE``
-    env var → the first acceptable language from ``Accept-Language`` →
-    ``"en"`` as a final fallback. Anything we don't recognise as a
-    supported 2-letter code is ignored.
+    env var → ``Accept-Language`` (q-weighted via
+    :func:`app.match_report_i18n.resolve_locale`) → ``"en"``.
     """
-    if query_lang:
-        candidate = query_lang.strip().lower()[:2]
-        if candidate in _SUPPORTED_OVERLAY_LOCALES:
-            return candidate
-    if persisted_locale:
-        candidate = persisted_locale.strip().lower()[:2]
-        if candidate in _SUPPORTED_OVERLAY_LOCALES:
-            return candidate
-    env_lang = (os.environ.get("OVERLAY_LOCALE") or "").strip().lower()[:2]
-    if env_lang in _SUPPORTED_OVERLAY_LOCALES:
-        return env_lang
-    accept = request.headers.get("accept-language") or ""
-    for raw in accept.split(","):
-        tag = raw.split(";")[0].strip().lower()[:2]
-        if tag in _SUPPORTED_OVERLAY_LOCALES:
-            return tag
-    return "en"
+    for candidate in (query_lang, persisted_locale, os.environ.get("OVERLAY_LOCALE")):
+        normalised = _normalise_locale(candidate)
+        if normalised is not None:
+            return normalised
+    return _resolve_accept_language(request.headers.get("accept-language"))
 
 
 def _get_overlay_server_credential() -> str | None:
@@ -222,12 +219,11 @@ def create_overlay_router(
         available = await run_in_threadpool(store.get_available_styles_list)
         renderable = await run_in_threadpool(store.get_renderable_styles)
 
-        # Always load the persisted state — both ``preferredStyle`` and
-        # the operator-chosen ``locale`` live on
-        # ``raw_remote_customization`` and we want to honour the locale
-        # on the initial HTML render so the page boots in the correct
-        # language before any WebSocket update arrives.
-        state = await store.load_persisted_state_async(overlay_id)
+        # Read the in-memory snapshot (lazy-loaded from disk on first
+        # touch). ``preferredStyle`` and the operator-chosen ``locale``
+        # both live on ``raw_remote_customization`` so the page boots in
+        # the right language and style before any WS update arrives.
+        state = await run_in_threadpool(store.get_state, overlay_id)
         customization = state.get("raw_remote_customization") or {}
 
         if not style:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -52,7 +52,7 @@ function getInitialOid(): string {
 }
 
 export default function App() {
-  const { t } = useI18n();
+  const { t, lang } = useI18n();
   const appConfig = useAppConfig();
   const { settings, setSetting } = useSettings();
   const { isPortrait, buttonSize, hasRoomForPersistentControls } = useOrientation();
@@ -94,6 +94,31 @@ export default function App() {
     actions,
     refreshCustomization,
   } = useGameState(oid);
+
+  // Push the operator's UI language onto the overlay's customization so
+  // OBS-embedded overlays (whose URL is fixed in the streaming app and
+  // cannot carry ``?lang=``) follow the operator's language live. The
+  // ref guards against re-sending the same value on unrelated
+  // customization refreshes.
+  const lastSyncedLocaleRef = useRef<string | null>(null);
+  const customizationLocale = asString(customization?.['locale']);
+  useEffect(() => {
+    if (!oid) return;
+    if (!customization) return;
+    if (lastSyncedLocaleRef.current === lang) return;
+    if (customizationLocale === lang) {
+      lastSyncedLocaleRef.current = lang;
+      return;
+    }
+    lastSyncedLocaleRef.current = lang;
+    api
+      .updateCustomization(oid, { locale: lang })
+      .then(() => refreshCustomization())
+      .catch((e) => {
+        lastSyncedLocaleRef.current = null;
+        console.warn('Failed to sync overlay locale:', e);
+      });
+  }, [oid, lang, customization, customizationLocale, refreshCustomization]);
 
   const { pulse } = useHaptics();
   // Set / match / finished transitions vibrate via the shared

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -107,9 +107,10 @@ export default function App() {
   const customizationLocale = asString(customization?.['locale']);
   useEffect(() => {
     if (!oid) return;
+    const attemptKey = oid + ':' + lang;
     if (customizationLocale === lang) return;
-    if (lastAttemptedLocaleRef.current === lang) return;
-    lastAttemptedLocaleRef.current = lang;
+    if (lastAttemptedLocaleRef.current === attemptKey) return;
+    lastAttemptedLocaleRef.current = attemptKey;
     api
       .updateCustomization(oid, { locale: lang })
       .then(() => refreshCustomization())

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -97,28 +97,26 @@ export default function App() {
 
   // Push the operator's UI language onto the overlay's customization so
   // OBS-embedded overlays (whose URL is fixed in the streaming app and
-  // cannot carry ``?lang=``) follow the operator's language live. The
-  // ref guards against re-sending the same value on unrelated
-  // customization refreshes.
-  const lastSyncedLocaleRef = useRef<string | null>(null);
+  // cannot carry ``?lang=``) follow language changes live. The ref
+  // pins per-``lang`` attempts so a failing backend doesn't retry on
+  // every parent re-render (only when the operator picks a new
+  // language). Invariant: the control WS broadcasts ``state_update``
+  // only, never ``customization_update`` — so a second operator's
+  // PUT cannot bounce this effect into a ping-pong.
+  const lastAttemptedLocaleRef = useRef<string | null>(null);
   const customizationLocale = asString(customization?.['locale']);
   useEffect(() => {
     if (!oid) return;
-    if (!customization) return;
-    if (lastSyncedLocaleRef.current === lang) return;
-    if (customizationLocale === lang) {
-      lastSyncedLocaleRef.current = lang;
-      return;
-    }
-    lastSyncedLocaleRef.current = lang;
+    if (customizationLocale === lang) return;
+    if (lastAttemptedLocaleRef.current === lang) return;
+    lastAttemptedLocaleRef.current = lang;
     api
       .updateCustomization(oid, { locale: lang })
       .then(() => refreshCustomization())
       .catch((e) => {
-        lastSyncedLocaleRef.current = null;
         console.warn('Failed to sync overlay locale:', e);
       });
-  }, [oid, lang, customization, customizationLocale, refreshCustomization]);
+  }, [oid, lang, customizationLocale, refreshCustomization]);
 
   const { pulse } = useHaptics();
   // Set / match / finished transitions vibrate via the shared

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -148,14 +148,8 @@ describe('App', () => {
   });
 
   it("syncs the operator's UI locale onto the overlay customization", async () => {
-    // The OBS browser source URL is fixed in the streaming app and
-    // cannot carry ``?lang=``, so the operator's UI language is the
-    // only live channel for the set-summary overlay to learn which
-    // language to render in. The locale-sync effect pushes it onto
-    // ``raw_remote_customization.locale`` whenever the operator's
-    // ``lang`` differs from what the customization currently carries.
-    // ``mockCustomization`` has no ``locale`` key — the operator's
-    // saved-or-default ``en`` should land on the first cycle.
+    // ``mockCustomization`` has no ``locale`` key; the test renders
+    // under the default I18nProvider so the resolved lang is ``en``.
     renderWithI18n(<App />);
     const input = screen.getByPlaceholderText('my-overlay');
     fireEvent.change(input, { target: { value: 'locale-sync-oid' } });
@@ -163,7 +157,7 @@ describe('App', () => {
     await waitFor(() => {
       expect(api.updateCustomization).toHaveBeenCalledWith(
         'locale-sync-oid',
-        { locale: expect.any(String) },
+        { locale: 'en' },
       );
     });
   });

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -45,6 +45,7 @@ describe('App', () => {
     vi.mocked(api.initSession).mockResolvedValue({ success: true, state: mockGameState });
     vi.mocked(api.getCustomization).mockResolvedValue(mockCustomization);
     vi.mocked(api.getLinks).mockResolvedValue({ control: '', overlay: '', preview: '' });
+    vi.mocked(api.updateCustomization).mockResolvedValue({ success: true });
   });
 
   it('renders OID entry screen initially', () => {
@@ -143,6 +144,27 @@ describe('App', () => {
 
     await waitFor(() => {
       expect(localStorage.setItem).toHaveBeenCalledWith('volley_oid', 'persist-oid');
+    });
+  });
+
+  it("syncs the operator's UI locale onto the overlay customization", async () => {
+    // The OBS browser source URL is fixed in the streaming app and
+    // cannot carry ``?lang=``, so the operator's UI language is the
+    // only live channel for the set-summary overlay to learn which
+    // language to render in. The locale-sync effect pushes it onto
+    // ``raw_remote_customization.locale`` whenever the operator's
+    // ``lang`` differs from what the customization currently carries.
+    // ``mockCustomization`` has no ``locale`` key — the operator's
+    // saved-or-default ``en`` should land on the first cycle.
+    renderWithI18n(<App />);
+    const input = screen.getByPlaceholderText('my-overlay');
+    fireEvent.change(input, { target: { value: 'locale-sync-oid' } });
+    fireEvent.submit(input.closest('form')!);
+    await waitFor(() => {
+      expect(api.updateCustomization).toHaveBeenCalledWith(
+        'locale-sync-oid',
+        { locale: expect.any(String) },
+      );
     });
   });
 

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -155,10 +155,7 @@ describe('App', () => {
     fireEvent.change(input, { target: { value: 'locale-sync-oid' } });
     fireEvent.submit(input.closest('form')!);
     await waitFor(() => {
-      expect(api.updateCustomization).toHaveBeenCalledWith(
-        'locale-sync-oid',
-        { locale: 'en' },
-      );
+      expect(api.updateCustomization).toHaveBeenCalledWith('locale-sync-oid', { locale: 'en' });
     });
   });
 

--- a/overlay_static/js/app.js
+++ b/overlay_static/js/app.js
@@ -76,7 +76,32 @@ function connectWebSocket() {
     };
 }
 
+// Locale codes the overlay JS can render — kept in sync with the LABELS
+// dictionaries in set_summary.js and SUPPORTED_OVERLAY_LOCALES on the
+// backend.
+const _SUPPORTED_OVERLAY_LOCALES = new Set(['en', 'es', 'pt', 'it', 'fr', 'de']);
+
+// The operator picks the language in the control UI; it gets pushed
+// onto ``raw_remote_customization.locale`` and broadcast over the
+// overlay WebSocket. The OBS browser source URL is fixed in the
+// streaming app, so this is the only channel the operator has to
+// change the set-summary overlay's language live. Re-syncing
+// ``window.OVERLAY_LOCALE`` from every incoming state means the next
+// ``window.SetSummary.render(state)`` call picks up the new language
+// without a page reload.
+function applyStateLocale(state) {
+    const next = state && state.raw_remote_customization
+        ? state.raw_remote_customization.locale
+        : null;
+    if (!next || typeof next !== 'string') return;
+    const candidate = next.slice(0, 2).toLowerCase();
+    if (_SUPPORTED_OVERLAY_LOCALES.has(candidate)) {
+        window.OVERLAY_LOCALE = candidate;
+    }
+}
+
 function processStateUpdate(newState) {
+    applyStateLocale(newState);
     if (!previousState) {
         // Initial render
         renderFullState(newState);

--- a/overlay_static/js/app.js
+++ b/overlay_static/js/app.js
@@ -76,26 +76,21 @@ function connectWebSocket() {
     };
 }
 
-// Locale codes the overlay JS can render — kept in sync with the LABELS
-// dictionaries in set_summary.js and SUPPORTED_OVERLAY_LOCALES on the
-// backend.
-const _SUPPORTED_OVERLAY_LOCALES = new Set(['en', 'es', 'pt', 'it', 'fr', 'de']);
+// Supported locales — mirrors match_report_i18n.SUPPORTED_LOCALES on
+// the backend and the LABELS keys in set_summary.js / spectator.js.
+const SUPPORTED_OVERLAY_LOCALES = new Set(['en', 'es', 'pt', 'it', 'fr', 'de']);
 
-// The operator picks the language in the control UI; it gets pushed
-// onto ``raw_remote_customization.locale`` and broadcast over the
-// overlay WebSocket. The OBS browser source URL is fixed in the
-// streaming app, so this is the only channel the operator has to
-// change the set-summary overlay's language live. Re-syncing
-// ``window.OVERLAY_LOCALE`` from every incoming state means the next
-// ``window.SetSummary.render(state)`` call picks up the new language
-// without a page reload.
+// Re-applied on every state push so a locale change pushed by the
+// operator (via raw_remote_customization.locale) lands before the next
+// SetSummary.render(state) — the OBS browser source URL is fixed in
+// the streaming app so we can't carry the locale in the URL.
 function applyStateLocale(state) {
     const next = state && state.raw_remote_customization
         ? state.raw_remote_customization.locale
         : null;
     if (!next || typeof next !== 'string') return;
     const candidate = next.slice(0, 2).toLowerCase();
-    if (_SUPPORTED_OVERLAY_LOCALES.has(candidate)) {
+    if (SUPPORTED_OVERLAY_LOCALES.has(candidate)) {
         window.OVERLAY_LOCALE = candidate;
     }
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -235,19 +235,11 @@ class TestGameService:
         assert result.success is True
 
     def test_update_customization_accepts_supported_locale(self, session):
-        """Operator UI locale syncs onto ``raw_remote_customization`` so
-        OBS overlays — whose URL is fixed in the streaming app — follow
-        the operator's language live."""
         result = GameService.update_customization(session, {"locale": "es"})
         assert result.success is True
-        saved = session.customization.get_model()
-        assert saved.get("locale") == "es"
+        assert session.customization.get_model().get("locale") == "es"
 
     def test_update_customization_rejects_unknown_locale(self, session):
-        """Anything outside the LABELS dictionaries in
-        ``set_summary.js`` would silently render English on the overlay
-        — fail loudly at the API boundary instead of letting bad data
-        persist."""
         result = GameService.update_customization(session, {"locale": "xx"})
         assert result.success is False
         assert "locale" in (result.message or "")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -234,6 +234,29 @@ class TestGameService:
         result = GameService.update_customization(session, new_data)
         assert result.success is True
 
+    def test_update_customization_accepts_supported_locale(self, session):
+        """Operator UI locale syncs onto ``raw_remote_customization`` so
+        OBS overlays — whose URL is fixed in the streaming app — follow
+        the operator's language live."""
+        result = GameService.update_customization(session, {"locale": "es"})
+        assert result.success is True
+        saved = session.customization.get_model()
+        assert saved.get("locale") == "es"
+
+    def test_update_customization_rejects_unknown_locale(self, session):
+        """Anything outside the LABELS dictionaries in
+        ``set_summary.js`` would silently render English on the overlay
+        — fail loudly at the API boundary instead of letting bad data
+        persist."""
+        result = GameService.update_customization(session, {"locale": "xx"})
+        assert result.success is False
+        assert "locale" in (result.message or "")
+
+    def test_update_customization_rejects_non_string_locale(self, session):
+        result = GameService.update_customization(session, {"locale": 123})
+        assert result.success is False
+        assert "locale" in (result.message or "")
+
     def test_refresh_customization_caches_within_ttl(self, session):
         """Back-to-back refreshes within the TTL must hit the backend once."""
         session.backend.get_current_customization.reset_mock()

--- a/tests/test_presets_operator.py
+++ b/tests/test_presets_operator.py
@@ -77,9 +77,16 @@ class TestPresetCategoriesPartition:
         covered: set[str] = set()
         for cat in preset_categories.CATEGORY_ORDER:
             covered.update(preset_categories.keys_for_category(cat))
-        assert covered == set(ALLOWED_CUSTOMIZATION_KEYS), (
+        # Non-preset keys (per-operator/per-session knobs that don't
+        # belong to a saved preset) are opted out via
+        # ``_NON_PRESET_KEYS`` and are intentionally excluded from the
+        # partition.
+        assert covered == (
+            set(ALLOWED_CUSTOMIZATION_KEYS) - preset_categories._NON_PRESET_KEYS
+        ), (
             "Each ``ALLOWED_CUSTOMIZATION_KEYS`` member must belong to "
-            "exactly one preset category."
+            "exactly one preset category (or be opted out via "
+            "``_NON_PRESET_KEYS``)."
         )
 
     def test_categories_for_keys_returns_canonical_order(self):

--- a/tests/test_spectator_route.py
+++ b/tests/test_spectator_route.py
@@ -64,13 +64,6 @@ def test_follow_serves_spectator_html(client):
 
 
 def test_overlay_picks_persisted_locale_over_env(client, monkeypatch):
-    """The operator's UI locale lands on
-    ``raw_remote_customization.locale`` via the customization endpoint;
-    ``serve_overlay`` must surface it on the first HTML render so the
-    page boots in the operator's language before any WS update lands.
-    This wins over ``OVERLAY_LOCALE`` (server-wide fallback) because
-    the OBS browser-source URL is fixed in the streaming app — the
-    operator has no way to pass ``?lang=`` once OBS is configured."""
     cli, store = client
     monkeypatch.setenv("OVERLAY_LOCALE", "de")
     store.set_raw_config("test-overlay", customization={"locale": "es"})
@@ -83,8 +76,6 @@ def test_overlay_picks_persisted_locale_over_env(client, monkeypatch):
 
 
 def test_overlay_falls_back_to_env_when_no_persisted_locale(client, monkeypatch):
-    """When the operator has not synced a locale yet, the legacy
-    server-wide ``OVERLAY_LOCALE`` env var still applies."""
     cli, _ = client
     monkeypatch.setenv("OVERLAY_LOCALE", "pt")
     res = cli.get("/overlay/test-overlay")
@@ -93,9 +84,6 @@ def test_overlay_falls_back_to_env_when_no_persisted_locale(client, monkeypatch)
 
 
 def test_overlay_query_lang_overrides_persisted_locale(client):
-    """``?lang=`` is the operator's manual override and stays
-    authoritative — useful when an OBS preview is opened in a browser
-    tab for ad-hoc inspection in a different language."""
     cli, store = client
     store.set_raw_config("test-overlay", customization={"locale": "es"})
     res = cli.get("/overlay/test-overlay?lang=fr")
@@ -104,8 +92,6 @@ def test_overlay_query_lang_overrides_persisted_locale(client):
 
 
 def test_overlay_ignores_unsupported_persisted_locale(client, monkeypatch):
-    """A junk persisted value (e.g. left over from a manual /manage
-    edit) must not poison the page — fall through to env/header."""
     cli, store = client
     monkeypatch.setenv("OVERLAY_LOCALE", "it")
     store.set_raw_config("test-overlay", customization={"locale": "xx"})

--- a/tests/test_spectator_route.py
+++ b/tests/test_spectator_route.py
@@ -58,6 +58,62 @@ def test_follow_serves_spectator_html(client):
     assert "test-overlay" not in body
 
 
+# ---------------------------------------------------------------------------
+# /overlay/{id} locale resolution
+# ---------------------------------------------------------------------------
+
+
+def test_overlay_picks_persisted_locale_over_env(client, monkeypatch):
+    """The operator's UI locale lands on
+    ``raw_remote_customization.locale`` via the customization endpoint;
+    ``serve_overlay`` must surface it on the first HTML render so the
+    page boots in the operator's language before any WS update lands.
+    This wins over ``OVERLAY_LOCALE`` (server-wide fallback) because
+    the OBS browser-source URL is fixed in the streaming app — the
+    operator has no way to pass ``?lang=`` once OBS is configured."""
+    cli, store = client
+    monkeypatch.setenv("OVERLAY_LOCALE", "de")
+    store.set_raw_config("test-overlay", customization={"locale": "es"})
+    res = cli.get(
+        "/overlay/test-overlay",
+        headers={"Accept-Language": "fr"},
+    )
+    assert res.status_code == 200
+    assert 'window.OVERLAY_LOCALE = "es"' in res.text
+
+
+def test_overlay_falls_back_to_env_when_no_persisted_locale(client, monkeypatch):
+    """When the operator has not synced a locale yet, the legacy
+    server-wide ``OVERLAY_LOCALE`` env var still applies."""
+    cli, _ = client
+    monkeypatch.setenv("OVERLAY_LOCALE", "pt")
+    res = cli.get("/overlay/test-overlay")
+    assert res.status_code == 200
+    assert 'window.OVERLAY_LOCALE = "pt"' in res.text
+
+
+def test_overlay_query_lang_overrides_persisted_locale(client):
+    """``?lang=`` is the operator's manual override and stays
+    authoritative — useful when an OBS preview is opened in a browser
+    tab for ad-hoc inspection in a different language."""
+    cli, store = client
+    store.set_raw_config("test-overlay", customization={"locale": "es"})
+    res = cli.get("/overlay/test-overlay?lang=fr")
+    assert res.status_code == 200
+    assert 'window.OVERLAY_LOCALE = "fr"' in res.text
+
+
+def test_overlay_ignores_unsupported_persisted_locale(client, monkeypatch):
+    """A junk persisted value (e.g. left over from a manual /manage
+    edit) must not poison the page — fall through to env/header."""
+    cli, store = client
+    monkeypatch.setenv("OVERLAY_LOCALE", "it")
+    store.set_raw_config("test-overlay", customization={"locale": "xx"})
+    res = cli.get("/overlay/test-overlay")
+    assert res.status_code == 200
+    assert 'window.OVERLAY_LOCALE = "it"' in res.text
+
+
 def test_follow_resolves_by_output_key(client):
     cli, _ = client
     output_key = OverlayStateStore.get_output_key("test-overlay")


### PR DESCRIPTION
The OBS browser-source URL is fixed in the streaming app and cannot
carry `?lang=`, so the spectator (follow) page's URL-parameter i18n
strategy never reaches an embedded set-summary overlay once OBS is
configured. Push the operator's UI locale onto
`raw_remote_customization.locale` instead so it rides the existing
overlay state broadcast: `set_summary.js` re-reads
`window.OVERLAY_LOCALE` on every WS update, and the served overlay
HTML seeds it from the persisted customization so the first render
boots in the right language.