### PR TITLE
Improve code quality: clean up lint/type warnings and add keyboard a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,9 @@ once a first tagged release ships.
   (`TeamPanel`) were click-only `<div>`/`<span>` elements; they now expose
   `role="button"`, are focusable (`tabIndex`), carry an `aria-label` (and
   `aria-pressed` on the serve toggle), and respond to Enter/Space — so the
-  controls are operable without a pointer.
+  controls are operable without a pointer. Both also gain a
+  `:focus-visible` outline so keyboard focus is clearly indicated
+  (WCAG 2.4.7).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ once a first tagged release ships.
   gaps in ``app/match_report.py`` (the streak/rally accumulator dicts and
   ``effective_duration`` now carry explicit annotations). No runtime
   behaviour changes.
+- **Keyboard access for the scoreboard wake-handle and serve toggle.** The
+  show/hide-controls handle (`ScoreboardView`) and the per-team serve icon
+  (`TeamPanel`) were click-only `<div>`/`<span>` elements; they now expose
+  `role="button"`, are focusable (`tabIndex`), carry an `aria-label` (and
+  `aria-pressed` on the serve toggle), and respond to Enter/Space — so the
+  controls are operable without a pointer.
 
 ### Changed
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -926,6 +926,11 @@ body {
   cursor: pointer;
 }
 
+.wakeup-handle:focus-visible {
+  outline: 2px solid var(--blue, #2196f3);
+  outline-offset: 2px;
+}
+
 .control-buttons {
   position: relative;
   display: flex;
@@ -3314,6 +3319,12 @@ body {
 
 .serve-icon {
   transition: opacity 0.2s;
+}
+
+.serve-icon:focus-visible {
+  outline: 2px solid var(--blue, #2196f3);
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
 /* ── Set summary active notice & style picker ────────────────────────── */

--- a/frontend/src/components/ColorPicker.tsx
+++ b/frontend/src/components/ColorPicker.tsx
@@ -27,7 +27,7 @@ function getRecentColors(): string[] {
       const parsed = JSON.parse(raw);
       if (Array.isArray(parsed)) return parsed.filter((c): c is string => typeof c === 'string');
     }
-  } catch (e) {
+  } catch {
     /* ignore */
   }
   return [];
@@ -39,7 +39,7 @@ function saveRecentColor(color: string) {
     const recent = getRecentColors().filter((c) => c !== normalized);
     recent.unshift(normalized);
     localStorage.setItem(LS_KEY, JSON.stringify(recent.slice(0, MAX_RECENT)));
-  } catch (e) {
+  } catch {
     /* ignore */
   }
 }

--- a/frontend/src/components/InitScreen.tsx
+++ b/frontend/src/components/InitScreen.tsx
@@ -98,6 +98,7 @@ export default function InitScreen({
           value={oidInput}
           onChange={(e) => setOidInput(e.target.value)}
           placeholder={t('app.oidPlaceholder')}
+          // eslint-disable-next-line jsx-a11y/no-autofocus -- sole actionable control on an otherwise empty connect screen
           autoFocus={predefinedOverlays.length === 0}
         />
         <button className="init-button" type="submit" disabled={!oidInput.trim()}>

--- a/frontend/src/components/PresetPicker.tsx
+++ b/frontend/src/components/PresetPicker.tsx
@@ -219,6 +219,7 @@ export default function PresetPicker({ model, onApplyPatch }: PresetPickerProps)
               onChange={(e) => setCreateName(e.target.value)}
               maxLength={120}
               data-testid="preset-create-name"
+              // eslint-disable-next-line jsx-a11y/no-autofocus -- focus the name field when the create form opens
               autoFocus
             />
           </label>

--- a/frontend/src/components/ScoreboardView.tsx
+++ b/frontend/src/components/ScoreboardView.tsx
@@ -230,7 +230,16 @@ export default function ScoreboardView({
         <div className="control-buttons-wrapper">
           <div
             className="wakeup-handle"
+            role="button"
+            tabIndex={0}
+            aria-label={showControls ? t('ctrl.hideControls') : t('ctrl.showControls')}
             onClick={() => setShowControls(!showControls)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                setShowControls(!showControls);
+              }
+            }}
             title={showControls ? t('ctrl.hideControls') : t('ctrl.showControls')}
           >
             <span className="material-icons">{showControls ? 'expand_more' : 'expand_less'}</span>

--- a/frontend/src/components/TeamCard.tsx
+++ b/frontend/src/components/TeamCard.tsx
@@ -80,6 +80,7 @@ export default function TeamCard({ teamId, model, updateField, predefinedTeams }
                 onChange={(e) => updateField(nameKey, e.target.value)}
                 onBlur={() => setEditing(false)}
                 placeholder={t('teams.customPlaceholder')}
+                // eslint-disable-next-line jsx-a11y/no-autofocus -- focus the inline editor the moment edit mode opens
                 autoFocus
                 data-testid={`team-${teamId}-name-selector`}
               />

--- a/frontend/src/components/TeamPanel.tsx
+++ b/frontend/src/components/TeamPanel.tsx
@@ -204,6 +204,10 @@ function TeamPanel({
           {!isPortrait && <div className="spacer" />}
           <span
             className="material-icons serve-icon"
+            role="button"
+            tabIndex={0}
+            aria-label={`Team ${teamId} serve`}
+            aria-pressed={isServing}
             style={{
               color: readableServeColor,
               opacity: isServing ? 1 : 0.4,
@@ -211,6 +215,12 @@ function TeamPanel({
               fontSize: '2rem',
             }}
             onClick={() => onChangeServe(teamId)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onChangeServe(teamId);
+              }
+            }}
             data-testid={`team-${teamId}-serve`}
           >
             sports_volleyball

--- a/frontend/src/hooks/useAutoSetSummary.ts
+++ b/frontend/src/hooks/useAutoSetSummary.ts
@@ -185,6 +185,5 @@ export function useAutoSetSummary(opts: UseAutoSetSummaryOptions): void {
   // Cleanup on unmount.
   useEffect(() => {
     return () => clearAll();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 }

--- a/frontend/src/hooks/useScreenWakeLock.ts
+++ b/frontend/src/hooks/useScreenWakeLock.ts
@@ -159,7 +159,6 @@ export function useScreenWakeLock(enabled: boolean): void {
     };
     // Mount-once binding. ``enabled`` is read via ref above; the
     // toggle effect below drives acquire/release on each flip.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Drive acquire/release from the latest ``enabled`` value

--- a/tests/test_auth_coverage.py
+++ b/tests/test_auth_coverage.py
@@ -276,7 +276,7 @@ def test_list_overlay_disabled_when_admin_unset(overlay_client_no_admin):
 # and backward-compatible no-op when the env var is unset.
 
 
-OVERLAY_TOKEN_GATED_ROUTES = [
+OVERLAY_TOKEN_GATED_ROUTES: list[tuple[str, str, dict | None]] = [
     ("POST", "/api/state/any-id", {}),
     ("GET", "/create/overlay/any-id", None),
     ("POST", "/create/overlay/any-id", None),

--- a/tests/test_match_archive.py
+++ b/tests/test_match_archive.py
@@ -172,7 +172,7 @@ class TestMatchArchive:
         assert match_archive.delete_match("match_aaaaaaaaaaaaaaaaaaaa_../boom") is False
         assert match_archive.delete_match("") is False
         # Non-string types must not crash.
-        assert match_archive.delete_match(None) is False  # type: ignore[arg-type]
+        assert match_archive.delete_match(None) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_match_report.py
+++ b/tests/test_match_report.py
@@ -365,6 +365,7 @@ class TestMatchReport:
                         "team_2": {"score": 1}}},
         ]
         path = _al._path(oid)
+        assert path is not None
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             for r in records:
@@ -632,6 +633,7 @@ class TestMatchReportRichSections:
                         "team_2": {"score": 0}}},
         ]
         path = _al._path(oid)
+        assert path is not None
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             for r in records:
@@ -680,6 +682,7 @@ class TestMatchReportRichSections:
                         "team_2": {"score": 1}}},
         ]
         path = _al._path(oid)
+        assert path is not None
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             for r in records:
@@ -723,6 +726,7 @@ class TestMatchReportRichSections:
                         "team_2": {"score": 1}}},
         ]
         path = _al._path(oid)
+        assert path is not None
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             for r in records:
@@ -762,6 +766,7 @@ class TestMatchReportRichSections:
                         "team_2": {"score": 1}}},
         ]
         path = _al._path(oid)
+        assert path is not None
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             for r in records:
@@ -805,6 +810,7 @@ class TestMatchReportRichSections:
                         "team_2": {"score": 0}}},
         ]
         path = _al._path(oid)
+        assert path is not None
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             for r in records:
@@ -1001,6 +1007,7 @@ class TestMatchReportComebacks:
                 ts += 30.0
                 prev = (s1, s2)
         path = _al._path(oid)
+        assert path is not None
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             for r in records:
@@ -1195,6 +1202,7 @@ class TestMatchReportPregameTrim:
     def _seed_audit(self, oid: str, records: list[dict]) -> None:
         from app.api import action_log as _al
         path = _al._path(oid)
+        assert path is not None
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             for r in records:
@@ -1364,6 +1372,7 @@ class TestMatchReportTimeoutsInline:
     def _seed_audit(self, oid: str, records: list[dict]) -> None:
         from app.api import action_log as _al
         path = _al._path(oid)
+        assert path is not None
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             for r in records:

--- a/tests/test_password_hash.py
+++ b/tests/test_password_hash.py
@@ -57,7 +57,7 @@ def test_hash_rejects_empty_password():
 
 def test_hash_rejects_non_string_password():
     with pytest.raises(TypeError):
-        ph.hash_password(b"bytes")  # type: ignore[arg-type]
+        ph.hash_password(b"bytes")
 
 
 def test_hash_rejects_non_power_of_two_n():
@@ -109,8 +109,8 @@ def test_verify_returns_false_on_malformed_record(malformed):
 
 
 def test_verify_returns_false_for_non_string_inputs():
-    assert ph.verify_password(123, "scrypt$n=16384,r=8,p=1$ab$cd") is False  # type: ignore[arg-type]
-    assert ph.verify_password("pw", None) is False  # type: ignore[arg-type]
+    assert ph.verify_password(123, "scrypt$n=16384,r=8,p=1$ab$cd") is False
+    assert ph.verify_password("pw", None) is False
 
 
 def test_verify_rejects_n_above_max_log2_cap():

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -117,8 +117,8 @@ class TestGameSessionMeta:
     def test_apply_meta_ignores_non_dict(self, mock_conf):
         session = GameSession("oid", mock_conf, _backend_for())
         original = session.simple
-        session.apply_meta(None)  # type: ignore[arg-type]
-        session.apply_meta("garbage")  # type: ignore[arg-type]
+        session.apply_meta(None)
+        session.apply_meta("garbage")
         assert session.simple == original
 
 

--- a/tests/test_state_store_sanitizer.py
+++ b/tests/test_state_store_sanitizer.py
@@ -56,9 +56,9 @@ def test_sanitize_rejects_bad_inputs(bad_id):
 
 def test_sanitize_rejects_non_string():
     with pytest.raises(ValueError):
-        OverlayStateStore._sanitize_id(None)  # type: ignore[arg-type]
+        OverlayStateStore._sanitize_id(None)
     with pytest.raises(ValueError):
-        OverlayStateStore._sanitize_id(b"bytes")  # type: ignore[arg-type]
+        OverlayStateStore._sanitize_id(b"bytes")
 
 
 def test_overlay_exists_returns_false_for_invalid_id(store):

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -201,7 +201,7 @@ class TestDispatch:
         # orderings).
         records: list[stdlogging.LogRecord] = []
         handler = stdlogging.Handler(level=stdlogging.WARNING)
-        handler.emit = records.append  # type: ignore[assignment]
+        handler.emit = records.append
         webhook_logger = stdlogging.getLogger("app.api.webhooks")
         prior_level = webhook_logger.level
         webhook_logger.addHandler(handler)


### PR DESCRIPTION
Backend test suite (mypy hygiene):
- Remove stale, now-unused `# type: ignore` comments across the test
  suite (password_hash, state_store_sanitizer, webhooks,
  session_persistence, match_archive).
- Narrow `_al._path(oid)` (str | None) with `assert path is not None`
  before os.makedirs/open in test_match_report.py.
- Annotate OVERLAY_TOKEN_GATED_ROUTES in test_auth_coverage.py.

Frontend lint:
- Use optional catch binding in ColorPicker localStorage helpers.
- Drop two stale eslint-disable react-hooks/exhaustive-deps directives.
- Document the intentional autoFocus usages with justified
  eslint-disable comments (InitScreen, PresetPicker, TeamCard).

Frontend accessibility:
- Make the scoreboard show/hide-controls handle and the per-team serve
  toggle keyboard-operable: role="button", tabIndex, aria-label
  (aria-pressed on serve), and Enter/Space handlers.

No runtime behaviour change beyond the added keyboard handlers.

https://claude.ai/code/session_01RiusLcnhqW9G2LbxW8yVpb