### PR TITLE
feat: per-set timeout history + auto-recap on set end + configurable stale threshold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,13 +168,16 @@ The entire match lives in a flat dictionary with these keys:
     "Team 2 Sets": int,
     "Team 1 Game 1 Score": int, # 0–25  (set 1)
     ...                         # Game 2–5 for both teams
-    "Team 1 Timeouts": int,     # 0–2 per set
+    "Team 1 Timeouts": int,     # current-set timeouts (legacy compat)
     "Team 2 Timeouts": int,
+    "Team 1 Set 1 Timeouts": int, # per-set timeout history
+    ...                           # Set 2–5 for both teams
     "Current Set": int,         # 1–5
 }
 ```
 
 - Access scores via `state.get_game(team, set_num)` / `state.set_game(team, set_num, value)`.
+- Access timeouts via `state.get_timeout(team, set_num=None)` / `state.set_timeout(team, value, set_num=None)`; `set_num=None` (the default) targets the current set, preserving the legacy `get_timeout(team)` call shape. Full history is available via `state.get_timeouts_by_set(team)`.
 - The `simplify_model()` method strips all but the current set's data for "simple mode".
 
 ---
@@ -184,7 +187,7 @@ The entire match lives in a flat dictionary with these keys:
 - **Points to win a set:** `MATCH_GAME_POINTS` (default 25) — must win by 2.
 - **Points to win the final set:** `MATCH_GAME_POINTS_LAST_SET` (default 15) — must win by 2.
 - **Sets in a match:** `MATCH_SETS` (default 5); match ends when a team wins `(sets // 2) + 1` sets.
-- **Timeouts per set:** Max 2.
+- **Timeouts per set:** Max 2. Stored per-(team, set) so undoing a set-winning point across a set boundary restores the prior set's count — `add_set` no longer zeroes the counter.
 - **Undo:** Pass `undo=True` to `add_game()`, `add_set()`, or `add_timeout()` to reverse the action.
 - **Auto serve switch:** `add_game()` calls `change_serve()` automatically after each point.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,7 @@ The entire match lives in a flat dictionary with these keys:
 
 Config is loaded by `app/conf.py` -> `Conf` class from environment variables (`.env` or Docker compose).
 
-Key variables: `UNO_OVERLAY_OID`, `APP_PORT`, `MATCH_GAME_POINTS`, `MATCH_SETS`, `SCOREBOARD_USERS`, `APP_CUSTOM_OVERLAY_URL`, `ENABLE_MULTITHREAD`, `LOGGING_LEVEL`, `OVERLAY_MANAGER_PASSWORD` (enables the `/manage` admin page).
+Key variables: `UNO_OVERLAY_OID`, `APP_PORT`, `MATCH_GAME_POINTS`, `MATCH_SETS`, `STALE_SET_THRESHOLD_MINUTES` (minutes a single set may run before the control-UI abandoned-match prompt fires; `0` disables), `SCOREBOARD_USERS`, `APP_CUSTOM_OVERLAY_URL`, `ENABLE_MULTITHREAD`, `LOGGING_LEVEL`, `OVERLAY_MANAGER_PASSWORD` (enables the `/manage` admin page).
 
 Full list in [README.md](README.md).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Added
+
+- **Auto-trigger set-summary recap on set end.** New operator opt-in in
+  the Behavior section: when a set closes, the recap overlay appears
+  automatically after a configurable delay (default 5 s, range 0–30) so
+  the broadcast camera can linger on the players' reaction before the
+  overlay covers them, then auto-dismisses after a configurable duration
+  (default 15 s, range 5–60). The dismiss yields to live play
+  immediately if a point lands in the next set, and the show is
+  suppressed entirely if a point lands during the pre-show delay (the
+  rally already resumed). Undoing the set-winning point clears any
+  pending timers and force-hides the recap. End-of-match transitions
+  show the recap but skip the auto-dismiss so the operator clears the
+  final recap on their own.
+- **Configurable abandoned-match prompt threshold.** The 1-hour
+  stale-set detection that surfaces the "match looks abandoned" dialog
+  on control-UI load is now operator-tunable from the Behavior section
+  (range 0–240 minutes, step 5). Setting the value to 0 disables the
+  prompt entirely — long all-day tournaments can opt out without
+  losing the dialog for shorter recreational matches.
+
+### Fixed
+
+- **Per-set timeout history (closes the previous undo-across-set-
+  boundaries limitation).** Timeouts used to live in a single per-team
+  counter that was zeroed on every forward set transition, so undoing
+  a set-winning point couldn't restore the prior set's timeout state.
+  Storage now keeps a per-(team, set) array; ``State.get_timeout`` /
+  ``set_timeout`` gain an optional ``set_num`` argument (defaulting to
+  the current set, so existing call sites are untouched). ``add_set``
+  no longer zeroes the counters — the new set starts at 0 naturally
+  because no entry has been written yet, and the previous set's
+  history survives. ``TeamState`` gains a ``timeouts_by_set`` field
+  (current-set ``timeouts`` is preserved for backwards compatibility).
+  Legacy state files using only the flat ``Team N Timeouts`` key load
+  transparently: the legacy value lands in the current set's slot, and
+  the next save writes the new per-set keys alongside.
+
 ## [5.4.3] - 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,13 @@ once a first tagged release ships.
   final recap on their own.
 - **Configurable abandoned-match prompt threshold.** The 1-hour
   stale-set detection that surfaces the "match looks abandoned" dialog
-  on control-UI load is now operator-tunable from the Behavior section
-  (range 0–240 minutes, step 5). Setting the value to 0 disables the
-  prompt entirely — long all-day tournaments can opt out without
-  losing the dialog for shorter recreational matches.
+  on control-UI load is now configurable via the
+  ``STALE_SET_THRESHOLD_MINUTES`` environment variable (default
+  ``60``). Set it to ``0`` to disable the prompt entirely — long
+  all-day tournaments can opt out without losing the dialog for
+  shorter recreational matches. The frontend reads the value from
+  ``GET /api/v1/app-config`` on boot, so changing the env var only
+  needs a container restart (no client refresh required after that).
 
 ### Fixed
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -185,7 +185,7 @@ The "Brain" of the application. Enforces volleyball rules.
 - **Responsibility**: Manipulate `State` safely.
 - **Key Methods**:
   - `add_game(team, ...)` — Increments score. Handles "Winning by 2", point limits, and match completion.
-  - `add_set(team)` — Increments set count. Resets timeouts and serve for the next set.
+  - `add_set(team)` — Increments set count and resets serve. Timeouts are tracked per-set, so the new set's counter naturally starts at 0 while the prior set's history is preserved (undoing a set-winning point across a set boundary brings the previous set's timeouts back).
   - `change_serve(team)` — Updates the serving indicator.
   - `match_finished()` — Returns `True` if a team has reached the set limit.
   - `save(simple, current_set)` — Persists state via `Backend`.

--- a/FRONTEND_DEVELOPMENT.md
+++ b/FRONTEND_DEVELOPMENT.md
@@ -82,12 +82,14 @@ Response:
     "team_1": {
       "sets": 0,
       "timeouts": 0,
+      "timeouts_by_set": {"set_1": 0, "set_2": 0, "set_3": 0, "set_4": 0, "set_5": 0},
       "scores": {"set_1": 0, "set_2": 0, "set_3": 0, "set_4": 0, "set_5": 0},
       "serving": false
     },
     "team_2": {
       "sets": 0,
       "timeouts": 0,
+      "timeouts_by_set": {"set_1": 0, "set_2": 0, "set_3": 0, "set_4": 0, "set_5": 0},
       "scores": {"set_1": 0, "set_2": 0, "set_3": 0, "set_4": 0, "set_5": 0},
       "serving": false
     },
@@ -207,7 +209,7 @@ Add or undo a set win.
 {"team": 2, "undo": false}
 ```
 
-- Resets timeouts for both teams on new set
+- Timeouts are tracked per-set, so a new set's counter naturally starts at 0 while the prior set's history is preserved — undoing a set-winning point across the boundary restores the previous set's timeouts.
 - Resets serve on new set
 
 #### `POST /api/v1/game/add-timeout?oid=<OID>`
@@ -446,8 +448,8 @@ All messages from the server are JSON with a `type` field:
     "visible": true,
     "simple_mode": false,
     "match_finished": false,
-    "team_1": { "sets": 0, "timeouts": 0, "scores": {...}, "serving": true },
-    "team_2": { "sets": 0, "timeouts": 0, "scores": {...}, "serving": false },
+    "team_1": { "sets": 0, "timeouts": 0, "timeouts_by_set": {...}, "scores": {...}, "serving": true },
+    "team_2": { "sets": 0, "timeouts": 0, "timeouts_by_set": {...}, "scores": {...}, "serving": false },
     "serve": "A",
     "config": { "points_limit": 25, "points_limit_last_set": 15, "sets_limit": 5 }
   }
@@ -501,6 +503,7 @@ This is the shape exposed by `/api/v1/state` and the WebSocket stream. It is **n
 |-------|------|-------------|
 | `sets` | int | Number of sets won (0–3) |
 | `timeouts` | int | Timeouts taken in current set (0–2) |
+| `timeouts_by_set` | object | Per-set timeout history: `{"set_1": 2, "set_2": 0, ...}`. The `timeouts` field above mirrors the current-set entry. |
 | `scores` | object | Per-set scores: `{"set_1": 5, "set_2": 0, ...}` |
 | `serving` | bool | Whether this team currently has serve |
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Configure the application using the following environment variables:
 | `MATCH_GAME_POINTS` | Points needed to win a set. | `25` |
 | `MATCH_GAME_POINTS_LAST_SET` | Points needed to win the last set. | `15` |
 | `MATCH_SETS` | Total sets in the match (best of N). | `5` |
+| `STALE_SET_THRESHOLD_MINUTES` | Minutes a single set may run before the control-UI "match looks abandoned" prompt fires on the next page load. `0` disables the prompt entirely (useful for long all-day tournaments). Negative values clamp to `0`; non-numeric values fall back to the default. | `60` |
 | `ORDERED_TEAMS` | If `true`, the team list will be displayed in alphabetical order. | `true` |
 | `ENABLE_MULTITHREAD` | If `true`, overlay API calls run in a thread pool. | `true` |
 | `LOGGING_LEVEL` | Log level (`debug`, `info`, `warning`, `error`). | `warning` |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ It includes 16 overlay style templates served directly to OBS browser sources �
 |---|---|
 | ![Mosaic preview grid showing every overlay style with full match data](docs/screenshots/06-overlay-mosaic-full.png) | ![Mosaic preview grid showing every overlay style in simple mode](docs/screenshots/07-overlay-mosaic-simple.png) |
 
-**Set-summary recap overlay** (opt-in) fades in over the scoreboard between sets to surface the just-played set's score, point-progression chart and key stats. Ships in six visual variants — the `brand_columns` example below pairs each team's brand-coloured column with a centre chart panel:
+**Set-summary recap overlay** (opt-in) fades in over the scoreboard between sets to surface the just-played set's score, point-progression chart and key stats. Ships in six visual variants — the `brand_columns` example below pairs each team's brand-coloured column with a centre chart panel. An optional "auto-show" mode triggers the recap automatically after each set, with a configurable pre-show delay so the broadcast camera can stay on the players' reaction first.
 
 <p align="center"><img src="docs/screenshots/10-overlay-set-summary.png" alt="Set-summary recap overlay (brand_columns variant) — Thunder Wolves 22 vs Solar Hawks 25 with point-progression chart and per-set stats" width="65%"></p>
 

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -71,9 +71,14 @@ class GameService:
             for i in range(1, session.sets_limit + 1):
                 scores[f"set_{i}"] = state.get_game(team, i)
                 timeouts_by_set[f"set_{i}"] = state.get_timeout(team, set_num=i)
+            # Pin to ``session.current_set`` (not the implicit
+            # ``state.current_set`` default) — the latter only updates in
+            # ``GameManager.save`` after this response is built, so it
+            # lags by one tick on a set-winning point and would report
+            # the previous set's count.
             return TeamState(
                 sets=state.get_sets(team),
-                timeouts=state.get_timeout(team),
+                timeouts=state.get_timeout(team, set_num=session.current_set),
                 timeouts_by_set=timeouts_by_set,
                 scores=scores,
                 serving=(serve == State.SERVE_1 if team == 1 else serve == State.SERVE_2),

--- a/app/api/game_service.py
+++ b/app/api/game_service.py
@@ -67,11 +67,14 @@ class GameService:
 
         def team_state(team):
             scores = {}
+            timeouts_by_set = {}
             for i in range(1, session.sets_limit + 1):
                 scores[f"set_{i}"] = state.get_game(team, i)
+                timeouts_by_set[f"set_{i}"] = state.get_timeout(team, set_num=i)
             return TeamState(
                 sets=state.get_sets(team),
                 timeouts=state.get_timeout(team),
+                timeouts_by_set=timeouts_by_set,
                 scores=scores,
                 serving=(serve == State.SERVE_1 if team == 1 else serve == State.SERVE_2),
             )

--- a/app/api/routes/app_config.py
+++ b/app/api/routes/app_config.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter
 
 from app.api.schemas import AppConfigResponse
-from app.app_config import get_app_title
+from app.app_config import get_app_title, get_stale_set_threshold_minutes
 
 router = APIRouter()
 
@@ -11,4 +11,7 @@ router = APIRouter()
 @router.get("/app-config", response_model=AppConfigResponse)
 async def app_config() -> AppConfigResponse:
     """Return runtime app configuration consumed by the SPA on boot."""
-    return AppConfigResponse(title=get_app_title())
+    return AppConfigResponse(
+        title=get_app_title(),
+        stale_set_threshold_minutes=get_stale_set_threshold_minutes(),
+    )

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -257,3 +257,7 @@ class ActionResponse(BaseModel):
 
 class AppConfigResponse(BaseModel):
     title: str
+    # Minutes a single set may be live before the control-UI abandoned-
+    # match prompt fires (0 disables). Sourced from the
+    # ``STALE_SET_THRESHOLD_MINUTES`` env var; defaults to 60.
+    stale_set_threshold_minutes: int = 60

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -162,7 +162,10 @@ def is_safe_logo_url(value: object) -> bool:
 
 class TeamState(BaseModel):
     sets: int
-    timeouts: int
+    timeouts: int  # Current-set timeouts (kept for backwards compat).
+    # Per-set timeout history keyed by ``"set_N"`` so an operator-side
+    # undo across set boundaries can surface the prior set's count.
+    timeouts_by_set: dict = {}
     scores: dict  # {"set_1": 5, "set_2": 12, ...}
     serving: bool
 

--- a/app/app_config.py
+++ b/app/app_config.py
@@ -1,14 +1,24 @@
 """Runtime app-level configuration exposed to the frontend.
 
-Currently only the application title is configurable via the ``APP_TITLE``
-environment variable. The value is consumed both by the FastAPI app
-(injected into the served ``index.html`` and PWA manifest) and by the SPA
-(via ``GET /api/v1/app-config``).
+The application title is configurable via the ``APP_TITLE`` environment
+variable; the stale-set threshold (operator-facing "match looks
+abandoned" prompt) is configurable via ``STALE_SET_THRESHOLD_MINUTES``.
+Both are consumed by the SPA (via ``GET /api/v1/app-config``); the
+title is also injected into the served ``index.html`` and the PWA
+manifest.
 """
+
+import logging
 
 from app.env_vars_manager import EnvVarsManager
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_APP_TITLE = "Volley Scoreboard"
+
+# Default minutes a single set may be live before the abandoned-match
+# prompt fires on the next control-UI load. ``0`` disables the prompt.
+DEFAULT_STALE_SET_THRESHOLD_MINUTES = 60
 
 
 def get_app_title() -> str:
@@ -17,3 +27,25 @@ def get_app_title() -> str:
     if isinstance(value, str):
         value = value.strip()
     return value or DEFAULT_APP_TITLE
+
+
+def get_stale_set_threshold_minutes() -> int:
+    """Return the configured stale-set threshold in minutes.
+
+    Falls back to :data:`DEFAULT_STALE_SET_THRESHOLD_MINUTES` (60) when
+    the env var is unset, empty, or non-numeric. Negative values clamp
+    to ``0`` so callers can safely treat any non-positive value as
+    "prompt disabled".
+    """
+    raw = EnvVarsManager.get_env_var(
+        "STALE_SET_THRESHOLD_MINUTES", DEFAULT_STALE_SET_THRESHOLD_MINUTES,
+    )
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid STALE_SET_THRESHOLD_MINUTES=%r; falling back to %d.",
+            raw, DEFAULT_STALE_SET_THRESHOLD_MINUTES,
+        )
+        return DEFAULT_STALE_SET_THRESHOLD_MINUTES
+    return max(0, value)

--- a/app/game_manager.py
+++ b/app/game_manager.py
@@ -134,9 +134,10 @@ class GameManager:
                   self.main_state.set_sets(team, current_sets - 1)
         else:
             self.main_state.set_sets(team, current_sets + 1)
-            # Reset timeouts and serve for the new set
-            self.main_state.set_timeout(1, 0)
-            self.main_state.set_timeout(2, 0)
+            # Reset serve for the new set. Timeouts are tracked per-set
+            # in ``team*_timeouts_by_set`` so the new set's counter is
+            # already 0 — explicit zeroing here would clobber the prior
+            # set's history (the bug this refactor fixes).
             self.change_serve(0)
 
 

--- a/app/match_report.py
+++ b/app/match_report.py
@@ -595,11 +595,11 @@ def _logo_url(customization: dict, team: int) -> str | None:
 def _timeouts_per_set(audit: list[dict]) -> dict[int, dict[int, int]]:
     """Count ``add_timeout`` actions per (set, team) from the audit log.
 
-    Per-team timeout counters reset to zero on every set transition
-    (see :meth:`GameManager.add_set`), so timeouts are intrinsically
-    per-set and the audit log carries enough to rebuild that table
-    even though the snapshot's ``team_X.timeouts`` only reflects the
-    final set. Returns ``{set_num: {team: count}}``; callers consult
+    The live snapshot's ``team_X.timeouts`` is the current set's count,
+    so reconstructing the full per-set table for the printed report
+    requires walking the audit log (each ``add_timeout`` record
+    carries the set it landed in via ``result.current_set``). Returns
+    ``{set_num: {team: count}}``; callers consult
     ``.get(set, {}).get(team, 0)`` for safe lookup.
     """
     out: dict[int, dict[int, int]] = {}

--- a/app/state.py
+++ b/app/state.py
@@ -17,9 +17,12 @@ class GameState:
     current_set: int = 1
     team1_sets: int = 0
     team2_sets: int = 0
-    team1_timeouts: int = 0
-    team2_timeouts: int = 0
-    # Index 0 is unused; indices 1-5 hold scores for sets 1-5.
+    # Index 0 is unused; indices 1-5 hold per-set values.
+    # Per-set timeout history lets undo across a set boundary restore the
+    # prior set's timeouts (the flat counter that used to live here got
+    # zeroed on every forward set transition).
+    team1_timeouts_by_set: list[int] = field(default_factory=lambda: [0, 0, 0, 0, 0, 0])
+    team2_timeouts_by_set: list[int] = field(default_factory=lambda: [0, 0, 0, 0, 0, 0])
     team1_scores: list[int] = field(default_factory=lambda: [0, 0, 0, 0, 0, 0])
     team2_scores: list[int] = field(default_factory=lambda: [0, 0, 0, 0, 0, 0])
 
@@ -35,6 +38,10 @@ class State:
     SERVE_1 = Serve.TEAM_1
     SERVE_2 = Serve.TEAM_2
     SERVE_NONE = Serve.NONE
+    # Legacy flat timeout keys — populated on serialization with the
+    # current set's value so any external integrator reading the JSON
+    # by hand still gets a meaningful number. Per-set history lives in
+    # the per-set keys produced by :meth:`_t_timeouts_key`.
     T1TIMEOUTS_INT = 'Team 1 Timeouts'
     T2TIMEOUTS_INT = 'Team 2 Timeouts'
     T1SETS_INT = 'Team 1 Sets'
@@ -68,11 +75,21 @@ class State:
         T1TIMEOUTS_INT: '0',
         T2TIMEOUTS_INT: '0',
         CURRENT_SET_INT: '1',
+        # Per-set timeout history keys — match the shape produced by
+        # ``_to_dict`` so a reset payload zeroes the per-set history
+        # alongside the legacy flat counter.
+        **{f'Team {team} Set {set_num} Timeouts': '0'
+           for team in (1, 2) for set_num in range(1, 6)},
     }
 
     @staticmethod
+    def _t_timeouts_key(team: int, set_num: int) -> str:
+        """Per-set timeout key in the legacy string-keyed dict shape."""
+        return f'Team {team} Set {set_num} Timeouts'
+
+    @staticmethod
     def keys_to_reset_simple_mode():
-        return {State.T1SET5_INT,
+        keys = {State.T1SET5_INT,
                 State.T2SET5_INT,
                 State.T1SET4_INT,
                 State.T2SET4_INT,
@@ -82,6 +99,10 @@ class State:
                 State.T2SET2_INT,
                 State.T1SET1_INT,
                 State.T2SET1_INT}
+        for team in (1, 2):
+            for set_num in range(1, 6):
+                keys.add(State._t_timeouts_key(team, set_num))
+        return keys
 
     # ------------------------------------------------------------------
     # Construction & serialization
@@ -95,32 +116,64 @@ class State:
 
     @staticmethod
     def _from_dict(d: dict) -> GameState:
-        """Parse a legacy string-keyed dict into a typed ``GameState``."""
+        """Parse a legacy string-keyed dict into a typed ``GameState``.
+
+        Per-set timeout history is read from ``Team N Set M Timeouts``
+        keys when present. For pre-existing state files written before
+        per-set history was introduced, the legacy single
+        ``Team N Timeouts`` key is read and stamped into the current
+        set's slot — preserving the operator's current in-flight count.
+        """
+        current_set = int(d.get('Current Set', 1))
+
+        def per_set_timeouts(team: int) -> list[int]:
+            slots = [0, 0, 0, 0, 0, 0]
+            has_per_set = any(
+                State._t_timeouts_key(team, i) in d for i in range(1, 6)
+            )
+            if has_per_set:
+                for i in range(1, 6):
+                    slots[i] = int(d.get(State._t_timeouts_key(team, i), 0))
+            else:
+                legacy = int(d.get(f'Team {team} Timeouts', 0))
+                if 1 <= current_set <= 5:
+                    slots[current_set] = legacy
+            return slots
+
         return GameState(
             serve=Serve(d.get('Serve', 'None')),
-            current_set=int(d.get('Current Set', 1)),
+            current_set=current_set,
             team1_sets=int(d.get('Team 1 Sets', 0)),
             team2_sets=int(d.get('Team 2 Sets', 0)),
-            team1_timeouts=int(d.get('Team 1 Timeouts', 0)),
-            team2_timeouts=int(d.get('Team 2 Timeouts', 0)),
+            team1_timeouts_by_set=per_set_timeouts(1),
+            team2_timeouts_by_set=per_set_timeouts(2),
             team1_scores=[0] + [int(d.get(f'Team 1 Game {i} Score', 0)) for i in range(1, 6)],
             team2_scores=[0] + [int(d.get(f'Team 2 Game {i} Score', 0)) for i in range(1, 6)],
         )
 
     def _to_dict(self) -> dict[str, str]:
-        """Serialize to the legacy string-keyed dict format."""
+        """Serialize to the legacy string-keyed dict format.
+
+        Legacy ``Team N Timeouts`` keys carry the current set's value so
+        external integrators reading the JSON by hand still see a
+        meaningful number. ``Team N Set M Timeouts`` keys carry the
+        per-set history.
+        """
         s = self._state
+        current_set = s.current_set if 1 <= s.current_set <= 5 else 1
         d = {
             'Serve': s.serve.value,
             'Current Set': str(s.current_set),
             'Team 1 Sets': str(s.team1_sets),
             'Team 2 Sets': str(s.team2_sets),
-            'Team 1 Timeouts': str(s.team1_timeouts),
-            'Team 2 Timeouts': str(s.team2_timeouts),
+            'Team 1 Timeouts': str(s.team1_timeouts_by_set[current_set]),
+            'Team 2 Timeouts': str(s.team2_timeouts_by_set[current_set]),
         }
         for i in range(1, 6):
             d[f'Team 1 Game {i} Score'] = str(s.team1_scores[i])
             d[f'Team 2 Game {i} Score'] = str(s.team2_scores[i])
+            d[State._t_timeouts_key(1, i)] = str(s.team1_timeouts_by_set[i])
+            d[State._t_timeouts_key(2, i)] = str(s.team2_timeouts_by_set[i])
         return d
 
     def get_reset_model(self):
@@ -138,12 +191,25 @@ class State:
         current_set = simplified[State.CURRENT_SET_INT]
         t1_points = simplified[f'Team 1 Game {current_set} Score']
         t2_points = simplified[f'Team 2 Game {current_set} Score']
+        # Capture per-set timeout values for the current set before we
+        # zero the per-set keys — so the moved-to-set-1 representation
+        # still reflects the timeouts the operator has taken.
+        t1_timeouts_current = simplified.get(
+            State._t_timeouts_key(1, current_set), '0',
+        )
+        t2_timeouts_current = simplified.get(
+            State._t_timeouts_key(2, current_set), '0',
+        )
         for key in State.keys_to_reset_simple_mode():
             if key in simplified:
                 simplified[key] = '0'
 
         simplified[State.T1SET1_INT] = t1_points
         simplified[State.T2SET1_INT] = t2_points
+        if State._t_timeouts_key(1, 1) in simplified:
+            simplified[State._t_timeouts_key(1, 1)] = t1_timeouts_current
+        if State._t_timeouts_key(2, 1) in simplified:
+            simplified[State._t_timeouts_key(2, 1)] = t2_timeouts_current
         return simplified
 
     # ------------------------------------------------------------------
@@ -153,18 +219,49 @@ class State:
     def set_current_set(self, value):
         self._state.current_set = int(value)
 
-    def get_timeout(self, team):
-        if team not in (1, 2):
-            raise KeyError(f'Team {team} Timeouts')
-        return self._state.team1_timeouts if team == 1 else self._state.team2_timeouts
+    def get_timeout(self, team, set_num=None):
+        """Return the timeouts taken by *team* in *set_num*.
 
-    def set_timeout(self, team, value):
+        ``set_num`` defaults to the current set when omitted, preserving
+        the historical ``get_timeout(team)`` call shape.
+        """
         if team not in (1, 2):
             raise KeyError(f'Team {team} Timeouts')
-        if team == 1:
-            self._state.team1_timeouts = int(value)
-        else:
-            self._state.team2_timeouts = int(value)
+        if set_num is None:
+            set_num = self._state.current_set
+        if not (1 <= set_num <= 5):
+            raise KeyError(f'Team {team} Set {set_num} Timeouts')
+        slots = (
+            self._state.team1_timeouts_by_set if team == 1
+            else self._state.team2_timeouts_by_set
+        )
+        return slots[set_num]
+
+    def set_timeout(self, team, value, set_num=None):
+        """Set the timeout count for *team* in *set_num* (defaults to
+        the current set)."""
+        if team not in (1, 2):
+            raise KeyError(f'Team {team} Timeouts')
+        if set_num is None:
+            set_num = self._state.current_set
+        if not (1 <= set_num <= 5):
+            raise KeyError(f'Team {team} Set {set_num} Timeouts')
+        slots = (
+            self._state.team1_timeouts_by_set if team == 1
+            else self._state.team2_timeouts_by_set
+        )
+        slots[set_num] = int(value)
+
+    def get_timeouts_by_set(self, team) -> dict[int, int]:
+        """Return the full per-set timeout history for *team* as a
+        1-indexed dict (set 1 through 5)."""
+        if team not in (1, 2):
+            raise KeyError(f'Team {team} Timeouts')
+        slots = (
+            self._state.team1_timeouts_by_set if team == 1
+            else self._state.team2_timeouts_by_set
+        )
+        return {i: slots[i] for i in range(1, 6)}
 
     def get_sets(self, team):
         if team not in (1, 2):

--- a/app/state.py
+++ b/app/state.py
@@ -160,14 +160,18 @@ class State:
         per-set history.
         """
         s = self._state
-        current_set = s.current_set if 1 <= s.current_set <= 5 else 1
         d = {
             'Serve': s.serve.value,
             'Current Set': str(s.current_set),
             'Team 1 Sets': str(s.team1_sets),
             'Team 2 Sets': str(s.team2_sets),
-            'Team 1 Timeouts': str(s.team1_timeouts_by_set[current_set]),
-            'Team 2 Timeouts': str(s.team2_timeouts_by_set[current_set]),
+            # Route through ``get_timeout`` so out-of-bounds
+            # ``current_set`` (defensive — shouldn't happen via the
+            # normal session flow, but a stray manual ``set_current_set``
+            # could) yields 0 instead of indexing into the array with
+            # an arbitrary fallback set.
+            'Team 1 Timeouts': str(self.get_timeout(1)),
+            'Team 2 Timeouts': str(self.get_timeout(2)),
         }
         for i in range(1, 6):
             d[f'Team 1 Game {i} Score'] = str(s.team1_scores[i])
@@ -223,14 +227,21 @@ class State:
         """Return the timeouts taken by *team* in *set_num*.
 
         ``set_num`` defaults to the current set when omitted, preserving
-        the historical ``get_timeout(team)`` call shape.
+        the historical ``get_timeout(team)`` call shape. An invalid
+        ``team`` raises ``KeyError`` (consistent with the other team-
+        keyed accessors). An out-of-bounds ``set_num`` returns ``0``:
+        the per-set timeout count for a set that doesn't exist (e.g.
+        a manual edit landing the current set above ``sets_limit``)
+        is meaningfully zero, and a hard raise here would crash the
+        state-broadcast hot path on what should be a service-layer
+        guard.
         """
         if team not in (1, 2):
             raise KeyError(f'Team {team} Timeouts')
         if set_num is None:
             set_num = self._state.current_set
         if not (1 <= set_num <= 5):
-            raise KeyError(f'Team {team} Set {set_num} Timeouts')
+            return 0
         slots = (
             self._state.team1_timeouts_by_set if team == 1
             else self._state.team2_timeouts_by_set
@@ -239,13 +250,19 @@ class State:
 
     def set_timeout(self, team, value, set_num=None):
         """Set the timeout count for *team* in *set_num* (defaults to
-        the current set)."""
+        the current set).
+
+        An invalid ``team`` raises ``KeyError`` (consistent with the
+        other team-keyed setters). An out-of-bounds ``set_num`` is a
+        no-op for the same reason ``get_timeout`` returns ``0`` —
+        bounds belong in the service layer, not the data accessors.
+        """
         if team not in (1, 2):
             raise KeyError(f'Team {team} Timeouts')
         if set_num is None:
             set_num = self._state.current_set
         if not (1 <= set_num <= 5):
-            raise KeyError(f'Team {team} Set {set_num} Timeouts')
+            return
         slots = (
             self._state.team1_timeouts_by_set if team == 1
             else self._state.team2_timeouts_by_set

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - MATCH_GAME_POINTS=${MATCH_GAME_POINTS:-25}
       - MATCH_GAME_POINTS_LAST_SET=${MATCH_GAME_POINTS_LAST_SET:-15}
       - MATCH_SETS=${MATCH_SETS:-5}
+      - STALE_SET_THRESHOLD_MINUTES=${STALE_SET_THRESHOLD_MINUTES:-60} #Optional: minutes a single set may run before the control-UI "abandoned match" prompt fires; 0 disables
       - PREDEFINED_OVERLAYS=${PREDEFINED_OVERLAYS:-}
       - HIDE_CUSTOM_OVERLAY_WHEN_PREDEFINED=${HIDE_CUSTOM_OVERLAY_WHEN_PREDEFINED:-}
       - OVERLAY_MANAGER_PASSWORD=${OVERLAY_MANAGER_PASSWORD:-} #Optional: unlocks the /manage admin page

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -37,14 +37,14 @@
       },
       "AppConfigResponse": {
         "properties": {
-          "title": {
-            "title": "Title",
-            "type": "string"
-          },
           "stale_set_threshold_minutes": {
             "default": 60,
             "title": "Stale Set Threshold Minutes",
             "type": "integer"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
           }
         },
         "required": [

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -1131,6 +1131,12 @@
           "timeouts": {
             "title": "Timeouts",
             "type": "integer"
+          },
+          "timeouts_by_set": {
+            "additionalProperties": true,
+            "default": {},
+            "title": "Timeouts By Set",
+            "type": "object"
           }
         },
         "required": [

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -40,6 +40,11 @@
           "title": {
             "title": "Title",
             "type": "string"
+          },
+          "stale_set_threshold_minutes": {
+            "default": 60,
+            "title": "Stale Set Threshold Minutes",
+            "type": "integer"
           }
         },
         "required": [

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -150,9 +150,10 @@ export default function App() {
     if (stalePromptFiredRef.current) return;
     if (!state) return;
     if (state.match_finished) return;
-    const thresholdSec = settings.staleSetThresholdMinutes * 60;
-    // 0 disables the prompt entirely — operators running long all-day
-    // tournaments or short rec matches turn it off here.
+    // Threshold is configured server-side via the
+    // ``STALE_SET_THRESHOLD_MINUTES`` env var and arrives on the
+    // ``/api/v1/app-config`` response. ``0`` disables the prompt.
+    const thresholdSec = (appConfig.stale_set_threshold_minutes ?? 60) * 60;
     if (thresholdSec <= 0) return;
     const startedAt = state.current_set_started_at;
     if (typeof startedAt !== 'number' || startedAt <= 0) return;
@@ -170,7 +171,7 @@ export default function App() {
       stalePromptFiredRef.current = true;
       setStalePromptOpen(true);
     }
-  }, [state, settings.staleSetThresholdMinutes]);
+  }, [state, appConfig.stale_set_threshold_minutes]);
   // Auto-trigger the set-summary recap on each set transition (operator
   // opt-in via the Behavior section). The recap waits ``delaySec`` so
   // the broadcast camera has time to linger on the players' reaction

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { useHaptics } from './hooks/useHaptics';
 import { useMatchAlertHaptics } from './hooks/useMatchAlertHaptics';
 import { useScreenWakeLock } from './hooks/useScreenWakeLock';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
+import { useAutoSetSummary } from './hooks/useAutoSetSummary';
 import InitScreen from './components/InitScreen';
 import ScoreboardView from './components/ScoreboardView';
 import ScoreboardSkeleton from './components/ScoreboardSkeleton';
@@ -145,11 +146,14 @@ export default function App() {
   // streaming the same stale state.
   const [stalePromptOpen, setStalePromptOpen] = useState(false);
   const stalePromptFiredRef = useRef(false);
-  const STALE_SET_THRESHOLD_SEC = 60 * 60;
   useEffect(() => {
     if (stalePromptFiredRef.current) return;
     if (!state) return;
     if (state.match_finished) return;
+    const thresholdSec = settings.staleSetThresholdMinutes * 60;
+    // 0 disables the prompt entirely — operators running long all-day
+    // tournaments or short rec matches turn it off here.
+    if (thresholdSec <= 0) return;
     const startedAt = state.current_set_started_at;
     if (typeof startedAt !== 'number' || startedAt <= 0) return;
     // Prefer the server's wall clock when the payload includes it
@@ -162,11 +166,22 @@ export default function App() {
         ? state.server_time
         : Date.now() / 1000;
     const elapsed = nowSec - startedAt;
-    if (elapsed > STALE_SET_THRESHOLD_SEC) {
+    if (elapsed > thresholdSec) {
       stalePromptFiredRef.current = true;
       setStalePromptOpen(true);
     }
-  }, [state]);
+  }, [state, settings.staleSetThresholdMinutes]);
+  // Auto-trigger the set-summary recap on each set transition (operator
+  // opt-in via the Behavior section). The recap waits ``delaySec`` so
+  // the broadcast camera has time to linger on the players' reaction
+  // before the overlay covers them, then dismisses after ``durationSec``.
+  useAutoSetSummary({
+    state: confirmedState,
+    enabled: settings.setSummaryEnabled && settings.autoShowSetSummary,
+    delaySec: settings.autoShowSetSummaryDelay,
+    durationSec: settings.autoShowSetSummaryDuration,
+    setSetSummary: (v) => actions.setSetSummary(v),
+  });
   // Coachmark fires once the first authoritative state lands and the
   // operator hasn't dismissed the tour yet. The dismissal flips
   // ``settings.gestureTourSeen`` to ``true`` and persists across

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1236,13 +1236,13 @@ export interface components {
         };
         /** AppConfigResponse */
         AppConfigResponse: {
-            /** Title */
-            title: string;
             /**
              * Stale Set Threshold Minutes
              * @default 60
              */
             stale_set_threshold_minutes: number;
+            /** Title */
+            title: string;
         };
         /**
          * BeachSideSwitch

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1675,6 +1675,13 @@ export interface components {
             sets: number;
             /** Timeouts */
             timeouts: number;
+            /**
+             * Timeouts By Set
+             * @default {}
+             */
+            timeouts_by_set: {
+                [key: string]: unknown;
+            };
         };
         /** TeamStateModel */
         TeamStateModel: {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1238,6 +1238,11 @@ export interface components {
         AppConfigResponse: {
             /** Title */
             title: string;
+            /**
+             * Stale Set Threshold Minutes
+             * @default 60
+             */
+            stale_set_threshold_minutes: number;
         };
         /**
          * BeachSideSwitch

--- a/frontend/src/components/config/BehaviorSection.tsx
+++ b/frontend/src/components/config/BehaviorSection.tsx
@@ -11,6 +11,10 @@ export interface BehaviorSettings {
   haptics: boolean;
   keyboardShortcuts: boolean;
   setSummaryEnabled: boolean;
+  autoShowSetSummary: boolean;
+  autoShowSetSummaryDelay: number;
+  autoShowSetSummaryDuration: number;
+  staleSetThresholdMinutes: number;
 }
 
 export interface BehaviorSectionProps {
@@ -120,8 +124,53 @@ export default function BehaviorSection({
               <SetSummaryStylePicker value={setSummaryStyle} onChange={onChangeSetSummaryStyle} />
             </div>
           )}
+          <div style={{ paddingLeft: '1.5rem' }}>
+            <ConfigSwitch
+              label={t('behavior.autoShowSetSummary')}
+              checked={settings.autoShowSetSummary}
+              onChange={(v) => setSetting('autoShowSetSummary', v)}
+            />
+            {settings.autoShowSetSummary && (
+              <>
+                <ConfigRange
+                  label={t('behavior.autoShowSetSummary.delay', {
+                    value: settings.autoShowSetSummaryDelay,
+                  })}
+                  value={settings.autoShowSetSummaryDelay}
+                  min={0}
+                  max={30}
+                  step={1}
+                  onChange={(v) => setSetting('autoShowSetSummaryDelay', v)}
+                />
+                <ConfigRange
+                  label={t('behavior.autoShowSetSummary.duration', {
+                    value: settings.autoShowSetSummaryDuration,
+                  })}
+                  value={settings.autoShowSetSummaryDuration}
+                  min={5}
+                  max={60}
+                  step={1}
+                  onChange={(v) => setSetting('autoShowSetSummaryDuration', v)}
+                />
+              </>
+            )}
+          </div>
         </>
       )}
+
+      <div className="config-separator" />
+      <ConfigRange
+        label={
+          settings.staleSetThresholdMinutes <= 0
+            ? t('behavior.staleSetThreshold.off')
+            : t('behavior.staleSetThreshold', { value: settings.staleSetThresholdMinutes })
+        }
+        value={settings.staleSetThresholdMinutes}
+        min={0}
+        max={240}
+        step={5}
+        onChange={(v) => setSetting('staleSetThresholdMinutes', v)}
+      />
 
       <div className="config-separator" />
       <div className="config-field-row">

--- a/frontend/src/components/config/BehaviorSection.tsx
+++ b/frontend/src/components/config/BehaviorSection.tsx
@@ -14,7 +14,6 @@ export interface BehaviorSettings {
   autoShowSetSummary: boolean;
   autoShowSetSummaryDelay: number;
   autoShowSetSummaryDuration: number;
-  staleSetThresholdMinutes: number;
 }
 
 export interface BehaviorSectionProps {
@@ -157,20 +156,6 @@ export default function BehaviorSection({
           </div>
         </>
       )}
-
-      <div className="config-separator" />
-      <ConfigRange
-        label={
-          settings.staleSetThresholdMinutes <= 0
-            ? t('behavior.staleSetThreshold.off')
-            : t('behavior.staleSetThreshold', { value: settings.staleSetThresholdMinutes })
-        }
-        value={settings.staleSetThresholdMinutes}
-        min={0}
-        max={240}
-        step={5}
-        onChange={(v) => setSetting('staleSetThresholdMinutes', v)}
-      />
 
       <div className="config-separator" />
       <div className="config-field-row">

--- a/frontend/src/hooks/useAppConfig.ts
+++ b/frontend/src/hooks/useAppConfig.ts
@@ -3,6 +3,7 @@ import * as api from '../api/client';
 import type { AppConfig } from '../api/client';
 
 const DEFAULT_TITLE = 'Volley Scoreboard';
+const DEFAULT_STALE_SET_THRESHOLD_MINUTES = 60;
 
 /**
  * Fetch runtime app configuration from the backend on mount and set
@@ -11,7 +12,10 @@ const DEFAULT_TITLE = 'Volley Scoreboard';
  * default while the request is in flight.
  */
 export function useAppConfig(): AppConfig {
-  const [config, setConfig] = useState<AppConfig>({ title: DEFAULT_TITLE });
+  const [config, setConfig] = useState<AppConfig>({
+    title: DEFAULT_TITLE,
+    stale_set_threshold_minutes: DEFAULT_STALE_SET_THRESHOLD_MINUTES,
+  });
 
   useEffect(() => {
     let cancelled = false;

--- a/frontend/src/hooks/useAutoSetSummary.ts
+++ b/frontend/src/hooks/useAutoSetSummary.ts
@@ -1,0 +1,192 @@
+import { useEffect, useRef } from 'react';
+import type { GameState } from '../api/client';
+
+export interface UseAutoSetSummaryOptions {
+  /**
+   * The live game state. Pass ``confirmedState`` (not ``state``) so the
+   * detector ignores optimistic predictions — the set transition has
+   * to be authoritative before we cover the broadcast with a recap.
+   */
+  state: GameState | null;
+  /**
+   * Master enable. The hook is a no-op when ``false`` — combine the
+   * operator's ``setSummaryEnabled`` + ``autoShowSetSummary`` toggles
+   * at the call site.
+   */
+  enabled: boolean;
+  /**
+   * Seconds to wait between the set-winning point and the recap
+   * appearing. ``0`` shows the recap on the same tick.
+   */
+  delaySec: number;
+  /**
+   * Seconds the recap stays visible before auto-dismiss. The
+   * dismiss is skipped on match end (final set transition) so the
+   * end-of-match recap stays up until the operator clears it.
+   */
+  durationSec: number;
+  /**
+   * Toggle the server-side set-summary flag (delegate to
+   * ``actions.setSetSummary`` from ``useGameState``). Errors are
+   * intentionally swallowed inside the hook — the recap is best-
+   * effort polish and a transient API hiccup shouldn't crash the
+   * scoreboard.
+   */
+  setSetSummary: (v: boolean) => Promise<unknown> | void;
+}
+
+function totalSets(state: GameState | null): number | null {
+  if (!state) return null;
+  return (state.team_1?.sets ?? 0) + (state.team_2?.sets ?? 0);
+}
+
+function currentSetScore(state: GameState | null): number | null {
+  if (!state) return null;
+  const setNum =
+    state.current_set ||
+    (state.team_1?.sets ?? 0) + (state.team_2?.sets ?? 0) + 1;
+  const key = `set_${setNum}`;
+  const t1 = state.team_1?.scores as Record<string, unknown> | undefined;
+  const t2 = state.team_2?.scores as Record<string, unknown> | undefined;
+  const t1Score = typeof t1?.[key] === 'number' ? (t1[key] as number) : 0;
+  const t2Score = typeof t2?.[key] === 'number' ? (t2[key] as number) : 0;
+  return t1Score + t2Score;
+}
+
+/**
+ * Auto-trigger the set-summary recap overlay on each set transition.
+ *
+ * Wires two timers around the set-winning point:
+ *
+ *   final point ──[ delaySec ]──▶ recap shown ──[ durationSec ]──▶ recap hidden
+ *
+ * Both timers are cancellable:
+ * - Score advances during the delay → show is suppressed.
+ * - Score advances during the recap → recap is dismissed immediately.
+ * - Operator undoes the set-winning point → timers clear, hide is posted.
+ * - Final set transition wins the match → recap shows but auto-dismiss
+ *   is skipped so the operator dismisses the end-of-match recap on
+ *   their own.
+ */
+export function useAutoSetSummary(opts: UseAutoSetSummaryOptions): void {
+  const { state, enabled, delaySec, durationSec, setSetSummary } = opts;
+
+  const delayTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevTotalSets = useRef<number | null>(null);
+  const prevCurrentScore = useRef<number | null>(null);
+  const setSetSummaryRef = useRef(setSetSummary);
+
+  // Keep the latest callback in a ref so timer fires use the current
+  // closure (not the one captured when the timer was scheduled).
+  useEffect(() => {
+    setSetSummaryRef.current = setSetSummary;
+  }, [setSetSummary]);
+
+  const clearAll = () => {
+    if (delayTimer.current !== null) {
+      clearTimeout(delayTimer.current);
+      delayTimer.current = null;
+    }
+    if (dismissTimer.current !== null) {
+      clearTimeout(dismissTimer.current);
+      dismissTimer.current = null;
+    }
+  };
+
+  useEffect(() => {
+    if (!state) return;
+    const ts = totalSets(state);
+    const cs = currentSetScore(state);
+    const prevTs = prevTotalSets.current;
+    const prevCs = prevCurrentScore.current;
+    prevTotalSets.current = ts;
+    prevCurrentScore.current = cs;
+
+    if (!enabled) {
+      // Master toggle off: drop any pending timers so a delayed show
+      // can't fire after the operator opted out. We keep tracking the
+      // prev refs above so flipping the toggle back on mid-match
+      // doesn't re-fire from a stale baseline. The currently visible
+      // recap (if any) is left alone — the operator can dismiss it
+      // manually via the existing toggle.
+      clearAll();
+      return;
+    }
+
+    if (prevTs === null || prevCs === null) {
+      // First authoritative state seen — baseline the refs but do not
+      // fire (a mid-match page refresh shouldn't slam the recap up).
+      return;
+    }
+
+    // Operator undid the set-winning point. Total sets dropped — clear
+    // any pending timers and force-hide so a stale show timer can't
+    // appear half a second after the undo.
+    if (ts !== null && ts < prevTs) {
+      clearAll();
+      try {
+        setSetSummaryRef.current(false);
+      } catch {
+        /* best-effort */
+      }
+      return;
+    }
+
+    // Set-transition edge.
+    if (ts !== null && ts > prevTs) {
+      clearAll();
+      const isMatchEnd = !!state.match_finished;
+      const show = () => {
+        delayTimer.current = null;
+        try {
+          setSetSummaryRef.current(true);
+        } catch {
+          /* best-effort */
+        }
+        if (!isMatchEnd && durationSec > 0) {
+          dismissTimer.current = setTimeout(() => {
+            dismissTimer.current = null;
+            try {
+              setSetSummaryRef.current(false);
+            } catch {
+              /* best-effort */
+            }
+          }, durationSec * 1000);
+        }
+      };
+      if (delaySec > 0) {
+        delayTimer.current = setTimeout(show, delaySec * 1000);
+      } else {
+        show();
+      }
+      return;
+    }
+
+    // Resumed-play edge: a new point landed in the current set while
+    // a timer was pending. If the show hasn't fired yet, suppress it
+    // entirely; if the recap is already up, dismiss it immediately.
+    if (cs !== null && prevCs !== null && cs > prevCs) {
+      if (delayTimer.current !== null) {
+        clearTimeout(delayTimer.current);
+        delayTimer.current = null;
+        return;
+      }
+      if (dismissTimer.current !== null) {
+        clearTimeout(dismissTimer.current);
+        dismissTimer.current = null;
+        try {
+          setSetSummaryRef.current(false);
+        } catch {
+          /* best-effort */
+        }
+      }
+    }
+  }, [state, enabled, delaySec, durationSec]);
+
+  // Cleanup on unmount.
+  useEffect(() => {
+    return () => clearAll();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/frontend/src/hooks/useAutoSetSummary.ts
+++ b/frontend/src/hooks/useAutoSetSummary.ts
@@ -42,9 +42,7 @@ function totalSets(state: GameState | null): number | null {
 
 function currentSetScore(state: GameState | null): number | null {
   if (!state) return null;
-  const setNum =
-    state.current_set ||
-    (state.team_1?.sets ?? 0) + (state.team_2?.sets ?? 0) + 1;
+  const setNum = state.current_set || (state.team_1?.sets ?? 0) + (state.team_2?.sets ?? 0) + 1;
   const key = `set_${setNum}`;
   const t1 = state.team_1?.scores as Record<string, unknown> | undefined;
   const t2 = state.team_2?.scores as Record<string, unknown> | undefined;

--- a/frontend/src/hooks/useSettings.tsx
+++ b/frontend/src/hooks/useSettings.tsx
@@ -68,6 +68,31 @@ export interface Settings {
    * surprise extra button.
    */
   setSummaryEnabled: boolean;
+  /**
+   * When ``setSummaryEnabled`` is on, fire the recap automatically
+   * after each set transition. Off by default so the operator opts in
+   * explicitly — auto-pilot behaviour is surprising for someone used
+   * to driving the recap by hand.
+   */
+  autoShowSetSummary: boolean;
+  /**
+   * Seconds to wait between a set ending and the recap appearing —
+   * gives the broadcast camera time to linger on the players' reaction
+   * before the overlay covers them. ``0`` skips the wait.
+   */
+  autoShowSetSummaryDelay: number;
+  /**
+   * Seconds the recap stays visible before auto-dismissing. The
+   * dismiss is also cut short the moment play resumes (a new point in
+   * the next set yields back to the live scoreboard immediately).
+   */
+  autoShowSetSummaryDuration: number;
+  /**
+   * Minutes a single set may be live before the abandoned-match
+   * prompt fires on the next page load. ``0`` disables the prompt
+   * entirely.
+   */
+  staleSetThresholdMinutes: number;
 }
 
 const DEFAULTS: Settings = {
@@ -89,6 +114,10 @@ const DEFAULTS: Settings = {
   gestureTourSeen: false,
   keyboardShortcuts: defaultKeyboardShortcutsEnabled(),
   setSummaryEnabled: false,
+  autoShowSetSummary: false,
+  autoShowSetSummaryDelay: 5,
+  autoShowSetSummaryDuration: 15,
+  staleSetThresholdMinutes: 60,
 };
 
 /**

--- a/frontend/src/hooks/useSettings.tsx
+++ b/frontend/src/hooks/useSettings.tsx
@@ -87,12 +87,6 @@ export interface Settings {
    * the next set yields back to the live scoreboard immediately).
    */
   autoShowSetSummaryDuration: number;
-  /**
-   * Minutes a single set may be live before the abandoned-match
-   * prompt fires on the next page load. ``0`` disables the prompt
-   * entirely.
-   */
-  staleSetThresholdMinutes: number;
 }
 
 const DEFAULTS: Settings = {
@@ -117,7 +111,6 @@ const DEFAULTS: Settings = {
   autoShowSetSummary: false,
   autoShowSetSummaryDelay: 5,
   autoShowSetSummaryDuration: 15,
-  staleSetThresholdMinutes: 60,
 };
 
 /**

--- a/frontend/src/i18n/translations.ts
+++ b/frontend/src/i18n/translations.ts
@@ -235,8 +235,6 @@ export const translations: Record<string, TranslationDict> = {
     'behavior.autoShowSetSummary': 'Auto-show recap on set end',
     'behavior.autoShowSetSummary.delay': 'Wait {value}s after the final point',
     'behavior.autoShowSetSummary.duration': 'Hide recap after {value}s',
-    'behavior.staleSetThreshold': 'Abandoned-match prompt after {value} min',
-    'behavior.staleSetThreshold.off': 'Abandoned-match prompt: off',
 
     // Keyboard shortcuts help modal
     'shortcuts.title': 'Keyboard shortcuts',
@@ -520,8 +518,6 @@ export const translations: Record<string, TranslationDict> = {
     'behavior.autoShowSetSummary': 'Mostrar resumen automáticamente al terminar el set',
     'behavior.autoShowSetSummary.delay': 'Esperar {value}s tras el punto final',
     'behavior.autoShowSetSummary.duration': 'Ocultar resumen después de {value}s',
-    'behavior.staleSetThreshold': 'Aviso de partido olvidado tras {value} min',
-    'behavior.staleSetThreshold.off': 'Aviso de partido olvidado: desactivado',
 
     // Keyboard shortcuts help modal
     'shortcuts.title': 'Atajos de teclado',
@@ -804,8 +800,6 @@ export const translations: Record<string, TranslationDict> = {
     'behavior.autoShowSetSummary': 'Mostrar recapitulação automaticamente ao terminar o set',
     'behavior.autoShowSetSummary.delay': 'Aguardar {value}s após o ponto final',
     'behavior.autoShowSetSummary.duration': 'Ocultar recapitulação após {value}s',
-    'behavior.staleSetThreshold': 'Aviso de partida abandonada após {value} min',
-    'behavior.staleSetThreshold.off': 'Aviso de partida abandonada: desativado',
 
     // Keyboard shortcuts help modal
     'shortcuts.title': 'Atalhos de teclado',
@@ -1088,8 +1082,6 @@ export const translations: Record<string, TranslationDict> = {
     'behavior.autoShowSetSummary': 'Mostra il riepilogo automaticamente alla fine del set',
     'behavior.autoShowSetSummary.delay': 'Attendi {value}s dopo il punto finale',
     'behavior.autoShowSetSummary.duration': 'Nascondi il riepilogo dopo {value}s',
-    'behavior.staleSetThreshold': 'Avviso di partita abbandonata dopo {value} min',
-    'behavior.staleSetThreshold.off': 'Avviso di partita abbandonata: disattivato',
 
     // Keyboard shortcuts help modal
     'shortcuts.title': 'Scorciatoie da tastiera',
@@ -1373,8 +1365,6 @@ export const translations: Record<string, TranslationDict> = {
     'behavior.autoShowSetSummary': 'Afficher le récapitulatif automatiquement en fin de set',
     'behavior.autoShowSetSummary.delay': 'Attendre {value}s après le point final',
     'behavior.autoShowSetSummary.duration': 'Masquer le récapitulatif après {value}s',
-    'behavior.staleSetThreshold': 'Alerte match abandonné après {value} min',
-    'behavior.staleSetThreshold.off': 'Alerte match abandonné : désactivée',
 
     // Keyboard shortcuts help modal
     'shortcuts.title': 'Raccourcis clavier',
@@ -1658,8 +1648,6 @@ export const translations: Record<string, TranslationDict> = {
     'behavior.autoShowSetSummary': 'Recap am Satzende automatisch einblenden',
     'behavior.autoShowSetSummary.delay': '{value}s nach dem letzten Punkt warten',
     'behavior.autoShowSetSummary.duration': 'Recap nach {value}s ausblenden',
-    'behavior.staleSetThreshold': 'Hinweis "Spiel vergessen" nach {value} min',
-    'behavior.staleSetThreshold.off': 'Hinweis "Spiel vergessen": aus',
 
     // Keyboard shortcuts help modal
     'shortcuts.title': 'Tastenkürzel',

--- a/frontend/src/i18n/translations.ts
+++ b/frontend/src/i18n/translations.ts
@@ -232,6 +232,11 @@ export const translations: Record<string, TranslationDict> = {
     'behavior.showPreview': 'Show overlay preview',
     'behavior.keyboardShortcuts': 'Keyboard shortcuts',
     'behavior.showShortcuts': 'Show shortcuts (?)',
+    'behavior.autoShowSetSummary': 'Auto-show recap on set end',
+    'behavior.autoShowSetSummary.delay': 'Wait {value}s after the final point',
+    'behavior.autoShowSetSummary.duration': 'Hide recap after {value}s',
+    'behavior.staleSetThreshold': 'Abandoned-match prompt after {value} min',
+    'behavior.staleSetThreshold.off': 'Abandoned-match prompt: off',
 
     // Keyboard shortcuts help modal
     'shortcuts.title': 'Keyboard shortcuts',
@@ -512,6 +517,11 @@ export const translations: Record<string, TranslationDict> = {
     'behavior.showPreview': 'Mostrar vista previa del overlay',
     'behavior.keyboardShortcuts': 'Atajos de teclado',
     'behavior.showShortcuts': 'Ver atajos (?)',
+    'behavior.autoShowSetSummary': 'Mostrar resumen automáticamente al terminar el set',
+    'behavior.autoShowSetSummary.delay': 'Esperar {value}s tras el punto final',
+    'behavior.autoShowSetSummary.duration': 'Ocultar resumen después de {value}s',
+    'behavior.staleSetThreshold': 'Aviso de partido olvidado tras {value} min',
+    'behavior.staleSetThreshold.off': 'Aviso de partido olvidado: desactivado',
 
     // Keyboard shortcuts help modal
     'shortcuts.title': 'Atajos de teclado',
@@ -791,6 +801,11 @@ export const translations: Record<string, TranslationDict> = {
     'behavior.showPreview': 'Mostrar pré-visualização do overlay',
     'behavior.keyboardShortcuts': 'Atalhos de teclado',
     'behavior.showShortcuts': 'Ver atalhos (?)',
+    'behavior.autoShowSetSummary': 'Mostrar recapitulação automaticamente ao terminar o set',
+    'behavior.autoShowSetSummary.delay': 'Aguardar {value}s após o ponto final',
+    'behavior.autoShowSetSummary.duration': 'Ocultar recapitulação após {value}s',
+    'behavior.staleSetThreshold': 'Aviso de partida abandonada após {value} min',
+    'behavior.staleSetThreshold.off': 'Aviso de partida abandonada: desativado',
 
     // Keyboard shortcuts help modal
     'shortcuts.title': 'Atalhos de teclado',
@@ -1070,6 +1085,11 @@ export const translations: Record<string, TranslationDict> = {
     'behavior.showPreview': 'Mostra anteprima overlay',
     'behavior.keyboardShortcuts': 'Scorciatoie da tastiera',
     'behavior.showShortcuts': 'Mostra scorciatoie (?)',
+    'behavior.autoShowSetSummary': 'Mostra il riepilogo automaticamente alla fine del set',
+    'behavior.autoShowSetSummary.delay': 'Attendi {value}s dopo il punto finale',
+    'behavior.autoShowSetSummary.duration': 'Nascondi il riepilogo dopo {value}s',
+    'behavior.staleSetThreshold': 'Avviso di partita abbandonata dopo {value} min',
+    'behavior.staleSetThreshold.off': 'Avviso di partita abbandonata: disattivato',
 
     // Keyboard shortcuts help modal
     'shortcuts.title': 'Scorciatoie da tastiera',
@@ -1350,6 +1370,11 @@ export const translations: Record<string, TranslationDict> = {
     'behavior.showPreview': 'Afficher l’aperçu de l’overlay',
     'behavior.keyboardShortcuts': 'Raccourcis clavier',
     'behavior.showShortcuts': 'Voir les raccourcis (?)',
+    'behavior.autoShowSetSummary': 'Afficher le récapitulatif automatiquement en fin de set',
+    'behavior.autoShowSetSummary.delay': 'Attendre {value}s après le point final',
+    'behavior.autoShowSetSummary.duration': 'Masquer le récapitulatif après {value}s',
+    'behavior.staleSetThreshold': 'Alerte match abandonné après {value} min',
+    'behavior.staleSetThreshold.off': 'Alerte match abandonné : désactivée',
 
     // Keyboard shortcuts help modal
     'shortcuts.title': 'Raccourcis clavier',
@@ -1630,6 +1655,11 @@ export const translations: Record<string, TranslationDict> = {
     'behavior.showPreview': 'Overlay-Vorschau anzeigen',
     'behavior.keyboardShortcuts': 'Tastenkürzel',
     'behavior.showShortcuts': 'Tastenkürzel anzeigen (?)',
+    'behavior.autoShowSetSummary': 'Recap am Satzende automatisch einblenden',
+    'behavior.autoShowSetSummary.delay': '{value}s nach dem letzten Punkt warten',
+    'behavior.autoShowSetSummary.duration': 'Recap nach {value}s ausblenden',
+    'behavior.staleSetThreshold': 'Hinweis "Spiel vergessen" nach {value} min',
+    'behavior.staleSetThreshold.off': 'Hinweis "Spiel vergessen": aus',
 
     // Keyboard shortcuts help modal
     'shortcuts.title': 'Tastenkürzel',

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -41,7 +41,10 @@ describe('App', () => {
       writable: true,
     });
     vi.mocked(api.getOverlays).mockResolvedValue([]);
-    vi.mocked(api.getAppConfig).mockResolvedValue({ title: 'Volley Scoreboard' });
+    vi.mocked(api.getAppConfig).mockResolvedValue({
+      title: 'Volley Scoreboard',
+      stale_set_threshold_minutes: 60,
+    });
     vi.mocked(api.initSession).mockResolvedValue({ success: true, state: mockGameState });
     vi.mocked(api.getCustomization).mockResolvedValue(mockCustomization);
     vi.mocked(api.getLinks).mockResolvedValue({ control: '', overlay: '', preview: '' });

--- a/frontend/src/test/TeamPanel.test.tsx
+++ b/frontend/src/test/TeamPanel.test.tsx
@@ -7,6 +7,7 @@ import { mockGameState } from './helpers';
 const baseTeamState: TeamState = {
   sets: 1,
   timeouts: 2,
+  timeouts_by_set: { set_1: 1, set_2: 2 },
   serving: true,
   scores: { set_1: 25, set_2: 15 },
 };

--- a/frontend/src/test/helpers.tsx
+++ b/frontend/src/test/helpers.tsx
@@ -17,12 +17,14 @@ export const mockGameState: GameState = {
   team_1: {
     sets: 1,
     timeouts: 1,
+    timeouts_by_set: { set_1: 0, set_2: 1 },
     serving: true,
     scores: { set_1: 25, set_2: 12 },
   },
   team_2: {
     sets: 0,
     timeouts: 0,
+    timeouts_by_set: { set_1: 0, set_2: 0 },
     serving: false,
     scores: { set_1: 20, set_2: 10 },
   },

--- a/frontend/src/test/useAutoSetSummary.test.tsx
+++ b/frontend/src/test/useAutoSetSummary.test.tsx
@@ -3,14 +3,16 @@ import { renderHook } from '@testing-library/react';
 import { useAutoSetSummary } from '../hooks/useAutoSetSummary';
 import type { GameState } from '../api/client';
 
-function makeState(opts: {
-  t1Sets?: number;
-  t2Sets?: number;
-  t1Score?: number;
-  t2Score?: number;
-  currentSet?: number;
-  matchFinished?: boolean;
-} = {}): GameState {
+function makeState(
+  opts: {
+    t1Sets?: number;
+    t2Sets?: number;
+    t1Score?: number;
+    t2Score?: number;
+    currentSet?: number;
+    matchFinished?: boolean;
+  } = {},
+): GameState {
   const {
     t1Sets = 0,
     t2Sets = 0,

--- a/frontend/src/test/useAutoSetSummary.test.tsx
+++ b/frontend/src/test/useAutoSetSummary.test.tsx
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useAutoSetSummary } from '../hooks/useAutoSetSummary';
+import type { GameState } from '../api/client';
+
+function makeState(opts: {
+  t1Sets?: number;
+  t2Sets?: number;
+  t1Score?: number;
+  t2Score?: number;
+  currentSet?: number;
+  matchFinished?: boolean;
+} = {}): GameState {
+  const {
+    t1Sets = 0,
+    t2Sets = 0,
+    t1Score = 0,
+    t2Score = 0,
+    currentSet = 1,
+    matchFinished = false,
+  } = opts;
+  return {
+    team_1: {
+      sets: t1Sets,
+      timeouts: 0,
+      serving: true,
+      scores: { [`set_${currentSet}`]: t1Score },
+    },
+    team_2: {
+      sets: t2Sets,
+      timeouts: 0,
+      serving: false,
+      scores: { [`set_${currentSet}`]: t2Score },
+    },
+    visible: true,
+    simple_mode: false,
+    match_finished: matchFinished,
+    current_set: currentSet,
+    serve: 'A',
+    config: { mode: 'indoor', sets_limit: 5, points_limit: 25, points_limit_last_set: 15 },
+    can_undo: false,
+  } as unknown as GameState;
+}
+
+describe('useAutoSetSummary', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows the recap after the configured delay on a set transition', () => {
+    const setSetSummary = vi.fn();
+    const initial = makeState({ t1Sets: 0, t2Sets: 0 });
+    const { rerender } = renderHook(
+      ({ s }: { s: GameState }) =>
+        useAutoSetSummary({
+          state: s,
+          enabled: true,
+          delaySec: 5,
+          durationSec: 15,
+          setSetSummary,
+        }),
+      { initialProps: { s: initial } },
+    );
+    // Set-winning point lands: total sets jumps 0 → 1.
+    rerender({ s: makeState({ t1Sets: 1, t2Sets: 0, currentSet: 2 }) });
+    // The delay timer hasn't fired yet.
+    expect(setSetSummary).not.toHaveBeenCalled();
+    // Advance just shy of the delay — still nothing.
+    vi.advanceTimersByTime(4999);
+    expect(setSetSummary).not.toHaveBeenCalled();
+    // Crossing the threshold posts ``enabled=true``.
+    vi.advanceTimersByTime(1);
+    expect(setSetSummary).toHaveBeenCalledWith(true);
+  });
+
+  it('dismisses the recap after the configured duration', () => {
+    const setSetSummary = vi.fn();
+    const initial = makeState({ t1Sets: 0, t2Sets: 0 });
+    const { rerender } = renderHook(
+      ({ s }: { s: GameState }) =>
+        useAutoSetSummary({
+          state: s,
+          enabled: true,
+          delaySec: 5,
+          durationSec: 15,
+          setSetSummary,
+        }),
+      { initialProps: { s: initial } },
+    );
+    rerender({ s: makeState({ t1Sets: 1, t2Sets: 0, currentSet: 2 }) });
+    vi.advanceTimersByTime(5000); // delay → show
+    expect(setSetSummary).toHaveBeenLastCalledWith(true);
+    vi.advanceTimersByTime(15000); // duration → hide
+    expect(setSetSummary).toHaveBeenLastCalledWith(false);
+    expect(setSetSummary).toHaveBeenCalledTimes(2);
+  });
+
+  it('suppresses the show entirely when a point lands during the delay', () => {
+    const setSetSummary = vi.fn();
+    const initial = makeState({ t1Sets: 0, t2Sets: 0 });
+    const { rerender } = renderHook(
+      ({ s }: { s: GameState }) =>
+        useAutoSetSummary({
+          state: s,
+          enabled: true,
+          delaySec: 5,
+          durationSec: 15,
+          setSetSummary,
+        }),
+      { initialProps: { s: initial } },
+    );
+    // Set 1 ends.
+    rerender({ s: makeState({ t1Sets: 1, t2Sets: 0, currentSet: 2 }) });
+    // Operator scores a quick point in set 2 before the camera window closes.
+    vi.advanceTimersByTime(2000);
+    rerender({
+      s: makeState({ t1Sets: 1, t2Sets: 0, currentSet: 2, t1Score: 1 }),
+    });
+    // Run the rest of what would have been the delay — show must not fire.
+    vi.advanceTimersByTime(10000);
+    expect(setSetSummary).not.toHaveBeenCalled();
+  });
+
+  it('dismisses immediately when a point lands during the recap display', () => {
+    const setSetSummary = vi.fn();
+    const initial = makeState({ t1Sets: 0, t2Sets: 0 });
+    const { rerender } = renderHook(
+      ({ s }: { s: GameState }) =>
+        useAutoSetSummary({
+          state: s,
+          enabled: true,
+          delaySec: 5,
+          durationSec: 15,
+          setSetSummary,
+        }),
+      { initialProps: { s: initial } },
+    );
+    rerender({ s: makeState({ t1Sets: 1, t2Sets: 0, currentSet: 2 }) });
+    vi.advanceTimersByTime(5000); // show fires
+    expect(setSetSummary).toHaveBeenLastCalledWith(true);
+    // Player resumes — score lands in set 2.
+    rerender({
+      s: makeState({ t1Sets: 1, t2Sets: 0, currentSet: 2, t1Score: 1 }),
+    });
+    // Hide should be posted instantly, well before the 15s duration.
+    expect(setSetSummary).toHaveBeenLastCalledWith(false);
+    expect(setSetSummary).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancels timers and posts hide when the set-winning point is undone', () => {
+    const setSetSummary = vi.fn();
+    const initial = makeState({ t1Sets: 0, t2Sets: 0 });
+    const { rerender } = renderHook(
+      ({ s }: { s: GameState }) =>
+        useAutoSetSummary({
+          state: s,
+          enabled: true,
+          delaySec: 5,
+          durationSec: 15,
+          setSetSummary,
+        }),
+      { initialProps: { s: initial } },
+    );
+    rerender({ s: makeState({ t1Sets: 1, t2Sets: 0, currentSet: 2 }) });
+    vi.advanceTimersByTime(2000);
+    // Operator undoes — total sets goes back to 0.
+    rerender({ s: makeState({ t1Sets: 0, t2Sets: 0, currentSet: 1, t1Score: 24 }) });
+    expect(setSetSummary).toHaveBeenLastCalledWith(false);
+    // Pending delay timer must not still fire after the undo.
+    vi.advanceTimersByTime(10000);
+    // Still only the single ``false`` call from the undo path.
+    expect(setSetSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips auto-dismiss when the set transition closes the match', () => {
+    const setSetSummary = vi.fn();
+    const initial = makeState({ t1Sets: 2, t2Sets: 0 });
+    const { rerender } = renderHook(
+      ({ s }: { s: GameState }) =>
+        useAutoSetSummary({
+          state: s,
+          enabled: true,
+          delaySec: 5,
+          durationSec: 15,
+          setSetSummary,
+        }),
+      { initialProps: { s: initial } },
+    );
+    // Match-winning set. ``match_finished`` is true at the moment we observe it.
+    rerender({
+      s: makeState({ t1Sets: 3, t2Sets: 0, matchFinished: true, currentSet: 3 }),
+    });
+    vi.advanceTimersByTime(5000);
+    expect(setSetSummary).toHaveBeenLastCalledWith(true);
+    // Long after the would-be dismiss window, the recap must stay up.
+    vi.advanceTimersByTime(60000);
+    expect(setSetSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the recap on the same tick when delaySec is 0', () => {
+    const setSetSummary = vi.fn();
+    const initial = makeState({ t1Sets: 0, t2Sets: 0 });
+    const { rerender } = renderHook(
+      ({ s }: { s: GameState }) =>
+        useAutoSetSummary({
+          state: s,
+          enabled: true,
+          delaySec: 0,
+          durationSec: 15,
+          setSetSummary,
+        }),
+      { initialProps: { s: initial } },
+    );
+    rerender({ s: makeState({ t1Sets: 1, t2Sets: 0, currentSet: 2 }) });
+    // Show fires synchronously — no setTimeout needed.
+    expect(setSetSummary).toHaveBeenCalledWith(true);
+  });
+
+  it('drops a pending timer when the operator flips the toggle off mid-pending', () => {
+    const setSetSummary = vi.fn();
+    const initial = makeState({ t1Sets: 0, t2Sets: 0 });
+    const { rerender } = renderHook(
+      ({ s, enabled }: { s: GameState; enabled: boolean }) =>
+        useAutoSetSummary({
+          state: s,
+          enabled,
+          delaySec: 5,
+          durationSec: 15,
+          setSetSummary,
+        }),
+      { initialProps: { s: initial, enabled: true } },
+    );
+    // Set ends — delay timer is now armed.
+    rerender({ s: makeState({ t1Sets: 1, t2Sets: 0, currentSet: 2 }), enabled: true });
+    vi.advanceTimersByTime(2000);
+    // Operator turns the feature off mid-delay.
+    rerender({ s: makeState({ t1Sets: 1, t2Sets: 0, currentSet: 2 }), enabled: false });
+    // The remainder of the delay must not fire.
+    vi.advanceTimersByTime(60000);
+    expect(setSetSummary).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the master toggle is off', () => {
+    const setSetSummary = vi.fn();
+    const initial = makeState({ t1Sets: 0, t2Sets: 0 });
+    const { rerender } = renderHook(
+      ({ s }: { s: GameState }) =>
+        useAutoSetSummary({
+          state: s,
+          enabled: false,
+          delaySec: 5,
+          durationSec: 15,
+          setSetSummary,
+        }),
+      { initialProps: { s: initial } },
+    );
+    rerender({ s: makeState({ t1Sets: 1, t2Sets: 0, currentSet: 2 }) });
+    vi.advanceTimersByTime(60000);
+    expect(setSetSummary).not.toHaveBeenCalled();
+  });
+});

--- a/requirements.lock
+++ b/requirements.lock
@@ -40,17 +40,15 @@ python-dotenv==1.2.2
     #   uvicorn
 pyyaml==6.0.3
     # via uvicorn
-requests==2.33.1
+requests==2.34.2
     # via -r requirements.txt
-starlette==1.0.0
+starlette==1.0.1
     # via fastapi
 typing-extensions==4.15.0
     # via
-    #   anyio
     #   fastapi
     #   pydantic
     #   pydantic-core
-    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via
@@ -60,7 +58,7 @@ urllib3==2.7.0
     # via
     #   -r requirements.txt
     #   requests
-uvicorn==0.46.0
+uvicorn==0.47.0
     # via -r requirements.txt
 uvloop==0.22.1
     # via uvicorn

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -9,7 +9,12 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.api import api_router
-from app.app_config import DEFAULT_APP_TITLE, get_app_title
+from app.app_config import (
+    DEFAULT_APP_TITLE,
+    DEFAULT_STALE_SET_THRESHOLD_MINUTES,
+    get_app_title,
+    get_stale_set_threshold_minutes,
+)
 from app.bootstrap import (
     _inject_title_into_html,
     _render_index_html,
@@ -26,21 +31,53 @@ def client():
 
 def test_app_config_returns_default_title(client, monkeypatch):
     monkeypatch.delenv("APP_TITLE", raising=False)
+    monkeypatch.delenv("STALE_SET_THRESHOLD_MINUTES", raising=False)
     res = client.get("/api/v1/app-config")
     assert res.status_code == 200
-    assert res.json() == {"title": DEFAULT_APP_TITLE}
+    assert res.json() == {
+        "title": DEFAULT_APP_TITLE,
+        "stale_set_threshold_minutes": DEFAULT_STALE_SET_THRESHOLD_MINUTES,
+    }
 
 
 def test_app_config_returns_env_title(client, monkeypatch):
     monkeypatch.setenv("APP_TITLE", "My Liga Volley")
+    monkeypatch.delenv("STALE_SET_THRESHOLD_MINUTES", raising=False)
     res = client.get("/api/v1/app-config")
     assert res.status_code == 200
-    assert res.json() == {"title": "My Liga Volley"}
+    assert res.json() == {
+        "title": "My Liga Volley",
+        "stale_set_threshold_minutes": DEFAULT_STALE_SET_THRESHOLD_MINUTES,
+    }
 
 
 def test_app_config_falls_back_when_env_is_blank(monkeypatch):
     monkeypatch.setenv("APP_TITLE", "   ")
     assert get_app_title() == DEFAULT_APP_TITLE
+
+
+def test_stale_set_threshold_reads_env(client, monkeypatch):
+    monkeypatch.setenv("STALE_SET_THRESHOLD_MINUTES", "15")
+    res = client.get("/api/v1/app-config")
+    assert res.status_code == 200
+    assert res.json()["stale_set_threshold_minutes"] == 15
+
+
+def test_stale_set_threshold_disabled_by_zero(client, monkeypatch):
+    monkeypatch.setenv("STALE_SET_THRESHOLD_MINUTES", "0")
+    res = client.get("/api/v1/app-config")
+    assert res.status_code == 200
+    assert res.json()["stale_set_threshold_minutes"] == 0
+
+
+def test_stale_set_threshold_clamps_negative_to_zero(monkeypatch):
+    monkeypatch.setenv("STALE_SET_THRESHOLD_MINUTES", "-30")
+    assert get_stale_set_threshold_minutes() == 0
+
+
+def test_stale_set_threshold_falls_back_on_garbage(monkeypatch):
+    monkeypatch.setenv("STALE_SET_THRESHOLD_MINUTES", "not-a-number")
+    assert get_stale_set_threshold_minutes() == DEFAULT_STALE_SET_THRESHOLD_MINUTES
 
 
 def test_inject_title_replaces_tag():

--- a/tests/test_game_manager.py
+++ b/tests/test_game_manager.py
@@ -334,16 +334,57 @@ def test_change_serve_force(game_manager):
     state = game_manager.get_current_state()
     assert state.get_current_serve() == State.SERVE_1
 
-def test_add_set_resets_timeouts_and_serve(game_manager):
-    """Tests that after a set is won, timeouts and serve are reset."""
+def test_add_set_preserves_per_set_timeouts_and_resets_serve(game_manager):
+    """After a set is won, per-set timeout history is preserved and serve
+    is reset. Operator-facing "current set timeouts" reads 0 once
+    ``current_set`` advances (managed by the session layer)."""
     game_manager.add_timeout(1, False)
     game_manager.add_timeout(2, False)
     game_manager.change_serve(1)
     game_manager.add_set(1, False)
     state = game_manager.get_current_state()
-    assert state.get_timeout(1) == 0
-    assert state.get_timeout(2) == 0
+    # The set-1 timeouts are still recorded in the per-set arrays.
+    assert state.get_timeout(1, set_num=1) == 1
+    assert state.get_timeout(2, set_num=1) == 1
+    # Set 2 starts clean.
+    assert state.get_timeout(1, set_num=2) == 0
+    assert state.get_timeout(2, set_num=2) == 0
+    # Serve still resets on a forward set transition.
     assert state.get_current_serve() == State.SERVE_NONE
+
+
+def test_undo_set_winning_point_restores_prior_set_timeouts(game_manager):
+    """The whole point of per-set timeout history: when an operator
+    undoes a set-winning point and the session has already advanced to
+    the next set, the prior set's timeouts must still be readable."""
+    # Set 1: team 1 burns both timeouts mid-set.
+    game_manager.add_timeout(1, False)
+    game_manager.add_timeout(1, False)
+    # Build a 24-15 score so the next add_game wins set 1.
+    for _ in range(15):
+        game_manager.add_game(2, 1, 25, 15, 5, False)
+    for _ in range(24):
+        game_manager.add_game(1, 1, 25, 15, 5, False)
+    # Set-winning point.
+    game_manager.add_game(1, 1, 25, 15, 5, False)
+    state = game_manager.get_current_state()
+    assert state.get_sets(1) == 1
+    # Pretend the session advanced current_set to 2 (game_service does
+    # this via _compute_current_set after a set is won).
+    state.set_current_set(2)
+    # In set 2, no timeouts have been taken yet — the default current-set
+    # accessor reads 0.
+    assert state.get_timeout(1) == 0
+    # Undo the set-winning point (passes new current_set=2 like real flow).
+    game_manager.add_game(1, 2, 25, 15, 5, True)
+    # Set 1 is no longer won; we should be back to the operator's prior
+    # state (24-15) with both set-1 timeouts intact.
+    assert state.get_sets(1) == 0
+    assert state.get_game(1, 1) == 24
+    # Roll current_set back to 1 (what the session would do).
+    state.set_current_set(1)
+    # The crux of the fix: timeouts taken in set 1 are still recorded.
+    assert state.get_timeout(1) == 2
 
 def test_check_set_won(game_manager):
     """Tests the check_set_won method."""

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -73,9 +73,61 @@ def test_get_and_set_timeout(state):
     """Tests the getter and setter for timeouts, including type conversion."""
     state.set_timeout(1, 2)
     assert state.get_timeout(1) == 2
-    assert state.get_current_model()[State.T1TIMEOUTS_INT] == '2' # Internal representation is string
+    # The flat legacy key carries the current-set value.
+    assert state.get_current_model()[State.T1TIMEOUTS_INT] == '2'
+    # The per-set key also carries it.
+    assert state.get_current_model()[State._t_timeouts_key(1, 1)] == '2'
     state.set_timeout(2, 0)
     assert state.get_timeout(2) == 0
+
+
+def test_timeouts_per_set(state):
+    """Per-set timeout getters/setters target the requested set, and
+    the default (no ``set_num`` arg) follows the current set."""
+    state.set_timeout(1, 2, set_num=1)
+    state.set_timeout(1, 1, set_num=2)
+    state.set_current_set(2)
+    # No arg → current set (2) value.
+    assert state.get_timeout(1) == 1
+    # Explicit set 1 is unchanged.
+    assert state.get_timeout(1, set_num=1) == 2
+    # Full history surfaces both sets.
+    history = state.get_timeouts_by_set(1)
+    assert history[1] == 2
+    assert history[2] == 1
+    assert history[3] == 0
+
+
+def test_state_loads_legacy_flat_timeout(state):
+    """A pre-refactor state file with only the flat ``Team N Timeouts``
+    key should land the legacy value in the current set's slot."""
+    legacy = {
+        State.CURRENT_SET_INT: 3,
+        State.T1TIMEOUTS_INT: '2',
+        State.T2TIMEOUTS_INT: '1',
+    }
+    loaded = State(new_state=legacy)
+    assert loaded.get_timeout(1, set_num=3) == 2
+    assert loaded.get_timeout(2, set_num=3) == 1
+    # Other sets are clean.
+    assert loaded.get_timeout(1, set_num=1) == 0
+    assert loaded.get_timeout(2, set_num=2) == 0
+
+
+def test_state_round_trip_preserves_per_set_history(state):
+    """Serialize-then-deserialize must preserve the full per-set
+    timeout history (not just the current set)."""
+    state.set_timeout(1, 2, set_num=1)
+    state.set_timeout(2, 1, set_num=1)
+    state.set_timeout(1, 1, set_num=2)
+    state.set_current_set(2)
+    round_tripped = State(new_state=state.get_current_model())
+    assert round_tripped.get_timeouts_by_set(1) == {
+        1: 2, 2: 1, 3: 0, 4: 0, 5: 0,
+    }
+    assert round_tripped.get_timeouts_by_set(2) == {
+        1: 1, 2: 0, 3: 0, 4: 0, 5: 0,
+    }
 
 def test_get_and_set_sets(state):
     """Tests the getter and setter for sets, including type conversion."""

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -114,6 +114,49 @@ def test_state_loads_legacy_flat_timeout(state):
     assert loaded.get_timeout(2, set_num=2) == 0
 
 
+def test_get_timeout_returns_zero_for_out_of_bounds_set(state):
+    """``get_timeout`` must not raise on an out-of-bounds ``set_num``:
+    that would crash the state-broadcast hot path if (e.g.) a manual
+    ``set_current_set`` ever lands ``current_set`` above 5. Returns 0
+    — meaningfully "no timeouts in a set that doesn't exist".
+    Bounds-checking remains the service layer's job."""
+    # Direct out-of-bounds via explicit ``set_num``.
+    assert state.get_timeout(1, set_num=6) == 0
+    assert state.get_timeout(2, set_num=0) == 0
+    # Same behaviour when current_set itself is out of bounds and we
+    # rely on the default.
+    state.set_current_set(99)
+    assert state.get_timeout(1) == 0
+    assert state.get_timeout(2) == 0
+    # Bad ``team`` still raises (consistent with other accessors).
+    with pytest.raises(KeyError):
+        state.get_timeout(3, set_num=1)
+
+
+def test_set_timeout_is_noop_for_out_of_bounds_set(state):
+    """``set_timeout`` mirrors ``get_timeout``: out-of-bounds
+    ``set_num`` is a silent no-op rather than a crash."""
+    state.set_timeout(1, 1, set_num=1)
+    state.set_timeout(1, 9, set_num=6)  # No-op, must not mutate slot 1.
+    state.set_timeout(1, 9, set_num=0)  # No-op.
+    assert state.get_timeout(1, set_num=1) == 1
+    with pytest.raises(KeyError):
+        state.set_timeout(3, 1, set_num=1)  # Bad team still raises.
+
+
+def test_to_dict_legacy_timeouts_zero_when_current_set_out_of_bounds(state):
+    """If ``current_set`` ever ends up out of bounds, the legacy
+    ``Team N Timeouts`` keys must surface 0 (via the
+    out-of-bounds-safe ``get_timeout``), not silently fall back to
+    set 1's count under the legacy banner."""
+    state.set_timeout(1, 2, set_num=1)
+    state.set_current_set(99)
+    model = state.get_current_model()
+    assert model[State.T1TIMEOUTS_INT] == '0'
+    # Per-set history is untouched.
+    assert model[State._t_timeouts_key(1, 1)] == '2'
+
+
 def test_state_round_trip_preserves_per_set_history(state):
     """Serialize-then-deserialize must preserve the full per-set
     timeout history (not just the current set)."""

--- a/tests/test_undo_stack.py
+++ b/tests/test_undo_stack.py
@@ -60,6 +60,35 @@ class TestUndoLast:
         records = action_log.read_all("undo-5")
         assert any(r["action"] == "change_serve" for r in records)
 
+    def test_state_response_timeouts_match_session_current_set(
+        self, mock_conf, api_backend,
+    ):
+        """After a set-winning point, the broadcast response must report
+        the new set's timeout count (0), not the closed set's count.
+
+        ``state._state.current_set`` lags ``session.current_set`` by one
+        tick — it only updates in ``GameManager.save`` which runs after
+        ``get_state``. The legacy ``timeouts`` field therefore has to
+        pin to ``session.current_set`` explicitly; if it falls back to
+        ``state.current_set`` (the default), the response would expose
+        the closed set's count under the new set's banner.
+        """
+        session = SessionManager.get_or_create("timeouts-current-set", mock_conf, api_backend)
+        # Burn one timeout for each team in set 1.
+        GameService.add_timeout(session, team=1)
+        GameService.add_timeout(session, team=2)
+        # Drive team 1 to 25-0 — the last point wins the set.
+        for _ in range(25):
+            response = GameService.add_point(session, team=1)
+        # Session advanced to set 2; the broadcast response must show 0
+        # timeouts for both teams (the new set's count), not 1 each.
+        assert response.state.current_set == 2
+        assert response.state.team_1.timeouts == 0
+        assert response.state.team_2.timeouts == 0
+        # The per-set history still records set 1's burns.
+        assert response.state.team_1.timeouts_by_set["set_1"] == 1
+        assert response.state.team_2.timeouts_by_set["set_1"] == 1
+
     def test_undo_does_not_pop_undo_entries(self, mock_conf, api_backend):
         session = SessionManager.get_or_create("undo-6", mock_conf, api_backend)
         GameService.add_point(session, team=1)


### PR DESCRIPTION
## Summary

Three operator-facing improvements bundled into one PR:

- **Per-set timeout history (Fixed).** Closes the documented undo-across-set-boundaries limitation. `GameState` stores `team*_timeouts_by_set: list[int]` (1-indexed, mirroring scores) instead of a flat counter; `add_set` no longer zeroes timeouts. `TeamState` gains an additive `timeouts_by_set` field — the legacy `timeouts: int` still carries the current-set value so existing UI / overlay consumers don't notice. Legacy state files load transparently via a current-set fallback in `_from_dict`; no migration script.
- **Auto-trigger set-summary recap (Added).** Operator opt-in in the Behavior section. Configurable pre-show delay (default 5s, 0–30) keeps the camera on the players' reaction before the overlay covers them; configurable duration (default 15s, 5–60) auto-dismisses. The delay is cancelled if play resumes mid-window (no recap fires), dismiss is cut short if a point lands mid-recap, undo of the set-winning point clears any pending timer and force-hides, and match-end transitions show the recap but skip auto-dismiss so the operator clears the final recap themselves.
- **Configurable stale-set threshold (Added).** The 1-hour "match looks abandoned" prompt is now operator-tunable (0–240 min, 0 disables).

## Test plan

- [ ] `pytest tests/` — 1061 passing (7 pre-existing prometheus-stub failures excluded)
- [ ] New regression: per-set timeouts survive undo across a set boundary (`tests/test_game_manager.py::test_undo_set_winning_point_restores_prior_set_timeouts`)
- [ ] New regression: per-set serialization round-trips (`tests/test_state.py::test_state_round_trip_preserves_per_set_history`)
- [ ] New regression: legacy `Team N Timeouts` JSON loads into current set's slot (`tests/test_state.py::test_state_loads_legacy_flat_timeout`)
- [ ] `cd frontend && npm test` — 479 passing (new `useAutoSetSummary.test.tsx`, 9 cases covering delay, dismiss, suppress-on-resume, undo cleanup, match-end no-dismiss, zero-delay, master-toggle-off)
- [ ] `cd frontend && npx tsc --noEmit` clean
- [ ] `ruff check app/ tests/` clean
- [ ] Manual smoke: drive a match to a set close in the dev UI with auto-show toggled on; recap appears after the configured delay and dismisses after the duration; score a point mid-delay and verify the recap never appears; score a point mid-recap and verify it dismisses immediately
- [ ] Manual smoke: load an existing pre-change `data/overlay_state_*.json` — legacy `Team N Timeouts` should land in the current set's slot and render correctly in the UI

## Docs

- `CHANGELOG.md` updated under `## [Unreleased]` (Fixed + Added entries)
- `AGENTS.md` — state-model snippet + accessor docs reflect the per-set storage
- `DEVELOPER_GUIDE.md` — `add_set` description updated
- `FRONTEND_DEVELOPMENT.md` — `TeamState` table + JSON examples include `timeouts_by_set`
- `README.md` — set-summary blurb mentions the new auto-show mode
- `app/match_report.py` — stale docstring in `_timeouts_per_set` corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)