### PR TITLE
docs: update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Volley Overlay Control
 
-![License](https://img.shields.io/github/license/jacobosanchez/volley-overlay-control)
+[![License](https://img.shields.io/github/license/jacobosanchez/volley-overlay-control)](https://github.com/jacobosanchez/volley-overlay-control)
 ![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)
-![CI](https://github.com/jacobosanchez/volley-overlay-control/actions/workflows/ci.yml/badge.svg)
+[![CI](https://github.com/jacobosanchez/volley-overlay-control/actions/workflows/ci.yml/badge.svg)](https://github.com/jacobosanchez/volley-overlay-control/actions/workflows/ci.yml)
 ![Docker](https://img.shields.io/badge/docker-available-2496ED?logo=docker&logoColor=white)
 ![FastAPI](https://img.shields.io/badge/built%20with-FastAPI-009688.svg)
 ![React](https://img.shields.io/badge/react-19-61DAFB?logo=react&logoColor=black)
@@ -104,7 +104,7 @@ For the full endpoint reference, request/response schemas, and WebSocket protoco
 
 ### Prerequisites
 
-*   **Python 3.x**
+*   **Python 3.11+**
 *   **Node.js 20+** and **npm** (for building the frontend)
 *   *(Optional)* An account on **[overlays.uno](https://overlays.uno)** for cloud overlays. Not needed when using the built-in overlay engine.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Volley Overlay Control
 
-![License](https://img.shields.io/badge/license-Apache%202-blue)
-![Python](https://img.shields.io/badge/python-3.x-blue.svg)
+![License](https://img.shields.io/github/license/jacobosanchez/volley-overlay-control)
+![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)
+![CI](https://github.com/jacobosanchez/volley-overlay-control/actions/workflows/ci.yml/badge.svg)
+![Docker](https://img.shields.io/badge/docker-available-2496ED?logo=docker&logoColor=white)
 ![FastAPI](https://img.shields.io/badge/built%20with-FastAPI-009688.svg)
+![React](https://img.shields.io/badge/react-19-61DAFB?logo=react&logoColor=black)
+![TypeScript](https://img.shields.io/badge/typescript-5.x-3178C6?logo=typescript&logoColor=white)
 
 **Volley Overlay Control** is a powerful, self-hostable application for controlling volleyball scoreboards. It bundles a touch-friendly React frontend, a FastAPI backend, and a **built-in overlay engine** into a single deployable service.
 


### PR DESCRIPTION
- Fix license badge: use live GitHub license badge (SPDX-correct, auto-synced)
- Fix Python badge: replace vague '3.x' with accurate '3.11+' (from pyproject.toml requires-python)
- Add CI badge: live GitHub Actions status for the CI pipeline
- Add Docker badge: signals the app ships as a Docker image
- Add React 19 badge: completes the full-stack picture alongside FastAPI
- Add TypeScript 5.x badge: reflects the typed frontend

https://claude.ai/code/session_01BXPdMAjv5eYyYb4m7dAJHE