### PR TITLE
Fix set-summary recap overflow with compact point-type chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Set-summary recap overlay overflowed with point-type stats.** The
+  per-point breakdown was added to the recap as one stat row per type,
+  which overran the fixed-size stat panels (services wrapped, the
+  opponent-errors row was clipped off the bottom). It now renders as a
+  bounded compact chip strip — short label + count per type, zeros
+  dimmed, team-coloured, headed by the team logo — that can't overflow
+  no matter how many types were tagged. Ledger/columns render it as a
+  per-team strip under each column; bento/bumper as a two-row block
+  below the core stats; glass as a full-width band spanning both tiles.
+
 ### Added
 
 - **Per-point classification (opt-in scouting tags).** `POST

--- a/overlay_static/css/set_summary.css
+++ b/overlay_static/css/set_summary.css
@@ -1636,6 +1636,6 @@ body.set-summary-mode #player-stats-container {
   font: 800 clamp(9px, 2.25cqw, 24px)/1 'Menlo', 'Consolas', monospace;
   color: #fff;
 }
-.ss-pt-chip-n.home { color: color-mix(in srgb, var(--ss-home, #7ea2ff) 45%, #fff); }
-.ss-pt-chip-n.away { color: color-mix(in srgb, var(--ss-away, #ff8f8f) 45%, #fff); }
+.ss-pt-chip-n.home { color: color-mix(in srgb, var(--ss-home, #d4314c) 45%, #fff); }
+.ss-pt-chip-n.away { color: color-mix(in srgb, var(--ss-away, #f0a020) 45%, #fff); }
 .ss-pt-chip.is-zero .ss-pt-chip-n { color: rgba(255, 255, 255, 0.28); }

--- a/overlay_static/css/set_summary.css
+++ b/overlay_static/css/set_summary.css
@@ -717,16 +717,21 @@ body.set-summary-mode #player-stats-container {
   min-width: 0;
   min-height: 0;
   padding: clamp(7px, 2.1cqw, 20px);
-  display: grid;
-  grid-template-rows: repeat(4, 1fr);
-  row-gap: clamp(3px, 1.2cqw, 12px);
+  /* Flex column (not a fixed 4-row grid) so the optional point-type
+     breakdown sits below the four core rows without the tile clipping
+     it. Core rows share the free space; the breakdown takes only its
+     natural two lines. */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  row-gap: clamp(2px, 0.9cqw, 9px);
 }
 .ss-stage[data-style="bento"] .ss-tile-stats .ss-stat-row {
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
   gap: clamp(4px, 1.5cqw, 14px);
-  padding: clamp(4px, 1.5cqw, 14px) clamp(1px, 0.6cqw, 6px);
+  padding: clamp(2px, 0.8cqw, 8px) clamp(1px, 0.6cqw, 6px);
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 .ss-stage[data-style="bento"] .ss-tile-stats .ss-stat-row:last-child { border-bottom: none; }
@@ -745,9 +750,10 @@ body.set-summary-mode #player-stats-container {
    contrast on the dark bento tile. The team origin of each stat
    stays visible via the icon column on the left. */
 .ss-stage[data-style="bento"] .ss-tile-stats .ss-stat-value {
-  font: 900 clamp(14px, 4.2cqw, 42px)/1 'Menlo', 'Consolas', monospace;
+  font: 900 clamp(11px, 2.85cqw, 28px)/1 'Menlo', 'Consolas', monospace;
   letter-spacing: -0.02em;
   color: #fff;
+  white-space: nowrap;
 }
 .ss-stage[data-style="bento"] .ss-tile-stats .ss-stat-value .home {
   color: color-mix(in srgb, var(--ss-home, #ff5a73) 40%, #fff);
@@ -874,13 +880,24 @@ body.set-summary-mode #player-stats-container {
 .ss-stage[data-style="glass"] {
   padding: clamp(11px, 3.6cqw, 36px) clamp(14px, 4.8cqw, 48px);
   grid-template-columns: 1fr 1fr;
-  /* Two rows now: header + body. The stats no longer have their
-     own footer row — they live inside the score tile below the
-     team rows so the user can scan ``teams + their stats`` in a
-     single column. */
-  grid-template-rows: auto 1fr;
+  /* header · body (two tiles) · full-width point-type breakdown band.
+     The body uses ``minmax(0, 1fr)`` (not bare ``1fr``) so it can't
+     grow to its content and shove the band off-stage; the tiles get
+     ``min-height: 0`` + clip so they stay within that capped row. */
+  grid-template-rows: auto minmax(0, 1fr) auto;
   gap: clamp(5px, 1.8cqw, 18px);
   position: relative; overflow: hidden;
+}
+.ss-stage[data-style="glass"] .ss-glass.ss-score-tile,
+.ss-stage[data-style="glass"] .ss-glass.ss-chart-tile {
+  min-height: 0;
+  overflow: hidden;
+}
+.ss-stage[data-style="glass"] > .ss-pt-breakdown-wide {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: clamp(5px, 1.5cqw, 16px) clamp(9px, 3cqw, 32px);
+  border-top: none;
 }
 .ss-stage[data-style="glass"] .ss-blob {
   position: absolute;
@@ -981,19 +998,19 @@ body.set-summary-mode #player-stats-container {
 }
 .ss-stage[data-style="glass"] .ss-meta strong { color: #fff; }
 .ss-stage[data-style="glass"] .ss-score-tile {
-  padding: clamp(11px, 3.6cqw, 32px) clamp(13px, 4.5cqw, 40px);
+  padding: clamp(9px, 3cqw, 28px) clamp(13px, 4.5cqw, 40px);
   display: flex; flex-direction: column;
-  justify-content: space-between; gap: 16px;
+  justify-content: space-between; gap: clamp(6px, 1.8cqw, 14px);
 }
 .ss-stage[data-style="glass"] .ss-score-tile .ss-teams {
-  display: flex; flex-direction: column; gap: 16px;
+  display: flex; flex-direction: column; gap: clamp(6px, 1.8cqw, 14px);
 }
 .ss-stage[data-style="glass"] .ss-team-row {
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
   gap: 18px;
-  padding: 14px 0;
+  padding: clamp(5px, 1.5cqw, 12px) 0;
   border-bottom: 1px solid rgba(255,255,255,0.12);
 }
 .ss-stage[data-style="glass"] .ss-team-row:last-child { border-bottom: none; }
@@ -1278,8 +1295,16 @@ body.set-summary-mode #player-stats-container {
     0 24px 60px rgba(0, 0, 0, 0.55),
     inset 0 1px 0 rgba(255, 255, 255, 0.16);
   display: grid;
-  grid-template-rows: auto 1fr;
+  /* ribbon · hero · optional point-type breakdown. The hero (1fr)
+     yields room to the breakdown's auto row instead of the block
+     overflowing the core into the bottom ledger. */
+  grid-template-rows: auto 1fr auto;
   overflow: hidden;
+}
+.ss-stage[data-style="bumper"] .ss-bumper-core > .ss-pt-breakdown {
+  margin: 0;
+  padding: clamp(5px, 1.5cqw, 16px) clamp(11px, 3.9cqw, 36px);
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .ss-stage[data-style="bumper"] .ss-bumper-core .ss-ribbon {
@@ -1371,7 +1396,7 @@ body.set-summary-mode #player-stats-container {
 }
 .ss-stage[data-style="bumper"] .ss-team.away .ss-team-name { text-align: right; }
 .ss-stage[data-style="bumper"] .ss-team-score {
-  font: 900 clamp(44px, 13cqw, 168px)/0.9 'Helvetica Neue', sans-serif;
+  font: 900 clamp(40px, 11cqw, 132px)/0.9 'Helvetica Neue', sans-serif;
   letter-spacing: -0.04em;
   background: linear-gradient(180deg,
     #ffffff 0%,
@@ -1541,3 +1566,76 @@ body.set-summary-mode #player-stats-container {
   font-weight: 800;
 }
 
+
+/* ── Point-type breakdown (compact chips, shared across variants) ──
+   A bounded chip strip — one chip per type (short label + count, zeros
+   dimmed), team-coloured. Replaces the per-type stat rows so the
+   fixed-size recap panel can't overflow no matter how many types were
+   tagged. Used two ways: the combined block (.ss-pt-breakdown, two
+   rows with a team logo) in the tile/centre variants, and a bare
+   .ss-pt-chips strip appended under each team's stat column in the
+   split-column variants. */
+.ss-pt-breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(4px, 1.2cqw, 12px);
+  margin-top: clamp(5px, 1.5cqw, 16px);
+  padding-top: clamp(5px, 1.5cqw, 16px);
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  min-width: 0;
+}
+.ss-pt-row {
+  display: flex;
+  align-items: center;
+  gap: clamp(5px, 1.5cqw, 14px);
+  min-width: 0;
+}
+.ss-pt-logo {
+  flex: 0 0 auto;
+  width: clamp(16px, 3.6cqw, 40px);
+  height: clamp(16px, 3.6cqw, 40px);
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.08);
+  font: 800 clamp(7px, 1.5cqw, 16px)/1 -apple-system, sans-serif;
+  color: #fff;
+}
+.ss-pt-logo img { width: 100%; height: 100%; object-fit: cover; }
+.ss-pt-chips {
+  display: flex;
+  gap: clamp(3px, 1cqw, 10px);
+  min-width: 0;
+}
+.ss-pt-row > .ss-pt-chips { flex: 1 1 auto; }
+.ss-team-stat-list > .ss-pt-chips {
+  width: 100%;
+  margin-top: clamp(4px, 1.2cqw, 12px);
+}
+.ss-pt-chip {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(1px, 0.4cqw, 4px);
+  padding: clamp(3px, 1cqw, 10px) clamp(2px, 0.6cqw, 6px);
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: clamp(5px, 1.2cqw, 10px);
+}
+.ss-pt-chip-k {
+  font: 700 clamp(4px, 1.05cqw, 11px)/1 -apple-system, sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.5);
+  white-space: nowrap;
+}
+.ss-pt-chip-n {
+  font: 800 clamp(9px, 2.25cqw, 24px)/1 'Menlo', 'Consolas', monospace;
+  color: #fff;
+}
+.ss-pt-chip-n.home { color: color-mix(in srgb, var(--ss-home, #7ea2ff) 45%, #fff); }
+.ss-pt-chip-n.away { color: color-mix(in srgb, var(--ss-away, #ff8f8f) 45%, #fff); }
+.ss-pt-chip.is-zero .ss-pt-chip-n { color: rgba(255, 255, 255, 0.28); }

--- a/overlay_static/js/set_summary.js
+++ b/overlay_static/js/set_summary.js
@@ -29,7 +29,7 @@
       setWinner: 'Set winner', runnerUp: 'Runner-up',
       live: 'LIVE', vs: 'VS', pointsShort: 'pts',
       empty: 'No points yet this set',
-      ptAce: 'Aces', ptKill: 'Kills', ptBlock: 'Blocks', ptOppError: 'Opp. errors',
+      chipAce: 'Ace', chipKill: 'Kill', chipBlock: 'Block', chipOppErr: 'Opp. err',
     },
     es: {
       set: 'Set', final: 'Final', duration: 'Duración',
@@ -42,7 +42,7 @@
       setWinner: 'Ganador del set', runnerUp: 'Segundo',
       live: 'EN VIVO', vs: 'VS', pointsShort: 'pts',
       empty: 'Aún sin puntos en este set',
-      ptAce: 'Saques directos', ptKill: 'Ataques', ptBlock: 'Bloqueos', ptOppError: 'Errores rival',
+      chipAce: 'Saque', chipKill: 'Ataque', chipBlock: 'Bloqueo', chipOppErr: 'Err. riv',
     },
     pt: {
       set: 'Set', final: 'Final', duration: 'Duração',
@@ -55,7 +55,7 @@
       setWinner: 'Vencedor do set', runnerUp: 'Segundo',
       live: 'AO VIVO', vs: 'VS', pointsShort: 'pts',
       empty: 'Ainda sem pontos neste set',
-      ptAce: 'Aces', ptKill: 'Ataques', ptBlock: 'Blocos', ptOppError: 'Erros adv.',
+      chipAce: 'Saque', chipKill: 'Ataque', chipBlock: 'Bloco', chipOppErr: 'Err. adv',
     },
     it: {
       set: 'Set', final: 'Finale', duration: 'Durata',
@@ -68,7 +68,7 @@
       setWinner: 'Vincitore del set', runnerUp: 'Secondo',
       live: 'LIVE', vs: 'VS', pointsShort: 'pti',
       empty: 'Nessun punto in questo set',
-      ptAce: 'Ace', ptKill: 'Attacchi', ptBlock: 'Muri', ptOppError: 'Errori avv.',
+      chipAce: 'Ace', chipKill: 'Attacco', chipBlock: 'Muro', chipOppErr: 'Err. avv',
     },
     fr: {
       set: 'Set', final: 'Final', duration: 'Durée',
@@ -81,7 +81,7 @@
       setWinner: 'Vainqueur du set', runnerUp: 'Finaliste',
       live: 'EN DIRECT', vs: 'VS', pointsShort: 'pts',
       empty: 'Pas encore de points dans ce set',
-      ptAce: 'Aces', ptKill: 'Attaques', ptBlock: 'Contres', ptOppError: 'Fautes adv.',
+      chipAce: 'Ace', chipKill: 'Attaque', chipBlock: 'Contre', chipOppErr: 'Faute adv',
     },
     de: {
       set: 'Satz', final: 'Final', duration: 'Dauer',
@@ -94,7 +94,7 @@
       setWinner: 'Satzgewinner', runnerUp: 'Zweiter',
       live: 'LIVE', vs: 'VS', pointsShort: 'Pkt',
       empty: 'Noch keine Punkte in diesem Satz',
-      ptAce: 'Asse', ptKill: 'Angriffe', ptBlock: 'Blocks', ptOppError: 'Gegnerfehler',
+      chipAce: 'Ass', chipKill: 'Angriff', chipBlock: 'Block', chipOppErr: 'Geg.-F.',
     },
   };
 
@@ -374,19 +374,22 @@
     const setPtRaw = pointTypesBySet[setNum] || pointTypesBySet[String(setNum)] || {};
     const ptHome = setPtRaw['1'] || setPtRaw[1] || {};
     const ptAway = setPtRaw['2'] || setPtRaw[2] || {};
-    const pointTypeRows = [
-      ['ace', 'ptAce'],
-      ['kill', 'ptKill'],
-      ['block', 'ptBlock'],
-      ['opp_error', 'ptOppError'],
-    ]
-      .map(([key, labelKey]) => ({
-        key,
-        label: t(labelKey),
-        home: Number(ptHome[key] || 0),
-        away: Number(ptAway[key] || 0),
-      }))
-      .filter((r) => (r.home + r.away) > 0);
+    // Per-team counts for all four types (zeros kept — rendered dimmed),
+    // shown as a compact chip strip rather than one row per type so the
+    // fixed-size recap panel can't overflow. ``hasPointTypes`` gates the
+    // whole block off when the set was scored without any tags.
+    const pointTypes = [
+      ['ace', 'chipAce'],
+      ['kill', 'chipKill'],
+      ['block', 'chipBlock'],
+      ['opp_error', 'chipOppErr'],
+    ].map(([key, labelKey]) => ({
+      key,
+      label: t(labelKey),
+      home: Number(ptHome[key] || 0),
+      away: Number(ptAway[key] || 0),
+    }));
+    const hasPointTypes = pointTypes.some((p) => (p.home + p.away) > 0);
 
     // Total points in the displayed set = sum of both team scores.
     const setTotalPoints = (homeScore || 0) + (awayScore || 0);
@@ -419,7 +422,7 @@
       stats,
       // Per-set values (preferred over match-wide so the recap
       // matches what the operator just watched).
-      longestSet, servicesSet, setTotalPoints, pointTypeRows,
+      longestSet, servicesSet, setTotalPoints, pointTypes, hasPointTypes,
       setFinished,
       matchFinished: !!matchInfo.match_finished,
       bestOf: matchInfo.best_of_sets || 5,
@@ -543,10 +546,10 @@
     awayStats.appendChild(buildStat(t('servicesWon'),
       formatServices(vm.servicesSet, 2)));
 
-    vm.pointTypeRows.forEach((row) => {
-      homeStats.appendChild(buildStat(row.label, row.home));
-      awayStats.appendChild(buildStat(row.label, row.away));
-    });
+    if (vm.hasPointTypes) {
+      homeStats.appendChild(buildPtChipStrip(vm, 1));
+      awayStats.appendChild(buildPtChipStrip(vm, 2));
+    }
 
     const homeCol = el('div', {
       class: 'ss-team ss-team-home',
@@ -635,6 +638,48 @@
     return `${block.won || 0} / ${block.served}`;
   }
 
+  // ── Point-type breakdown (compact chips) ───────────────────────
+  // A bounded chip strip (one chip per type, short label + count, zeros
+  // dimmed) replaces the per-type stat rows so the fixed-size recap
+  // panel can never overflow no matter how many types were tagged.
+
+  function buildPtChip(label, value, teamClass) {
+    return el('span', {
+      class: 'ss-pt-chip' + (value === 0 ? ' is-zero' : ''),
+      children: [
+        el('span', { class: 'ss-pt-chip-k', text: label }),
+        el('span', { class: 'ss-pt-chip-n ' + (teamClass || ''), text: String(value) }),
+      ],
+    });
+  }
+
+  function buildPtChipStrip(vm, team) {
+    const teamClass = team === 1 ? 'home' : 'away';
+    return el('div', {
+      class: 'ss-pt-chips',
+      children: (vm.pointTypes || []).map((p) =>
+        buildPtChip(p.label, team === 1 ? p.home : p.away, teamClass)),
+    });
+  }
+
+  // Combined two-row breakdown (team logo + chip strip per side) for the
+  // tile / centre variants. Returns ``null`` when nothing was tagged so
+  // the block disappears entirely; always exactly two lines otherwise.
+  function buildPtBreakdown(vm) {
+    if (!vm.hasPointTypes) return null;
+    const row = (team, side) => el('div', {
+      class: 'ss-pt-row',
+      children: [
+        teamLogoNode(team === 1 ? vm.home : vm.away, side, 'ss-pt-logo'),
+        buildPtChipStrip(vm, team),
+      ],
+    });
+    return el('div', {
+      class: 'ss-pt-breakdown',
+      children: [row(1, 'home'), row(2, 'away')],
+    });
+  }
+
   function buildLedger(vm) {
     const merged = [];
     vm.setPoints.forEach((p) => merged.push({ ...p, kind: 'point' }));
@@ -691,10 +736,10 @@
       vm.longestSet[2] ? `${vm.longestSet[2]} ${t('pointsShort')}` : '–'));
     awayStats.appendChild(buildStat(t('servicesWon'), formatServices(vm.servicesSet, 2)));
 
-    vm.pointTypeRows.forEach((row) => {
-      homeStats.appendChild(buildStat(row.label, row.home));
-      awayStats.appendChild(buildStat(row.label, row.away));
-    });
+    if (vm.hasPointTypes) {
+      homeStats.appendChild(buildPtChipStrip(vm, 1));
+      awayStats.appendChild(buildPtChipStrip(vm, 2));
+    }
 
     stage.appendChild(el('div', {
       class: 'ss-team ss-team-home',
@@ -909,10 +954,10 @@
         vm.home.timeouts_taken || 0, vm.away.timeouts_taken || 0),
       buildBentoStatRow('∑', t('totalPoints'), vm.setTotalPoints),
     ];
-    vm.pointTypeRows.forEach((row) => {
-      rows.push(buildBentoStatRowDual('•', row.label, row.home, row.away));
-    });
-    return el('div', { class: 'ss-tile ss-tile-stats', children: rows });
+    const tile = el('div', { class: 'ss-tile ss-tile-stats', children: rows });
+    const breakdown = buildPtBreakdown(vm);
+    if (breakdown) tile.appendChild(breakdown);
+    return tile;
   }
 
   function buildBentoStatRow(icon, label, value) {
@@ -1017,23 +1062,23 @@
         buildGlassStatRowDual(t('timeoutsUsed'),
           vm.home.timeouts_taken || 0, vm.away.timeouts_taken || 0),
         buildGlassStatRow(t('totalPoints'), vm.setTotalPoints),
-        ...vm.pointTypeRows.map((row) =>
-          buildGlassStatRowDual(row.label, row.home, row.away)),
       ],
     });
 
+    const scoreTileChildren = [
+      el('div', {
+        class: 'ss-teams',
+        children: [
+          buildGlassTeamRow(vm, 'home'),
+          buildGlassTeamRow(vm, 'away'),
+        ],
+      }),
+      stats,
+    ];
+
     stage.appendChild(el('div', {
       class: 'ss-glass ss-score-tile',
-      children: [
-        el('div', {
-          class: 'ss-teams',
-          children: [
-            buildGlassTeamRow(vm, 'home'),
-            buildGlassTeamRow(vm, 'away'),
-          ],
-        }),
-        stats,
-      ],
+      children: scoreTileChildren,
     }));
 
     const chartTile = el('div', {
@@ -1052,6 +1097,18 @@
     box.appendChild(buildSvgChart(vm, { width: 480, height: 360, padTop: 8, padBottom: 6 }));
     chartTile.appendChild(box);
     stage.appendChild(chartTile);
+
+    // Full-width breakdown band below both tiles — mirrors the top
+    // header strip. Spans the score + chart columns so the two-line
+    // chip strip gets the whole width instead of cramming the tile.
+    const glassBreakdown = buildPtBreakdown(vm);
+    if (glassBreakdown) {
+      // ``ss-glass`` gives the band the same frosted-dark tile backing
+      // as the score/chart tiles so its labels stay legible over any
+      // scene; ``ss-pt-breakdown-wide`` makes it span both columns.
+      glassBreakdown.classList.add('ss-glass', 'ss-pt-breakdown-wide');
+      stage.appendChild(glassBreakdown);
+    }
   }
 
   function buildGlassStatRow(label, value) {
@@ -1252,8 +1309,6 @@
         buildBumperStatCellDual(t('timeouts'),
           vm.home.timeouts_taken || 0, vm.away.timeouts_taken || 0),
         buildBumperStatCell(t('totalPoints'), vm.setTotalPoints),
-        ...vm.pointTypeRows.map((row) =>
-          buildBumperStatCellDual(row.label, row.home, row.away)),
       ],
     });
 
@@ -1280,9 +1335,12 @@
       ],
     });
 
+    const coreChildren = [ribbon, hero];
+    const bumperBreakdown = buildPtBreakdown(vm);
+    if (bumperBreakdown) coreChildren.push(bumperBreakdown);
     const core = el('div', {
       class: 'ss-bumper-core',
-      children: [ribbon, hero],
+      children: coreChildren,
     });
 
     // Bottom ledger — full stage width so 25+ chips fit per team


### PR DESCRIPTION
## Summary

Follow-up fix for the per-point classification feature (#348). The set-summary **recap overlay** added the point-type breakdown as one stat row per type, which overran the fixed-size stat panels — services wrapped to multiple lines and the opponent-errors row was clipped off the bottom (most visible on the `bento` variant).

This replaces the per-type rows with a **bounded compact chip strip**: one chip per type (short localized label + count, zeros dimmed, team-coloured), headed by the team logo. It can't overflow regardless of how many types were tagged.

Per variant:
- **brand_ledger / brand_columns** — per-team chip strip appended under each team's stat column.
- **bento / bumper** — a two-row combined block (team logo + chip strip per side); the bento stats tile switches from a fixed 4-row grid to flex with tighter rows so the block fits below the core stats.
- **glass** — a full-width band spanning both tiles at the bottom (mirrors the top header). The body grid row is capped with `minmax(0, 1fr)` so the tiles stay contained instead of pushing the band off-stage.

Gating is unchanged: the breakdown only renders when at least one point was tagged (`hasPointTypes`). With no tags, every variant shows exactly the existing stats — verified by rendering all five variants both tagged and untagged.

## Scope
- `overlay_static/js/set_summary.js`, `overlay_static/css/set_summary.css`, `CHANGELOG.md` only — no backend or `frontend/src` changes, so the pytest/vitest suites are unaffected.
- Localized short chip labels across all six locales (en/es/pt/it/fr/de).

## Testing
- `node --check` clean on the overlay JS.
- Rendered each of the 5 recap variants headless with both tagged and untagged data to confirm: tagged → compact breakdown, no overflow; untagged → existing stats intact, no block.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBwR8h6pawkFr9WoSo1z5P)_