### PR TITLE
Beach overlay: full team names + team-coloured highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ once a first tagged release ships.
   `overlay_static/css/beach.css`), so it appears in the style picker and
   is selectable per overlay like any other style.
 
+### Changed
+
+- **Beach overlay: team-name bars now expand to fit the longest name (both sides symmetric) and shrink the font instead of truncating; the SETS label, timeout dots and serving indicator now use each team's name colour for contrast.**
+
 ### Fixed
 
 - **Set-summary recap overlay overflowed with point-type stats.** The

--- a/overlay_static/css/beach.css
+++ b/overlay_static/css/beach.css
@@ -162,8 +162,13 @@ body {
     font-size: 11px;
     font-weight: 700;
     letter-spacing: 1px;
-    opacity: 0.7;
+    opacity: 0.85;
 }
+
+/* The "SETS" label tracks each team's name colour so it keeps contrast
+   against the team's primary background (same colour as .team-name). */
+.team-home .team-meta::before { color: var(--home-secondary); }
+.team-away .team-meta::before { color: var(--away-secondary); }
 
 .timeout-container {
     display: flex;
@@ -178,9 +183,16 @@ body {
     transition: background 0.3s ease, box-shadow 0.3s ease;
 }
 
-.timeout-dot.active {
-    background: var(--serve-glow);
-    box-shadow: 0 0 8px var(--serve-glow);
+/* Active timeout dots glow in each team's name colour for contrast
+   against its own primary-coloured bar. */
+.team-home .timeout-dot.active {
+    background: var(--home-secondary);
+    box-shadow: 0 0 8px color-mix(in srgb, var(--home-secondary) 65%, transparent);
+}
+
+.team-away .timeout-dot.active {
+    background: var(--away-secondary);
+    box-shadow: 0 0 8px color-mix(in srgb, var(--away-secondary) 65%, transparent);
 }
 
 /* Serving indicator — a slim bar on the inner edge (facing the centre)
@@ -195,9 +207,16 @@ body {
     transition: background-color 0.3s ease, box-shadow 0.3s ease;
 }
 
-.serving-indicator.active {
-    background-color: var(--serve-glow);
-    box-shadow: 0 0 14px var(--serve-glow);
+/* The serving indicator lights up in the serving team's name colour so
+   it stays legible against that team's primary-coloured bar. */
+.team-home .serving-indicator.active {
+    background-color: var(--home-secondary);
+    box-shadow: 0 0 14px color-mix(in srgb, var(--home-secondary) 65%, transparent);
+}
+
+.team-away .serving-indicator.active {
+    background-color: var(--away-secondary);
+    box-shadow: 0 0 14px color-mix(in srgb, var(--away-secondary) 65%, transparent);
 }
 
 /* ── Centre: current-set score, two tall raised white cards ──────── */

--- a/overlay_static/css/beach.css
+++ b/overlay_static/css/beach.css
@@ -184,14 +184,17 @@ body {
 }
 
 /* Active timeout dots glow in each team's name colour for contrast
-   against its own primary-coloured bar. */
+   against its own primary-coloured bar. The solid box-shadow is a
+   fallback for OBS/CEF builds older than Chromium 111 (no color-mix). */
 .team-home .timeout-dot.active {
     background: var(--home-secondary);
+    box-shadow: 0 0 8px var(--home-secondary);
     box-shadow: 0 0 8px color-mix(in srgb, var(--home-secondary) 65%, transparent);
 }
 
 .team-away .timeout-dot.active {
     background: var(--away-secondary);
+    box-shadow: 0 0 8px var(--away-secondary);
     box-shadow: 0 0 8px color-mix(in srgb, var(--away-secondary) 65%, transparent);
 }
 
@@ -208,14 +211,17 @@ body {
 }
 
 /* The serving indicator lights up in the serving team's name colour so
-   it stays legible against that team's primary-coloured bar. */
+   it stays legible against that team's primary-coloured bar. The solid
+   box-shadow is a fallback for OBS/CEF builds older than Chromium 111. */
 .team-home .serving-indicator.active {
     background-color: var(--home-secondary);
+    box-shadow: 0 0 14px var(--home-secondary);
     box-shadow: 0 0 14px color-mix(in srgb, var(--home-secondary) 65%, transparent);
 }
 
 .team-away .serving-indicator.active {
     background-color: var(--away-secondary);
+    box-shadow: 0 0 14px var(--away-secondary);
     box-shadow: 0 0 14px color-mix(in srgb, var(--away-secondary) 65%, transparent);
 }
 

--- a/overlay_static/js/app.js
+++ b/overlay_static/js/app.js
@@ -594,6 +594,7 @@ const BEACH_NAME_MIN_FONT = 16;
 const BEACH_NAME_MIN_BAR = 260;
 const BEACH_NAME_MAX_BAR = 480;
 const BEACH_NAME_PADDING = 44;    // .name-bar horizontal padding (2 * 22px)
+let beachFontsHooked = false;
 
 // Measure the rendered width of a beach team name at a given font size with
 // an offscreen node, so the live (possibly clipped) element is untouched and
@@ -629,8 +630,8 @@ function fitBeachNames() {
 
     // The first measurement can land before the Montserrat webfont loads
     // (fallback metrics differ). Re-fit once it is ready, just once.
-    if (document.fonts && !window.__beachFontsHooked) {
-        window.__beachFontsHooked = true;
+    if (document.fonts && !beachFontsHooked) {
+        beachFontsHooked = true;
         document.fonts.ready.then(() => fitBeachNames());
     }
 

--- a/overlay_static/js/app.js
+++ b/overlay_static/js/app.js
@@ -279,6 +279,7 @@ function renderFullState(state) {
     withEl("home-name", el => { el.textContent = state.team_home.name; });
     withEl("away-name", el => { el.textContent = state.team_away.name; });
     equalizeNamePanels();
+    fitBeachNames();
 
     // 4b. Logo visibility toggle (from remote-scoreboard "Logos" setting).
     // Run before the per-logo URL branches so those have the final say on
@@ -400,6 +401,7 @@ function updateStateDiff(oldState, newState) {
     if (oldState.team_home.name !== newState.team_home.name ||
         oldState.team_away.name !== newState.team_away.name) {
         equalizeNamePanels();
+        fitBeachNames();
     }
 
     // Logo visibility toggle (runs before per-logo URL updates so the
@@ -490,6 +492,8 @@ function updateStateDiff(oldState, newState) {
         withEl("scoreboard-container", container => {
             container.classList.toggle("compact-mode", !!newState.match_info.show_only_current_set);
         });
+        // Re-fit beach names when they reappear leaving compact mode.
+        fitBeachNames();
     }
 
     // Set summary recap panel toggle / re-render. Re-render also on
@@ -573,6 +577,87 @@ function updateStateDiff(oldState, newState) {
     // helper restarts the keyframe via a forced reflow if the same
     // class re-applies on a rapid follow-up event.
     dispatchAlertTransitions(oldState, newState);
+}
+
+// ── Beach name fitting ───────────────────────────────────────────────
+// The beach board keeps both name bars symmetric. Rather than clipping a
+// long name with an ellipsis, widen both bars to fit the longer of the two
+// names, and only when that would exceed BEACH_NAME_MAX_BAR shrink the type
+// (down to BEACH_NAME_MIN_FONT) so the full name still shows. Both sides
+// always share the same width and font size.
+const BEACH_NAME_BASE_FONT = 29;  // matches .team-name font-size in beach.css
+const BEACH_NAME_MIN_FONT = 17;
+const BEACH_NAME_MIN_BAR = 260;
+const BEACH_NAME_MAX_BAR = 440;
+const BEACH_NAME_PADDING = 44;    // .name-bar horizontal padding (2 * 22px)
+
+// Measure the rendered width of a beach team name at a given font size with
+// an offscreen node, so the live (possibly clipped) element is untouched and
+// short names report their true width.
+function measureBeachName(text, fontSize) {
+    let m = document.getElementById("beach-name-measure");
+    if (!m) {
+        m = document.createElement("span");
+        m.id = "beach-name-measure";
+        m.style.position = "absolute";
+        m.style.left = "-9999px";
+        m.style.top = "0";
+        m.style.visibility = "hidden";
+        m.style.whiteSpace = "nowrap";
+        m.style.fontFamily = "'Montserrat', sans-serif";
+        m.style.fontWeight = "800";
+        m.style.textTransform = "uppercase";
+        m.style.letterSpacing = "1px";
+        document.body.appendChild(m);
+    }
+    m.style.fontSize = fontSize + "px";
+    m.textContent = text || "";
+    return m.offsetWidth;
+}
+
+function fitBeachNames() {
+    const container = document.getElementById("scoreboard-container");
+    const homeName = document.getElementById("home-name");
+    const awayName = document.getElementById("away-name");
+    if (!container || !homeName || !awayName) return;
+    // Only the beach template uses `.name-bar`; bail out for every other style.
+    if (!container.querySelector(".name-bar")) return;
+
+    // The first measurement can land before the Montserrat webfont loads
+    // (fallback metrics differ). Re-fit once it is ready, just once.
+    if (document.fonts && !window.__beachFontsHooked) {
+        window.__beachFontsHooked = true;
+        document.fonts.ready.then(() => fitBeachNames());
+    }
+
+    const homeText = homeName.textContent || "";
+    const awayText = awayName.textContent || "";
+
+    let fontSize = BEACH_NAME_BASE_FONT;
+    let maxText = Math.max(
+        measureBeachName(homeText, fontSize),
+        measureBeachName(awayText, fontSize)
+    );
+
+    // Shrink the type proportionally only when the longer name would overflow
+    // the widest bar we allow, never below the legibility floor.
+    const maxContent = BEACH_NAME_MAX_BAR - BEACH_NAME_PADDING;
+    if (maxText > maxContent) {
+        fontSize = Math.max(BEACH_NAME_MIN_FONT, fontSize * (maxContent / maxText));
+        maxText = Math.max(
+            measureBeachName(homeText, fontSize),
+            measureBeachName(awayText, fontSize)
+        );
+    }
+
+    homeName.style.fontSize = fontSize + "px";
+    awayName.style.fontSize = fontSize + "px";
+
+    const barWidth = Math.min(
+        BEACH_NAME_MAX_BAR,
+        Math.max(BEACH_NAME_MIN_BAR, Math.ceil(maxText) + BEACH_NAME_PADDING + 2)
+    );
+    container.style.setProperty("--name-bar-width", barWidth + "px");
 }
 
 function equalizeNamePanels() {

--- a/overlay_static/js/app.js
+++ b/overlay_static/js/app.js
@@ -586,9 +586,9 @@ function updateStateDiff(oldState, newState) {
 // (down to BEACH_NAME_MIN_FONT) so the full name still shows. Both sides
 // always share the same width and font size.
 const BEACH_NAME_BASE_FONT = 29;  // matches .team-name font-size in beach.css
-const BEACH_NAME_MIN_FONT = 17;
+const BEACH_NAME_MIN_FONT = 16;
 const BEACH_NAME_MIN_BAR = 260;
-const BEACH_NAME_MAX_BAR = 440;
+const BEACH_NAME_MAX_BAR = 480;
 const BEACH_NAME_PADDING = 44;    // .name-bar horizontal padding (2 * 22px)
 
 // Measure the rendered width of a beach team name at a given font size with
@@ -633,17 +633,20 @@ function fitBeachNames() {
     const homeText = homeName.textContent || "";
     const awayText = awayName.textContent || "";
 
+    // Shrink the type one step at a time, re-measuring each time, until the
+    // longer name fits the widest bar we allow (or we hit the legibility
+    // floor). We can't shrink proportionally in a single step because the
+    // fixed 1px letter-spacing does not scale with the font size, so a
+    // proportional guess lands a few pixels too wide and the name still
+    // clips — the measured loop accounts for it exactly.
+    const maxContent = BEACH_NAME_MAX_BAR - BEACH_NAME_PADDING;
     let fontSize = BEACH_NAME_BASE_FONT;
     let maxText = Math.max(
         measureBeachName(homeText, fontSize),
         measureBeachName(awayText, fontSize)
     );
-
-    // Shrink the type proportionally only when the longer name would overflow
-    // the widest bar we allow, never below the legibility floor.
-    const maxContent = BEACH_NAME_MAX_BAR - BEACH_NAME_PADDING;
-    if (maxText > maxContent) {
-        fontSize = Math.max(BEACH_NAME_MIN_FONT, fontSize * (maxContent / maxText));
+    while (maxText > maxContent && fontSize > BEACH_NAME_MIN_FONT) {
+        fontSize -= 1;
         maxText = Math.max(
             measureBeachName(homeText, fontSize),
             measureBeachName(awayText, fontSize)

--- a/overlay_static/js/app.js
+++ b/overlay_static/js/app.js
@@ -492,8 +492,12 @@ function updateStateDiff(oldState, newState) {
         withEl("scoreboard-container", container => {
             container.classList.toggle("compact-mode", !!newState.match_info.show_only_current_set);
         });
-        // Re-fit beach names when they reappear leaving compact mode.
-        fitBeachNames();
+        // Re-fit beach names only when they reappear leaving compact mode;
+        // entering it hides the names and CSS pins the bar width, so a
+        // re-fit there would be a wasted reflow.
+        if (!newState.match_info.show_only_current_set) {
+            fitBeachNames();
+        }
     }
 
     // Set summary recap panel toggle / re-render. Re-render also on


### PR DESCRIPTION
## Resumen

Adaptaciones al overlay **beach** recién añadido, a partir de dos peticiones del operador:

### 1. Nombres de equipo completos (sin acortar)
Antes los nombres se truncaban con elipsis (`…`) en barras de ancho fijo. Ahora:
- Ambas barras de nombre se **expanden simétricamente** hasta caber en el más largo de los dos nombres — los dos lados mantienen siempre el mismo ancho y tamaño de fuente.
- La fuente solo se **reduce** (hasta un mínimo legible) cuando el nombre más largo superaría el ancho máximo de barra, en lugar de cortarlo.
- Se reajusta en el render completo, al cambiar un nombre y al salir del modo simple. Incluye un reajuste tras cargar la fuente Montserrat (sus métricas difieren del fallback).

Implementado en `overlay_static/js/app.js` con `fitBeachNames()` / `measureBeachName()`.

### 2. Contraste de SET / timeout / servicio según color de equipo
La etiqueta **"SETS"**, los **puntos de timeout activos** y el **indicador de servicio** ya no usan el amarillo compartido (`--serve-glow`), sino el color del nombre de cada equipo (`var(--home-secondary)` / `var(--away-secondary)`), manteniendo el contraste contra su propia barra de color primario.

Implementado en `overlay_static/css/beach.css`.

## Archivos
- `overlay_static/js/app.js`
- `overlay_static/css/beach.css`
- `CHANGELOG.md` (entrada en `[Unreleased] → Changed`)

## Verificación
- `node --check overlay_static/js/app.js` ✅

> Nota: no se han regenerado las capturas del README (requieren build del frontend + Chromium). Puedo hacerlo si se desea.

https://claude.ai/code/session_01BiEqtCyxnwrCKf6KiYcKGC

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiEqtCyxnwrCKf6KiYcKGC)_