### PR TITLE
Beach overlay: name-fitting + per-team colours, plus two-line layout mockups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ once a first tagged release ships.
   `overlay_static/css/beach.css`), so it appears in the style picker and
   is selectable per overlay like any other style.
 
+### Changed
+
+- **Beach overlay: team-name bars now expand to fit the longest name (both sides symmetric) and shrink the font instead of truncating; the SETS label, timeout dots and serving indicator now use each team's name colour for contrast.**
+
 ### Fixed
 
 - **Set-summary recap overlay overflowed with point-type stats.** The

--- a/docs/mockups/beach-twoline/disambiguation.html
+++ b/docs/mockups/beach-twoline/disambiguation.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8" />
+<title>Beach two-line — opciones de desambiguación marcador↔barra</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700;800;900&display=swap" rel="stylesheet" />
+<style>
+  :root { --pg-bg:#0d1117; --pg-text:#e6edf3; --pg-muted:#8b949e; --pg-border:rgba(255,255,255,.08); }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  body { background:var(--pg-bg); color:var(--pg-text); font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; padding:40px 28px 64px; }
+  main { max-width:1180px; margin:0 auto; }
+  h1 { font-size:26px; letter-spacing:-0.02em; margin-bottom:6px; }
+  .lead { color:var(--pg-muted); line-height:1.55; max-width:860px; margin-bottom:22px; }
+  .opt-title { font-size:15px; margin:30px 0 4px; color:var(--pg-text); font-weight:600; }
+  .opt-desc { color:var(--pg-muted); font-size:13px; line-height:1.5; margin-bottom:10px; max-width:820px; }
+  .stage {
+    border:1px solid var(--pg-border); border-radius:12px; overflow:hidden;
+    background:
+      linear-gradient(135deg, rgba(0,0,0,.35), rgba(0,0,0,.55)),
+      repeating-conic-gradient(#1b2230 0% 25%, #232c3d 0% 50%) 50% / 36px 36px,
+      linear-gradient(160deg,#2b5876,#4e4376);
+    padding:44px 48px; display:flex; align-items:flex-end; justify-content:flex-start; min-height:220px;
+  }
+
+  /* ── Shared two-line scoreboard core (simple mode, no icons) ───────── */
+  .sb2 {
+    --home-primary:#0077B6; --home-secondary:#FFFFFF;
+    --away-primary:#F4A300; --away-secondary:#1A1A1A;
+    --score-bg:#FFFFFF; --score-text:#111111;
+    --bar-height:60px; --bar-gap:8px;
+    font-family:'Montserrat',sans-serif; display:flex; flex-direction:row; align-items:stretch; gap:12px; color:#fff;
+  }
+  .sb2-score {
+    width:132px; height:calc(var(--bar-height)*2 + var(--bar-gap));
+    display:flex; align-items:center; justify-content:center; position:relative; overflow:hidden;
+    background:var(--score-bg); color:var(--score-text); border-radius:14px;
+    box-shadow:0 10px 26px rgba(0,0,0,.45); flex-shrink:0;
+  }
+  .sb2-points { font-size:78px; font-weight:900; line-height:1; font-variant-numeric:tabular-nums; }
+  .sb2-names { display:flex; flex-direction:column; gap:var(--bar-gap); align-items:flex-start; }
+  .sb2-bar {
+    height:var(--bar-height); width:auto; border-radius:10px; overflow:hidden;
+    box-shadow:0 6px 16px rgba(0,0,0,.4); display:flex; align-items:center; gap:12px; padding:0 6px; position:relative;
+  }
+  .sb2-bar.home { flex-direction:row; background:linear-gradient(100deg,var(--home-primary),color-mix(in srgb,var(--home-primary) 80%,#000)); }
+  .sb2-bar.away { flex-direction:row-reverse; align-self:flex-end; background:linear-gradient(260deg,var(--away-primary),color-mix(in srgb,var(--away-primary) 80%,#000)); }
+  .sb2-sets {
+    min-width:42px; height:42px; padding:0 10px; border-radius:9px;
+    display:flex; align-items:center; justify-content:center; font-size:30px; font-weight:900; line-height:1;
+    background:rgba(0,0,0,.28); color:#fff; font-variant-numeric:tabular-nums; flex-shrink:0;
+  }
+
+  .note { color:var(--pg-muted); font-size:13px; line-height:1.55; margin-top:28px; padding-top:18px; border-top:1px solid var(--pg-border); }
+  .note strong { color:var(--pg-text); }
+
+  /* ════════════════════════════════════════════════════════════════════
+     OPTION 1 — Row-aligned score numeral
+     The big number is nudged toward the row it belongs to (home up to the
+     top bar, away down to the bottom bar) instead of being centred across
+     both. Pure typography, no extra ink. ════════════════════════════════ */
+  .opt1 .sb2-score.home .sb2-points { transform: translateY(-30px); }
+  .opt1 .sb2-score.away .sb2-points { transform: translateY(30px); }
+
+  /* ════════════════════════════════════════════════════════════════════
+     OPTION 2 — Coloured connector notch
+     A team-coloured tab on the inner edge of the score card, vertically
+     centred on that team's bar row, visually "pointing" to it. ══════════ */
+  .opt2 .sb2-score::after {
+    content:""; position:absolute; width:14px; height:var(--bar-height);
+    border-radius:4px;
+  }
+  .opt2 .sb2-score.home::after { right:-7px; top:0;    background:var(--home-primary); }
+  .opt2 .sb2-score.away::after { left:-7px;  bottom:0; background:var(--away-primary); }
+
+  /* ════════════════════════════════════════════════════════════════════
+     OPTION 3 — Half-height coloured edge aligned to the row
+     The coloured band on the card's inner edge only covers the half-height
+     matching its bar (top half = home, bottom half = away). ═════════════ */
+  .opt3 .sb2-score::before {
+    content:""; position:absolute; width:9px; height:50%;
+  }
+  .opt3 .sb2-score.home::before { right:0; top:0;    background:var(--home-primary); }
+  .opt3 .sb2-score.away::before { left:0;  bottom:0; background:var(--away-primary); }
+
+  /* ════════════════════════════════════════════════════════════════════
+     OPTION 4 — Team-coloured numerals
+     The score number takes the team's colour (matching its bar) so the eye
+     groups blue-with-blue / orange-with-orange. ════════════════════════ */
+  .opt4 .sb2-score.home .sb2-points { color: var(--home-primary); }
+  .opt4 .sb2-score.away .sb2-points { color: var(--away-primary); }
+
+  /* ════════════════════════════════════════════════════════════════════
+     OPTION 5 — Combo: row-aligned numeral + half-height coloured edge
+     The two cheapest, strongest cues together. ═════════════════════════ */
+  .opt5 .sb2-score.home .sb2-points { transform: translateY(-30px); }
+  .opt5 .sb2-score.away .sb2-points { transform: translateY(30px); }
+  .opt5 .sb2-score::before { content:""; position:absolute; width:9px; height:50%; }
+  .opt5 .sb2-score.home::before { right:0; top:0;    background:var(--home-primary); }
+  .opt5 .sb2-score.away::before { left:0;  bottom:0; background:var(--away-primary); }
+</style>
+</head>
+<body>
+<main>
+  <h1>¿Qué marcador es de qué barra? — opciones</h1>
+  <p class="lead">
+    El caso difícil: <strong>modo simple sin icono</strong>, donde las dos
+    barras quedan muy simétricas y el marcador alto (que abarca ambas) no
+    deja claro a cuál pertenece. Local arriba (azul), visitante abajo
+    (naranja). Compara las técnicas y dime cuál prefieres (o combina). El
+    <em>saque</em> es ortogonal: aquí no se muestra para aislar la pista.
+  </p>
+
+  <div class="opt-title">Base actual (ambiguo) — sin pista</div>
+  <div class="opt-desc">Como está ahora: el número va centrado y el borde del marcador es transparente. Es lo que quieres mejorar.</div>
+  <div class="stage">
+    <div class="sb2">
+      <div class="sb2-score home"><span class="sb2-points">21</span></div>
+      <div class="sb2-names">
+        <div class="sb2-bar home"><div class="sb2-sets">1</div></div>
+        <div class="sb2-bar away"><div class="sb2-sets">0</div></div>
+      </div>
+      <div class="sb2-score away"><span class="sb2-points">18</span></div>
+    </div>
+  </div>
+
+  <div class="opt-title">Opción 1 — Número alineado a su fila</div>
+  <div class="opt-desc">El número se desplaza hacia su barra (local arriba, visitante abajo). Solo tipografía, sin tinta extra.</div>
+  <div class="stage">
+    <div class="sb2 opt1">
+      <div class="sb2-score home"><span class="sb2-points">21</span></div>
+      <div class="sb2-names">
+        <div class="sb2-bar home"><div class="sb2-sets">1</div></div>
+        <div class="sb2-bar away"><div class="sb2-sets">0</div></div>
+      </div>
+      <div class="sb2-score away"><span class="sb2-points">18</span></div>
+    </div>
+  </div>
+
+  <div class="opt-title">Opción 2 — Conector de color (pestaña)</div>
+  <div class="opt-desc">Una pestaña del color del equipo en el borde interior del marcador, a la altura de su barra, "apuntando" a ella.</div>
+  <div class="stage">
+    <div class="sb2 opt2">
+      <div class="sb2-score home"><span class="sb2-points">21</span></div>
+      <div class="sb2-names">
+        <div class="sb2-bar home"><div class="sb2-sets">1</div></div>
+        <div class="sb2-bar away"><div class="sb2-sets">0</div></div>
+      </div>
+      <div class="sb2-score away"><span class="sb2-points">18</span></div>
+    </div>
+  </div>
+
+  <div class="opt-title">Opción 3 — Borde de color a media altura</div>
+  <div class="opt-desc">La franja de color del marcador solo cubre la mitad alineada con su barra (mitad superior = local, inferior = visitante).</div>
+  <div class="stage">
+    <div class="sb2 opt3">
+      <div class="sb2-score home"><span class="sb2-points">21</span></div>
+      <div class="sb2-names">
+        <div class="sb2-bar home"><div class="sb2-sets">1</div></div>
+        <div class="sb2-bar away"><div class="sb2-sets">0</div></div>
+      </div>
+      <div class="sb2-score away"><span class="sb2-points">18</span></div>
+    </div>
+  </div>
+
+  <div class="opt-title">Opción 4 — Número con color de equipo</div>
+  <div class="opt-desc">El número toma el color del equipo (igual que su barra), agrupando por color azul↔azul / naranja↔naranja.</div>
+  <div class="stage">
+    <div class="sb2 opt4">
+      <div class="sb2-score home"><span class="sb2-points">21</span></div>
+      <div class="sb2-names">
+        <div class="sb2-bar home"><div class="sb2-sets">1</div></div>
+        <div class="sb2-bar away"><div class="sb2-sets">0</div></div>
+      </div>
+      <div class="sb2-score away"><span class="sb2-points">18</span></div>
+    </div>
+  </div>
+
+  <div class="opt-title">Opción 5 — Combo (nº alineado + borde a media altura)</div>
+  <div class="opt-desc">Las dos pistas más baratas y fuertes juntas: alineación vertical + franja de color en la mitad correcta.</div>
+  <div class="stage">
+    <div class="sb2 opt5">
+      <div class="sb2-score home"><span class="sb2-points">21</span></div>
+      <div class="sb2-names">
+        <div class="sb2-bar home"><div class="sb2-sets">1</div></div>
+        <div class="sb2-bar away"><div class="sb2-sets">0</div></div>
+      </div>
+      <div class="sb2-score away"><span class="sb2-points">18</span></div>
+    </div>
+  </div>
+
+  <p class="note">
+    <strong>Nota:</strong> la pista elegida convive con el saque (que pinta
+    el borde de color del marcador). Si elegimos la <strong>Opción 3/5</strong>
+    (borde a media altura), el saque podría reforzar esa misma franja
+    —p.ej. borde tenue = solo desambiguación, borde brillante/lleno = saque—
+    para no duplicar elementos. Lo afinamos al implementar.
+  </p>
+</main>
+</body>
+</html>

--- a/docs/mockups/beach-twoline/fade.html
+++ b/docs/mockups/beach-twoline/fade.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8" />
+<title>Beach two-line — cola de desvanecimiento (espacio extra)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700;800;900&display=swap" rel="stylesheet" />
+<style>
+  :root { --pg-bg:#0d1117; --pg-text:#e6edf3; --pg-muted:#8b949e; --pg-border:rgba(255,255,255,.08); }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  body { background:var(--pg-bg); color:var(--pg-text); font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; padding:40px 28px 64px; }
+  main { max-width:1180px; margin:0 auto; }
+  h1 { font-size:26px; letter-spacing:-0.02em; margin-bottom:6px; }
+  .lead { color:var(--pg-muted); line-height:1.55; max-width:860px; margin-bottom:22px; }
+  .opt-title { font-size:15px; margin:30px 0 4px; color:var(--pg-text); font-weight:600; }
+  .opt-desc { color:var(--pg-muted); font-size:13px; line-height:1.5; margin-bottom:10px; max-width:820px; }
+  .stage {
+    border:1px solid var(--pg-border); border-radius:12px; overflow:hidden;
+    background:
+      linear-gradient(135deg, rgba(0,0,0,.35), rgba(0,0,0,.55)),
+      repeating-conic-gradient(#1b2230 0% 25%, #232c3d 0% 50%) 50% / 36px 36px,
+      linear-gradient(160deg,#2b5876,#4e4376);
+    padding:44px 48px; display:flex; align-items:flex-end; justify-content:flex-start; min-height:220px;
+  }
+
+  /* ── Shared two-line scoreboard core ───────────────────────────────── */
+  .sb2 {
+    --home-primary:#0077B6; --home-secondary:#FFFFFF;
+    --away-primary:#F4A300; --away-secondary:#1A1A1A;
+    --score-bg:#FFFFFF; --score-text:#111111;
+    --bar-height:60px; --bar-gap:8px;
+    --fade-tail: 70px;   /* EXTRA space appended at the inner end that fades out */
+    font-family:'Montserrat',sans-serif; display:flex; flex-direction:row; align-items:stretch; gap:12px; color:#fff;
+  }
+  .sb2-score {
+    width:132px; height:calc(var(--bar-height)*2 + var(--bar-gap));
+    display:flex; align-items:center; justify-content:center; position:relative; overflow:hidden;
+    background:var(--score-bg); color:var(--score-text); border-radius:14px;
+    box-shadow:0 10px 26px rgba(0,0,0,.45); flex-shrink:0;
+  }
+  .sb2-points { font-size:78px; font-weight:900; line-height:1; font-variant-numeric:tabular-nums; }
+
+  .sb2-names { display:flex; flex-direction:column; gap:var(--bar-gap); align-items:flex-start; }
+  .sb2-bar {
+    height:var(--bar-height); border-radius:10px; overflow:hidden;
+    box-shadow:0 6px 16px rgba(0,0,0,.4); display:flex; align-items:center; gap:12px; padding:0 6px; position:relative;
+  }
+  /* The fade lives in an EXTRA spacer (.sb2-tail) added at the inner end —
+     the end toward the OTHER team's score. Only that added space tapers to
+     transparent, so sets/name never lose pixels. The mask fades exactly the
+     tail width (fixed px), leaving the content region fully solid.          */
+  .sb2-tail { width:var(--fade-tail); flex-shrink:0; align-self:stretch; }
+  .sb2-bar.home {
+    flex-direction:row;
+    background:linear-gradient(100deg,var(--home-primary),color-mix(in srgb,var(--home-primary) 80%,#000));
+    -webkit-mask-image: linear-gradient(to right, #000 calc(100% - var(--fade-tail)), transparent 100%);
+            mask-image: linear-gradient(to right, #000 calc(100% - var(--fade-tail)), transparent 100%);
+  }
+  .sb2-bar.away {
+    flex-direction:row-reverse; align-self:flex-end;
+    background:linear-gradient(260deg,var(--away-primary),color-mix(in srgb,var(--away-primary) 80%,#000));
+    -webkit-mask-image: linear-gradient(to left, #000 calc(100% - var(--fade-tail)), transparent 100%);
+            mask-image: linear-gradient(to left, #000 calc(100% - var(--fade-tail)), transparent 100%);
+  }
+  .sb2-sets {
+    min-width:42px; height:42px; padding:0 10px; border-radius:9px;
+    display:flex; align-items:center; justify-content:center; font-size:30px; font-weight:900; line-height:1;
+    background:rgba(0,0,0,.28); color:#fff; font-variant-numeric:tabular-nums; flex-shrink:0;
+  }
+  .sb2-name {
+    flex:1; padding:0 14px; font-size:26px; font-weight:800; text-transform:uppercase; letter-spacing:1px;
+    line-height:1; white-space:nowrap; overflow:hidden; text-shadow:1px 2px 3px rgba(0,0,0,.35);
+  }
+  .sb2-bar.home .sb2-name { color:var(--home-secondary); text-align:right; }
+  .sb2-bar.away .sb2-name { color:var(--away-secondary); text-align:left; }
+
+  /* simple-mode bars shrink to content (+ the fade tail) & hug their score */
+  .simple .sb2-bar { width:auto; }
+  .simple .sb2-name { display:none; }
+
+  .tail-sm { --fade-tail: 48px; }
+  .tail-md { --fade-tail: 70px; }
+  .tail-lg { --fade-tail: 96px; }
+
+  .note { color:var(--pg-muted); font-size:13px; line-height:1.55; margin-top:28px; padding-top:18px; border-top:1px solid var(--pg-border); }
+  .note strong { color:var(--pg-text); }
+</style>
+</head>
+<body>
+<main>
+  <h1>Cola de desvanecimiento — espacio extra que no toca el contenido</h1>
+  <p class="lead">
+    Ahora el fundido es un <strong>espacio a mayores</strong> añadido en el
+    borde interior de la barra (hacia el número del marcador del otro equipo):
+    solo esa cola se desvanece a transparente, así que <strong>sets y nombre
+    quedan intactos</strong>. La barra se "despega" del marcador contrario sin
+    perder legibilidad. Local arriba (azul), visitante abajo (naranja).
+    Intensidad media por defecto; abajo comparo tres longitudes de cola.
+  </p>
+
+  <div class="opt-title">Expandido · cola media (70px)</div>
+  <div class="stage">
+    <div class="sb2 tail-md" style="--name-bar-width:340px;">
+      <div class="sb2-score home"><span class="sb2-points">21</span></div>
+      <div class="sb2-names">
+        <div class="sb2-bar home" style="width:340px;"><div class="sb2-sets">1</div><div class="sb2-name">Thunder Wolves</div><div class="sb2-tail"></div></div>
+        <div class="sb2-bar away" style="width:340px;"><div class="sb2-sets">0</div><div class="sb2-name">Solar Hawks</div><div class="sb2-tail"></div></div>
+      </div>
+      <div class="sb2-score away"><span class="sb2-points">18</span></div>
+    </div>
+  </div>
+
+  <div class="opt-title">Simple sin icono · cola media (70px)</div>
+  <div class="opt-desc">El caso que querías resolver: la cola fundida separa cada barra del marcador contrario, dejando los sets totalmente sólidos.</div>
+  <div class="stage">
+    <div class="sb2 simple tail-md">
+      <div class="sb2-score home"><span class="sb2-points">21</span></div>
+      <div class="sb2-names">
+        <div class="sb2-bar home"><div class="sb2-sets">1</div><div class="sb2-tail"></div></div>
+        <div class="sb2-bar away"><div class="sb2-sets">0</div><div class="sb2-tail"></div></div>
+      </div>
+      <div class="sb2-score away"><span class="sb2-points">18</span></div>
+    </div>
+  </div>
+
+  <div class="opt-title">Simple con icono · cola media (70px)</div>
+  <div class="opt-desc">Comprobación con icono: el degradado queda después del icono, sin tocarlo.</div>
+  <div class="stage">
+    <div class="sb2 simple tail-md">
+      <div class="sb2-score home"><span class="sb2-points">21</span></div>
+      <div class="sb2-names">
+        <div class="sb2-bar home">
+          <div class="sb2-sets">1</div>
+          <div style="width:48px;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.2);border-radius:8px;flex-shrink:0;"><img src="data:image/svg+xml;utf8,&lt;svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'&gt;&lt;circle cx='20' cy='20' r='18' fill='%23ffffff'/&gt;&lt;text x='20' y='26' font-size='16' font-family='Montserrat,sans-serif' font-weight='900' text-anchor='middle' fill='%230077B6'&gt;L&lt;/text&gt;&lt;/svg&gt;" style="max-width:40px;max-height:40px;" alt="" /></div>
+          <div class="sb2-tail"></div>
+        </div>
+        <div class="sb2-bar away">
+          <div class="sb2-sets">0</div>
+          <div style="width:48px;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.2);border-radius:8px;flex-shrink:0;"><img src="data:image/svg+xml;utf8,&lt;svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'&gt;&lt;circle cx='20' cy='20' r='18' fill='%231a1a1a'/&gt;&lt;text x='20' y='26' font-size='16' font-family='Montserrat,sans-serif' font-weight='900' text-anchor='middle' fill='%23F4A300'&gt;V&lt;/text&gt;&lt;/svg&gt;" style="max-width:40px;max-height:40px;" alt="" /></div>
+          <div class="sb2-tail"></div>
+        </div>
+      </div>
+      <div class="sb2-score away"><span class="sb2-points">18</span></div>
+    </div>
+  </div>
+
+  <div class="opt-title">Comparativa de longitud de cola (simple sin icono): 48 · 70 · 96px</div>
+  <div class="stage" style="gap:40px;flex-wrap:wrap;">
+    <div class="sb2 simple tail-sm">
+      <div class="sb2-score home"><span class="sb2-points">21</span></div>
+      <div class="sb2-names">
+        <div class="sb2-bar home"><div class="sb2-sets">1</div><div class="sb2-tail"></div></div>
+        <div class="sb2-bar away"><div class="sb2-sets">0</div><div class="sb2-tail"></div></div>
+      </div>
+      <div class="sb2-score away"><span class="sb2-points">18</span></div>
+    </div>
+    <div class="sb2 simple tail-md">
+      <div class="sb2-score home"><span class="sb2-points">21</span></div>
+      <div class="sb2-names">
+        <div class="sb2-bar home"><div class="sb2-sets">1</div><div class="sb2-tail"></div></div>
+        <div class="sb2-bar away"><div class="sb2-sets">0</div><div class="sb2-tail"></div></div>
+      </div>
+      <div class="sb2-score away"><span class="sb2-points">18</span></div>
+    </div>
+    <div class="sb2 simple tail-lg">
+      <div class="sb2-score home"><span class="sb2-points">21</span></div>
+      <div class="sb2-names">
+        <div class="sb2-bar home"><div class="sb2-sets">1</div><div class="sb2-tail"></div></div>
+        <div class="sb2-bar away"><div class="sb2-sets">0</div><div class="sb2-tail"></div></div>
+      </div>
+      <div class="sb2-score away"><span class="sb2-points">18</span></div>
+    </div>
+  </div>
+
+  <p class="note">
+    <strong>Nota:</strong> la cola es un <code>.sb2-tail</code> de ancho fijo
+    al final de la barra; la <code>mask-image</code> funde exactamente ese
+    ancho, por lo que el contenido nunca pierde píxeles. Como no afecta al
+    contenido, puede ir en ambos modos. El saque (línea de color del marcador)
+    es independiente y convive sin estorbar.
+  </p>
+</main>
+</body>
+</html>

--- a/docs/mockups/beach-twoline/fade.html
+++ b/docs/mockups/beach-twoline/fade.html
@@ -29,7 +29,7 @@
     --away-primary:#F4A300; --away-secondary:#1A1A1A;
     --score-bg:#FFFFFF; --score-text:#111111;
     --bar-height:60px; --bar-gap:8px;
-    --fade-tail: 70px;   /* EXTRA space appended at the inner end that fades out */
+    --fade-tail: 40px;   /* EXTRA space appended at the inner end that fades out */
     font-family:'Montserrat',sans-serif; display:flex; flex-direction:row; align-items:stretch; gap:12px; color:#fff;
   }
   .sb2-score {
@@ -78,9 +78,9 @@
   .simple .sb2-bar { width:auto; }
   .simple .sb2-name { display:none; }
 
-  .tail-sm { --fade-tail: 48px; }
-  .tail-md { --fade-tail: 70px; }
-  .tail-lg { --fade-tail: 96px; }
+  .tail-sm { --fade-tail: 28px; }
+  .tail-md { --fade-tail: 40px; }
+  .tail-lg { --fade-tail: 52px; }
 
   .note { color:var(--pg-muted); font-size:13px; line-height:1.55; margin-top:28px; padding-top:18px; border-top:1px solid var(--pg-border); }
   .note strong { color:var(--pg-text); }
@@ -98,7 +98,7 @@
     Intensidad media por defecto; abajo comparo tres longitudes de cola.
   </p>
 
-  <div class="opt-title">Expandido · cola media (70px)</div>
+  <div class="opt-title">Expandido · cola corta (40px)</div>
   <div class="stage">
     <div class="sb2 tail-md" style="--name-bar-width:340px;">
       <div class="sb2-score home"><span class="sb2-points">21</span></div>
@@ -110,7 +110,7 @@
     </div>
   </div>
 
-  <div class="opt-title">Simple sin icono · cola media (70px)</div>
+  <div class="opt-title">Simple sin icono · cola corta (40px)</div>
   <div class="opt-desc">El caso que querías resolver: la cola fundida separa cada barra del marcador contrario, dejando los sets totalmente sólidos.</div>
   <div class="stage">
     <div class="sb2 simple tail-md">
@@ -123,7 +123,7 @@
     </div>
   </div>
 
-  <div class="opt-title">Simple con icono · cola media (70px)</div>
+  <div class="opt-title">Simple con icono · cola corta (40px)</div>
   <div class="opt-desc">Comprobación con icono: el degradado queda después del icono, sin tocarlo.</div>
   <div class="stage">
     <div class="sb2 simple tail-md">
@@ -144,7 +144,7 @@
     </div>
   </div>
 
-  <div class="opt-title">Comparativa de longitud de cola (simple sin icono): 48 · 70 · 96px</div>
+  <div class="opt-title">Comparativa de longitud de cola (simple sin icono): 28 · 40 · 52px</div>
   <div class="stage" style="gap:40px;flex-wrap:wrap;">
     <div class="sb2 simple tail-sm">
       <div class="sb2-score home"><span class="sb2-points">21</span></div>

--- a/docs/mockups/beach-twoline/index.html
+++ b/docs/mockups/beach-twoline/index.html
@@ -192,15 +192,21 @@
   .sb2-bar.away .sb2-name { color: var(--away-secondary); text-align: left; }
 
   /* ── Mode toggles ──────────────────────────────────────────────────
-     Expanded → name only (logo hidden).
+     Expanded → name only (logo hidden). The name width is auto-fit by
+                the inline script below (mirrors fitBeachNames()), so long
+                names show in full instead of clipping with an ellipsis.
      Simple   → logo only if present (name hidden); empty logos collapse,
-                so a team without a logo shows just its sets numeral. */
+                so a team without a logo shows just its sets numeral. Each
+                bar shrinks to its content and hugs its own score card, so
+                the icon sits flush against the inner edge (no dead space). */
   .sb2.expanded .sb2-logo { display: none; }
 
   .sb2.simple .sb2-name { display: none; }
   .sb2.simple .sb2-logo.empty { display: none; }
-  /* Without a name the bars need far less width — keep them tidy. */
-  .sb2.simple { --name-bar-width: 150px; }
+  /* Fit each simple-mode bar to its content and pin it to its score card. */
+  .sb2.simple .sb2-names { align-items: flex-start; }
+  .sb2.simple .sb2-bar { width: auto; }
+  .sb2.simple .sb2-bar.away { align-self: flex-end; }
 
   .note { color: var(--pg-muted); font-size: 13px; line-height: 1.55; margin-top: 22px; padding-top: 18px; border-top: 1px solid var(--pg-border); }
   .note strong { color: var(--pg-text); }
@@ -244,18 +250,18 @@
   <!-- ── Expanded mode, long name, away serving ── -->
   <div class="stage-label">Expandido · nombre largo · saque del VISITANTE (línea roja en su marcador)</div>
   <div class="stage bottom-left">
-    <div class="sb2 expanded" style="--home-primary:#1f6f3b; --home-secondary:#FFFFFF; --away-primary:#C0392B; --away-secondary:#FFFFFF; --name-bar-width:430px;">
+    <div class="sb2 expanded" style="--home-primary:#1f6f3b; --home-secondary:#FFFFFF; --away-primary:#C0392B; --away-secondary:#FFFFFF;">
       <div class="sb2-score home"><span class="sb2-points">9</span></div>
       <div class="sb2-names">
         <div class="sb2-bar home">
           <div class="sb2-sets">0</div>
           <div class="sb2-logo"><img src="data:image/svg+xml;utf8,&lt;svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'&gt;&lt;circle cx='20' cy='20' r='18' fill='%23ffffff'/&gt;&lt;text x='20' y='26' font-size='14' font-family='Montserrat,sans-serif' font-weight='900' text-anchor='middle' fill='%231f6f3b'&gt;OUR&lt;/text&gt;&lt;/svg&gt;" alt="" /></div>
-          <div class="sb2-name" style="font-size:22px;">Club Ourense Voleib Praia</div>
+          <div class="sb2-name">Club Ourense Voleib Praia</div>
         </div>
         <div class="sb2-bar away">
           <div class="sb2-sets">1</div>
           <div class="sb2-logo"><img src="data:image/svg+xml;utf8,&lt;svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'&gt;&lt;circle cx='20' cy='20' r='18' fill='%23ffffff'/&gt;&lt;text x='20' y='26' font-size='15' font-family='Montserrat,sans-serif' font-weight='900' text-anchor='middle' fill='%23C0392B'&gt;CV&lt;/text&gt;&lt;/svg&gt;" alt="" /></div>
-          <div class="sb2-name" style="font-size:22px;">Voley Vigo</div>
+          <div class="sb2-name">Voley Vigo</div>
         </div>
       </div>
       <div class="sb2-score away serving"><span class="sb2-points">13</span></div>
@@ -296,5 +302,60 @@
     nombre en modo expandido.
   </p>
 </main>
+
+<script>
+  // Mirrors fitBeachNames() from app.js so the mockup behaves like the real
+  // overlay: each expanded board grows BOTH name bars to fit the longer of
+  // the two names (symmetric) and only shrinks the font when the longest
+  // name would exceed the max bar width — never truncating with an ellipsis.
+  // Measured step-by-step because the fixed 1px letter-spacing does not
+  // scale proportionally with the font size.
+  const BASE_FONT = 26, MIN_FONT = 16, MIN_BAR = 220, MAX_BAR = 460, PAD = 28 + 42 + 12 + 12;
+  // PAD ≈ name h-padding (2*14) + sets (~42) + logo-gap budget; the script
+  // measures live so this is only a starting allowance for the bar chrome.
+
+  function measure(text, fontSize) {
+    let m = document.getElementById('sb2-measure');
+    if (!m) {
+      m = document.createElement('span');
+      m.id = 'sb2-measure';
+      Object.assign(m.style, {
+        position: 'absolute', left: '-9999px', top: '0', visibility: 'hidden',
+        whiteSpace: 'nowrap', fontFamily: "'Montserrat', sans-serif",
+        fontWeight: '800', textTransform: 'uppercase', letterSpacing: '1px',
+      });
+      document.body.appendChild(m);
+    }
+    m.style.fontSize = fontSize + 'px';
+    m.textContent = text || '';
+    return m.offsetWidth;
+  }
+
+  function fitExpanded(sb2) {
+    const names = [...sb2.querySelectorAll('.sb2-name')];
+    if (!names.length) return;
+    // Width available for text inside a bar = bar width − non-name chrome.
+    // Measure the actual non-name chrome from the first bar so PAD is exact.
+    const bar = sb2.querySelector('.sb2-bar');
+    const chrome = [...bar.children].reduce((w, el) =>
+      el.classList.contains('sb2-name') ? w : w + el.offsetWidth, 0)
+      + 28 /* name h-padding */ + 24 /* gaps */;
+
+    let font = BASE_FONT;
+    const longest = () => Math.max(...names.map(n => measure(n.textContent, font)));
+    const maxContent = MAX_BAR - chrome;
+    while (longest() > maxContent && font > MIN_FONT) font -= 1;
+    names.forEach(n => { n.style.fontSize = font + 'px'; });
+
+    const barW = Math.min(MAX_BAR, Math.max(MIN_BAR, Math.ceil(longest()) + chrome + 4));
+    sb2.style.setProperty('--name-bar-width', barW + 'px');
+  }
+
+  function fitAll() {
+    document.querySelectorAll('.sb2.expanded').forEach(fitExpanded);
+  }
+  document.fonts ? document.fonts.ready.then(fitAll) : fitAll();
+  fitAll();
+</script>
 </body>
 </html>

--- a/docs/mockups/beach-twoline/index.html
+++ b/docs/mockups/beach-twoline/index.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Beach overlay — variante dos líneas (mockup)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700;800;900&display=swap" rel="stylesheet" />
+<style>
+  /* ── Page chrome (mockup only — not part of the overlay) ───────────── */
+  :root {
+    --pg-bg: #0d1117;
+    --pg-text: #e6edf3;
+    --pg-muted: #8b949e;
+    --pg-border: rgba(255, 255, 255, 0.08);
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--pg-bg);
+    color: var(--pg-text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    min-height: 100vh;
+    padding: 40px 28px 64px;
+  }
+  main { max-width: 1180px; margin: 0 auto; }
+  h1 { font-size: 28px; letter-spacing: -0.02em; margin-bottom: 6px; }
+  .lead { color: var(--pg-muted); line-height: 1.55; max-width: 820px; margin-bottom: 26px; }
+  .lead code {
+    background: rgba(255, 255, 255, 0.06);
+    padding: 1px 6px; border-radius: 4px;
+    font-family: 'Menlo', 'Consolas', monospace; font-size: 0.9em;
+  }
+  .stage-label { color: var(--pg-muted); font-size: 13px; margin: 28px 0 10px; text-transform: uppercase; letter-spacing: 1px; }
+  /* A "broadcast-like" backdrop so the transparent overlay reads as it
+     would over live video. The checker hints at OBS transparency. */
+  .stage {
+    border: 1px solid var(--pg-border);
+    border-radius: 12px;
+    overflow: hidden;
+    background:
+      linear-gradient(135deg, rgba(0,0,0,0.35), rgba(0,0,0,0.55)),
+      repeating-conic-gradient(#1b2230 0% 25%, #232c3d 0% 50%) 50% / 36px 36px,
+      linear-gradient(160deg, #2b5876, #4e4376);
+    padding: 60px 56px;
+    display: flex;
+    align-items: flex-end;
+    min-height: 320px;
+  }
+  .stage.bottom-left { align-items: flex-end; justify-content: flex-start; }
+
+  /* ════════════════════════════════════════════════════════════════════
+     OVERLAY — "beach two-line" scoreboard
+     Left → right:  [HOME score]  ·  [two name bars]  ·  [AWAY score]
+     The two score cards each span the full height of the two stacked
+     name bars (top = home: name→logo, bottom = away: logo→name).
+     Palette + type mirror the existing beach.css.
+     ════════════════════════════════════════════════════════════════════ */
+  .sb2 {
+    /* Team colours (defaults match beach.css; JS overrides at runtime) */
+    --home-primary: #0077B6;
+    --home-secondary: #FFFFFF;
+    --away-primary: #F4A300;
+    --away-secondary: #1A1A1A;
+    --serve-glow: #FFDD00;
+
+    --score-bg: #FFFFFF;
+    --score-text: #111111;
+    --bar-height: 60px;        /* one name bar */
+    --bar-gap: 8px;            /* gap between the two bars */
+    --name-bar-width: 360px;   /* both bars share this (JS fits to longest) */
+
+    font-family: 'Montserrat', sans-serif;
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    gap: 12px;
+    color: #fff;
+  }
+
+  /* ── Score cards — tall, span both name bars ───────────────────────── */
+  .sb2-score {
+    width: 132px;
+    /* exactly the height of the two stacked bars + the gap between them */
+    height: calc(var(--bar-height) * 2 + var(--bar-gap));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    overflow: hidden;
+    background: var(--score-bg);
+    color: var(--score-text);
+    border-radius: 14px;
+    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.45);
+    flex-shrink: 0;
+  }
+  /* A coloured cap ties each card to its team (left edge here, since the
+     cards flank the names horizontally). */
+  .sb2-score::before {
+    content: "";
+    position: absolute;
+    top: 0; bottom: 0;
+    width: 9px;
+  }
+  .sb2-score.home::before { left: 0; background: var(--home-primary); }
+  .sb2-score.away::before { right: 0; background: var(--away-primary); }
+  .sb2-points {
+    font-size: 82px;
+    font-weight: 900;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* ── Centre: two stacked name bars ─────────────────────────────────── */
+  /* Each team groups ALL its info next to its OWN score card. Order, from
+     closest to that team's score outward to the centre:
+        sets (big numerals) → logo → serving indicator → name
+     So the names end up on the inner edge and nothing from the rival
+     appears on the wrong side of your score. */
+  .sb2-names {
+    display: flex;
+    flex-direction: column;
+    gap: var(--bar-gap);
+    flex-shrink: 0;
+  }
+  .sb2-bar {
+    height: var(--bar-height);
+    width: var(--name-bar-width);
+    border-radius: 10px;
+    overflow: hidden;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 0 6px;
+    position: relative;
+  }
+  .sb2-bar.home {
+    /* score is to the LEFT → sets,logo,serve,name read left→right */
+    flex-direction: row;
+    background: linear-gradient(100deg, var(--home-primary), color-mix(in srgb, var(--home-primary) 80%, #000));
+  }
+  .sb2-bar.away {
+    /* score is to the RIGHT → mirror so sets sits next to it */
+    flex-direction: row-reverse;
+    background: linear-gradient(260deg, var(--away-primary), color-mix(in srgb, var(--away-primary) 80%, #000));
+  }
+
+  /* Sets-won — promoted to a large numeral, sitting closest to the score. */
+  .sb2-sets {
+    min-width: 42px; height: 42px; padding: 0 10px;
+    border-radius: 9px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 30px; font-weight: 900; line-height: 1;
+    background: rgba(0, 0, 0, 0.28);
+    color: #fff;
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+
+  .sb2-logo {
+    width: 48px;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.20);
+    border-radius: 8px;
+    flex-shrink: 0;
+  }
+  .sb2-logo img { max-width: 40px; max-height: 40px; object-fit: contain; filter: drop-shadow(0 2px 4px rgba(0,0,0,0.4)); }
+
+  /* serving indicator — slim glowing bar between the logo and the name */
+  .sb2-bar .serve {
+    width: 6px; height: 60%;
+    border-radius: 3px;
+    flex-shrink: 0;
+    background-color: rgba(255, 255, 255, 0.16);
+  }
+  .sb2-bar.home.serving .serve {
+    background-color: var(--home-secondary);
+    box-shadow: 0 0 12px var(--home-secondary);
+  }
+  .sb2-bar.away.serving .serve {
+    background-color: var(--away-secondary);
+    box-shadow: 0 0 12px var(--away-secondary);
+  }
+
+  .sb2-name {
+    flex: 1;
+    padding: 0 14px;
+    font-size: 26px;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    line-height: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-shadow: 1px 2px 3px rgba(0, 0, 0, 0.35);
+  }
+  /* name hugs the inner (centre) edge of each bar */
+  .sb2-bar.home .sb2-name { color: var(--home-secondary); text-align: right; }
+  .sb2-bar.away .sb2-name { color: var(--away-secondary); text-align: left; }
+
+  .variants { display: flex; flex-direction: column; gap: 8px; }
+  .note { color: var(--pg-muted); font-size: 13px; line-height: 1.55; margin-top: 22px; padding-top: 18px; border-top: 1px solid var(--pg-border); }
+</style>
+</head>
+<body>
+<main>
+  <h1>Beach overlay — variante "dos líneas" (mockup)</h1>
+  <p class="lead">
+    De izquierda a derecha: <strong>marcador local</strong> (alto = las dos
+    barras), las <strong>dos barras</strong> apiladas (arriba local, abajo
+    visitante) y el <strong>marcador visitante</strong> (mismo alto). Cada
+    equipo agrupa <strong>toda su info junto a su propio marcador</strong>,
+    en orden de más próximo a más lejano del marcador:
+    <strong>sets (números grandes) → icono → saque → nombre</strong>. Así el
+    nombre queda en el borde interior y nada del rival aparece al otro lado
+    de tu marcador. Tipografía y paleta heredadas de <code>beach.css</code>.
+    Preview estático para validar la composición antes de implementarlo.
+  </p>
+
+  <!-- Variante A: colores por defecto, nombres cortos -->
+  <div class="stage-label">A · Nombres cortos · saque del local</div>
+  <div class="stage bottom-left">
+    <div class="sb2">
+      <div class="sb2-score home"><span class="sb2-points">21</span></div>
+      <div class="sb2-names">
+        <div class="sb2-bar home serving">
+          <div class="sb2-sets">1</div>
+          <div class="sb2-logo"><img src="data:image/svg+xml;utf8,&lt;svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'&gt;&lt;circle cx='20' cy='20' r='18' fill='%23ffffff'/&gt;&lt;text x='20' y='26' font-size='16' font-family='Montserrat,sans-serif' font-weight='900' text-anchor='middle' fill='%230077B6'&gt;L&lt;/text&gt;&lt;/svg&gt;" alt="" /></div>
+          <div class="serve"></div>
+          <div class="sb2-name">Thunder Wolves</div>
+        </div>
+        <div class="sb2-bar away">
+          <div class="sb2-sets">0</div>
+          <div class="sb2-logo"><img src="data:image/svg+xml;utf8,&lt;svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'&gt;&lt;circle cx='20' cy='20' r='18' fill='%231a1a1a'/&gt;&lt;text x='20' y='26' font-size='16' font-family='Montserrat,sans-serif' font-weight='900' text-anchor='middle' fill='%23F4A300'&gt;V&lt;/text&gt;&lt;/svg&gt;" alt="" /></div>
+          <div class="serve"></div>
+          <div class="sb2-name">Solar Hawks</div>
+        </div>
+      </div>
+      <div class="sb2-score away"><span class="sb2-points">18</span></div>
+    </div>
+  </div>
+
+  <!-- Variante B: nombre largo (caso "Club Ourense Voleib Praia") -->
+  <div class="stage-label">B · Nombre largo · saque del visitante</div>
+  <div class="stage bottom-left">
+    <div class="sb2" style="--home-primary:#1f6f3b; --home-secondary:#FFFFFF; --away-primary:#C0392B; --away-secondary:#FFFFFF; --name-bar-width:430px;">
+      <div class="sb2-score home"><span class="sb2-points">9</span></div>
+      <div class="sb2-names">
+        <div class="sb2-bar home">
+          <div class="sb2-sets">0</div>
+          <div class="sb2-logo"><img src="data:image/svg+xml;utf8,&lt;svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'&gt;&lt;circle cx='20' cy='20' r='18' fill='%23ffffff'/&gt;&lt;text x='20' y='26' font-size='14' font-family='Montserrat,sans-serif' font-weight='900' text-anchor='middle' fill='%231f6f3b'&gt;OUR&lt;/text&gt;&lt;/svg&gt;" alt="" /></div>
+          <div class="serve"></div>
+          <div class="sb2-name" style="font-size:22px;">Club Ourense Voleib Praia</div>
+        </div>
+        <div class="sb2-bar away serving">
+          <div class="sb2-sets">1</div>
+          <div class="sb2-logo"><img src="data:image/svg+xml;utf8,&lt;svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'&gt;&lt;circle cx='20' cy='20' r='18' fill='%23ffffff'/&gt;&lt;text x='20' y='26' font-size='15' font-family='Montserrat,sans-serif' font-weight='900' text-anchor='middle' fill='%23C0392B'&gt;CV&lt;/text&gt;&lt;/svg&gt;" alt="" /></div>
+          <div class="serve"></div>
+          <div class="sb2-name" style="font-size:22px;">Voley Vigo</div>
+        </div>
+      </div>
+      <div class="sb2-score away"><span class="sb2-points">13</span></div>
+    </div>
+  </div>
+
+  <p class="note">
+    <strong>Notas de implementación (pendiente de tu OK):</strong>
+    serían un template nuevo <code>beach_twoline.html</code> + CSS
+    <code>beach_twoline.css</code> autodescubiertos por el motor de overlays
+    (como el resto de estilos). Reutilizaría el mismo
+    <code>fitBeachNames()</code> de <code>app.js</code> para ajustar el ancho
+    de barra al nombre más largo (los dos lados simétricos), y los mismos
+    resaltados por color de equipo. La altura de cada tarjeta de marcador se
+    calcula como <code>2·barra + gap</code> para cuadrar exactamente con las
+    dos barras. Los <code>sets</code>/saque mostrados son opcionales: dime si
+    los quieres dentro o los dejo fuera para una composición más limpia.
+  </p>
+</main>
+</body>
+</html>

--- a/docs/mockups/beach-twoline/index.html
+++ b/docs/mockups/beach-twoline/index.html
@@ -24,7 +24,7 @@
   }
   main { max-width: 1180px; margin: 0 auto; }
   h1 { font-size: 28px; letter-spacing: -0.02em; margin-bottom: 6px; }
-  .lead { color: var(--pg-muted); line-height: 1.55; max-width: 820px; margin-bottom: 26px; }
+  .lead { color: var(--pg-muted); line-height: 1.55; max-width: 860px; margin-bottom: 26px; }
   .lead code {
     background: rgba(255, 255, 255, 0.06);
     padding: 1px 6px; border-radius: 4px;
@@ -44,7 +44,7 @@
     padding: 60px 56px;
     display: flex;
     align-items: flex-end;
-    min-height: 320px;
+    min-height: 300px;
   }
   .stage.bottom-left { align-items: flex-end; justify-content: flex-start; }
 
@@ -52,8 +52,16 @@
      OVERLAY — "beach two-line" scoreboard
      Left → right:  [HOME score]  ·  [two name bars]  ·  [AWAY score]
      The two score cards each span the full height of the two stacked
-     name bars (top = home: name→logo, bottom = away: logo→name).
-     Palette + type mirror the existing beach.css.
+     bars (top = home, bottom = away). Palette + type mirror beach.css.
+
+     Per-team grouping, from each team's own score outward to the centre:
+        sets (big numerals) → logo → name
+
+     · Expanded mode  → NAME only (logo hidden)
+     · Simple mode    → LOGO only, if it exists (name hidden)
+     · Serving        → shown by the coloured line decorating the SCORE
+                        card: serving team = coloured line, otherwise the
+                        card is fully white. (No serve bar inside the bars.)
      ════════════════════════════════════════════════════════════════════ */
   .sb2 {
     /* Team colours (defaults match beach.css; JS overrides at runtime) */
@@ -61,7 +69,6 @@
     --home-secondary: #FFFFFF;
     --away-primary: #F4A300;
     --away-secondary: #1A1A1A;
-    --serve-glow: #FFDD00;
 
     --score-bg: #FFFFFF;
     --score-text: #111111;
@@ -77,10 +84,9 @@
     color: #fff;
   }
 
-  /* ── Score cards — tall, span both name bars ───────────────────────── */
+  /* ── Score cards — tall, span both bars ────────────────────────────── */
   .sb2-score {
     width: 132px;
-    /* exactly the height of the two stacked bars + the gap between them */
     height: calc(var(--bar-height) * 2 + var(--bar-gap));
     display: flex;
     align-items: center;
@@ -93,16 +99,20 @@
     box-shadow: 0 10px 26px rgba(0, 0, 0, 0.45);
     flex-shrink: 0;
   }
-  /* A coloured cap ties each card to its team (left edge here, since the
-     cards flank the names horizontally). */
+  /* The coloured line on the score card is now the SERVING indicator:
+     transparent by default (white card), team-coloured when serving. */
   .sb2-score::before {
     content: "";
     position: absolute;
     top: 0; bottom: 0;
     width: 9px;
+    background: transparent;
+    transition: background 0.3s ease;
   }
-  .sb2-score.home::before { left: 0; background: var(--home-primary); }
-  .sb2-score.away::before { right: 0; background: var(--away-primary); }
+  .sb2-score.home::before { left: 0; }
+  .sb2-score.away::before { right: 0; }
+  .sb2-score.home.serving::before { background: var(--home-primary); }
+  .sb2-score.away.serving::before { background: var(--away-primary); }
   .sb2-points {
     font-size: 82px;
     font-weight: 900;
@@ -110,12 +120,7 @@
     font-variant-numeric: tabular-nums;
   }
 
-  /* ── Centre: two stacked name bars ─────────────────────────────────── */
-  /* Each team groups ALL its info next to its OWN score card. Order, from
-     closest to that team's score outward to the centre:
-        sets (big numerals) → logo → serving indicator → name
-     So the names end up on the inner edge and nothing from the rival
-     appears on the wrong side of your score. */
+  /* ── Centre: two stacked bars ──────────────────────────────────────── */
   .sb2-names {
     display: flex;
     flex-direction: column;
@@ -135,7 +140,7 @@
     position: relative;
   }
   .sb2-bar.home {
-    /* score is to the LEFT → sets,logo,serve,name read left→right */
+    /* score is to the LEFT → sets, logo, name read left→right */
     flex-direction: row;
     background: linear-gradient(100deg, var(--home-primary), color-mix(in srgb, var(--home-primary) 80%, #000));
   }
@@ -145,7 +150,7 @@
     background: linear-gradient(260deg, var(--away-primary), color-mix(in srgb, var(--away-primary) 80%, #000));
   }
 
-  /* Sets-won — promoted to a large numeral, sitting closest to the score. */
+  /* Sets-won — large numeral, sitting closest to the score. */
   .sb2-sets {
     min-width: 42px; height: 42px; padding: 0 10px;
     border-radius: 9px;
@@ -169,22 +174,6 @@
   }
   .sb2-logo img { max-width: 40px; max-height: 40px; object-fit: contain; filter: drop-shadow(0 2px 4px rgba(0,0,0,0.4)); }
 
-  /* serving indicator — slim glowing bar between the logo and the name */
-  .sb2-bar .serve {
-    width: 6px; height: 60%;
-    border-radius: 3px;
-    flex-shrink: 0;
-    background-color: rgba(255, 255, 255, 0.16);
-  }
-  .sb2-bar.home.serving .serve {
-    background-color: var(--home-secondary);
-    box-shadow: 0 0 12px var(--home-secondary);
-  }
-  .sb2-bar.away.serving .serve {
-    background-color: var(--away-secondary);
-    box-shadow: 0 0 12px var(--away-secondary);
-  }
-
   .sb2-name {
     flex: 1;
     padding: 0 14px;
@@ -202,41 +191,49 @@
   .sb2-bar.home .sb2-name { color: var(--home-secondary); text-align: right; }
   .sb2-bar.away .sb2-name { color: var(--away-secondary); text-align: left; }
 
-  .variants { display: flex; flex-direction: column; gap: 8px; }
+  /* ── Mode toggles ──────────────────────────────────────────────────
+     Expanded → name only (logo hidden).
+     Simple   → logo only if present (name hidden); empty logos collapse,
+                so a team without a logo shows just its sets numeral. */
+  .sb2.expanded .sb2-logo { display: none; }
+
+  .sb2.simple .sb2-name { display: none; }
+  .sb2.simple .sb2-logo.empty { display: none; }
+  /* Without a name the bars need far less width — keep them tidy. */
+  .sb2.simple { --name-bar-width: 150px; }
+
   .note { color: var(--pg-muted); font-size: 13px; line-height: 1.55; margin-top: 22px; padding-top: 18px; border-top: 1px solid var(--pg-border); }
+  .note strong { color: var(--pg-text); }
 </style>
 </head>
 <body>
 <main>
   <h1>Beach overlay — variante "dos líneas" (mockup)</h1>
   <p class="lead">
-    De izquierda a derecha: <strong>marcador local</strong> (alto = las dos
-    barras), las <strong>dos barras</strong> apiladas (arriba local, abajo
-    visitante) y el <strong>marcador visitante</strong> (mismo alto). Cada
-    equipo agrupa <strong>toda su info junto a su propio marcador</strong>,
-    en orden de más próximo a más lejano del marcador:
-    <strong>sets (números grandes) → icono → saque → nombre</strong>. Así el
-    nombre queda en el borde interior y nada del rival aparece al otro lado
-    de tu marcador. Tipografía y paleta heredadas de <code>beach.css</code>.
-    Preview estático para validar la composición antes de implementarlo.
+    Iteración: en <strong>modo expandido</strong> cada barra muestra solo el
+    <strong>nombre</strong> (sin icono); en <strong>modo simple</strong> solo
+    el <strong>icono</strong> (si existe). Se ha quitado la barrita de saque:
+    ahora el <strong>saque lo marca la línea de color que decora el marcador
+    de puntos</strong> — si el equipo tiene saque se ve la línea de color, y
+    si no, el marcador se ve todo blanco. Orden por equipo, de su marcador
+    hacia el centro: <strong>sets → icono/nombre</strong>. Paleta y tipografía
+    heredadas de <code>beach.css</code>.
   </p>
 
-  <!-- Variante A: colores por defecto, nombres cortos -->
-  <div class="stage-label">A · Nombres cortos · saque del local</div>
+  <!-- ── Expanded mode: names only, no icons. Home serving. ── -->
+  <div class="stage-label">Expandido · solo nombre · saque del LOCAL (línea azul en su marcador)</div>
   <div class="stage bottom-left">
-    <div class="sb2">
-      <div class="sb2-score home"><span class="sb2-points">21</span></div>
+    <div class="sb2 expanded">
+      <div class="sb2-score home serving"><span class="sb2-points">21</span></div>
       <div class="sb2-names">
-        <div class="sb2-bar home serving">
+        <div class="sb2-bar home">
           <div class="sb2-sets">1</div>
           <div class="sb2-logo"><img src="data:image/svg+xml;utf8,&lt;svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'&gt;&lt;circle cx='20' cy='20' r='18' fill='%23ffffff'/&gt;&lt;text x='20' y='26' font-size='16' font-family='Montserrat,sans-serif' font-weight='900' text-anchor='middle' fill='%230077B6'&gt;L&lt;/text&gt;&lt;/svg&gt;" alt="" /></div>
-          <div class="serve"></div>
           <div class="sb2-name">Thunder Wolves</div>
         </div>
         <div class="sb2-bar away">
           <div class="sb2-sets">0</div>
           <div class="sb2-logo"><img src="data:image/svg+xml;utf8,&lt;svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'&gt;&lt;circle cx='20' cy='20' r='18' fill='%231a1a1a'/&gt;&lt;text x='20' y='26' font-size='16' font-family='Montserrat,sans-serif' font-weight='900' text-anchor='middle' fill='%23F4A300'&gt;V&lt;/text&gt;&lt;/svg&gt;" alt="" /></div>
-          <div class="serve"></div>
           <div class="sb2-name">Solar Hawks</div>
         </div>
       </div>
@@ -244,40 +241,59 @@
     </div>
   </div>
 
-  <!-- Variante B: nombre largo (caso "Club Ourense Voleib Praia") -->
-  <div class="stage-label">B · Nombre largo · saque del visitante</div>
+  <!-- ── Expanded mode, long name, away serving ── -->
+  <div class="stage-label">Expandido · nombre largo · saque del VISITANTE (línea roja en su marcador)</div>
   <div class="stage bottom-left">
-    <div class="sb2" style="--home-primary:#1f6f3b; --home-secondary:#FFFFFF; --away-primary:#C0392B; --away-secondary:#FFFFFF; --name-bar-width:430px;">
+    <div class="sb2 expanded" style="--home-primary:#1f6f3b; --home-secondary:#FFFFFF; --away-primary:#C0392B; --away-secondary:#FFFFFF; --name-bar-width:430px;">
       <div class="sb2-score home"><span class="sb2-points">9</span></div>
       <div class="sb2-names">
         <div class="sb2-bar home">
           <div class="sb2-sets">0</div>
           <div class="sb2-logo"><img src="data:image/svg+xml;utf8,&lt;svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'&gt;&lt;circle cx='20' cy='20' r='18' fill='%23ffffff'/&gt;&lt;text x='20' y='26' font-size='14' font-family='Montserrat,sans-serif' font-weight='900' text-anchor='middle' fill='%231f6f3b'&gt;OUR&lt;/text&gt;&lt;/svg&gt;" alt="" /></div>
-          <div class="serve"></div>
           <div class="sb2-name" style="font-size:22px;">Club Ourense Voleib Praia</div>
         </div>
-        <div class="sb2-bar away serving">
+        <div class="sb2-bar away">
           <div class="sb2-sets">1</div>
           <div class="sb2-logo"><img src="data:image/svg+xml;utf8,&lt;svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'&gt;&lt;circle cx='20' cy='20' r='18' fill='%23ffffff'/&gt;&lt;text x='20' y='26' font-size='15' font-family='Montserrat,sans-serif' font-weight='900' text-anchor='middle' fill='%23C0392B'&gt;CV&lt;/text&gt;&lt;/svg&gt;" alt="" /></div>
-          <div class="serve"></div>
           <div class="sb2-name" style="font-size:22px;">Voley Vigo</div>
         </div>
       </div>
-      <div class="sb2-score away"><span class="sb2-points">13</span></div>
+      <div class="sb2-score away serving"><span class="sb2-points">13</span></div>
+    </div>
+  </div>
+
+  <!-- ── Simple mode: icons only (away has no logo → just its sets). ── -->
+  <div class="stage-label">Simple · solo icono · saque del LOCAL · el VISITANTE no tiene icono (solo sets)</div>
+  <div class="stage bottom-left">
+    <div class="sb2 simple">
+      <div class="sb2-score home serving"><span class="sb2-points">21</span></div>
+      <div class="sb2-names">
+        <div class="sb2-bar home">
+          <div class="sb2-sets">1</div>
+          <div class="sb2-logo"><img src="data:image/svg+xml;utf8,&lt;svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'&gt;&lt;circle cx='20' cy='20' r='18' fill='%23ffffff'/&gt;&lt;text x='20' y='26' font-size='16' font-family='Montserrat,sans-serif' font-weight='900' text-anchor='middle' fill='%230077B6'&gt;L&lt;/text&gt;&lt;/svg&gt;" alt="" /></div>
+          <div class="sb2-name">Thunder Wolves</div>
+        </div>
+        <div class="sb2-bar away">
+          <div class="sb2-sets">0</div>
+          <div class="sb2-logo empty"></div>
+          <div class="sb2-name">Solar Hawks</div>
+        </div>
+      </div>
+      <div class="sb2-score away"><span class="sb2-points">18</span></div>
     </div>
   </div>
 
   <p class="note">
     <strong>Notas de implementación (pendiente de tu OK):</strong>
-    serían un template nuevo <code>beach_twoline.html</code> + CSS
-    <code>beach_twoline.css</code> autodescubiertos por el motor de overlays
-    (como el resto de estilos). Reutilizaría el mismo
-    <code>fitBeachNames()</code> de <code>app.js</code> para ajustar el ancho
-    de barra al nombre más largo (los dos lados simétricos), y los mismos
-    resaltados por color de equipo. La altura de cada tarjeta de marcador se
-    calcula como <code>2·barra + gap</code> para cuadrar exactamente con las
-    dos barras. Los <code>sets</code>/saque mostrados son opcionales: dime si
-    los quieres dentro o los dejo fuera para una composición más limpia.
+    template nuevo <code>beach_twoline.html</code> + <code>beach_twoline.css</code>
+    autodescubiertos por el motor de overlays. El modo simple se ata al toggle
+    existente del operador (<code>show_only_current_set</code> →
+    <code>.compact-mode</code>); el icono solo se pinta si el equipo tiene
+    <code>logo_url</code>, y si no, su barra muestra solo el contador de sets.
+    El saque dejará de tener barrita propia: se reflejará pintando/ocultando
+    la línea de color del marcador (<code>.sb2-score.serving::before</code>).
+    Reutilizaría <code>fitBeachNames()</code> para el ajuste simétrico del
+    nombre en modo expandido.
   </p>
 </main>
 </body>

--- a/overlay_static/css/beach.css
+++ b/overlay_static/css/beach.css
@@ -162,8 +162,13 @@ body {
     font-size: 11px;
     font-weight: 700;
     letter-spacing: 1px;
-    opacity: 0.7;
+    opacity: 0.85;
 }
+
+/* The "SETS" label tracks each team's name colour so it keeps contrast
+   against the team's primary background (same colour as .team-name). */
+.team-home .team-meta::before { color: var(--home-secondary); }
+.team-away .team-meta::before { color: var(--away-secondary); }
 
 .timeout-container {
     display: flex;
@@ -178,9 +183,16 @@ body {
     transition: background 0.3s ease, box-shadow 0.3s ease;
 }
 
-.timeout-dot.active {
-    background: var(--serve-glow);
-    box-shadow: 0 0 8px var(--serve-glow);
+/* Active timeout dots glow in each team's name colour for contrast
+   against its own primary-coloured bar. */
+.team-home .timeout-dot.active {
+    background: var(--home-secondary);
+    box-shadow: 0 0 8px color-mix(in srgb, var(--home-secondary) 65%, transparent);
+}
+
+.team-away .timeout-dot.active {
+    background: var(--away-secondary);
+    box-shadow: 0 0 8px color-mix(in srgb, var(--away-secondary) 65%, transparent);
 }
 
 /* Serving indicator — a slim bar on the inner edge (facing the centre)
@@ -195,9 +207,16 @@ body {
     transition: background-color 0.3s ease, box-shadow 0.3s ease;
 }
 
-.serving-indicator.active {
-    background-color: var(--serve-glow);
-    box-shadow: 0 0 14px var(--serve-glow);
+/* The serving indicator lights up in the serving team's name colour so
+   it stays legible against that team's primary-coloured bar. */
+.team-home .serving-indicator.active {
+    background-color: var(--home-secondary);
+    box-shadow: 0 0 14px color-mix(in srgb, var(--home-secondary) 65%, transparent);
+}
+
+.team-away .serving-indicator.active {
+    background-color: var(--away-secondary);
+    box-shadow: 0 0 14px color-mix(in srgb, var(--away-secondary) 65%, transparent);
 }
 
 /* ── Centre: current-set score, two tall raised white cards ──────── */

--- a/overlay_static/css/beach.css
+++ b/overlay_static/css/beach.css
@@ -184,14 +184,17 @@ body {
 }
 
 /* Active timeout dots glow in each team's name colour for contrast
-   against its own primary-coloured bar. */
+   against its own primary-coloured bar. The solid box-shadow is a
+   fallback for OBS/CEF builds older than Chromium 111 (no color-mix). */
 .team-home .timeout-dot.active {
     background: var(--home-secondary);
+    box-shadow: 0 0 8px var(--home-secondary);
     box-shadow: 0 0 8px color-mix(in srgb, var(--home-secondary) 65%, transparent);
 }
 
 .team-away .timeout-dot.active {
     background: var(--away-secondary);
+    box-shadow: 0 0 8px var(--away-secondary);
     box-shadow: 0 0 8px color-mix(in srgb, var(--away-secondary) 65%, transparent);
 }
 
@@ -208,14 +211,17 @@ body {
 }
 
 /* The serving indicator lights up in the serving team's name colour so
-   it stays legible against that team's primary-coloured bar. */
+   it stays legible against that team's primary-coloured bar. The solid
+   box-shadow is a fallback for OBS/CEF builds older than Chromium 111. */
 .team-home .serving-indicator.active {
     background-color: var(--home-secondary);
+    box-shadow: 0 0 14px var(--home-secondary);
     box-shadow: 0 0 14px color-mix(in srgb, var(--home-secondary) 65%, transparent);
 }
 
 .team-away .serving-indicator.active {
     background-color: var(--away-secondary);
+    box-shadow: 0 0 14px var(--away-secondary);
     box-shadow: 0 0 14px color-mix(in srgb, var(--away-secondary) 65%, transparent);
 }
 

--- a/overlay_static/js/app.js
+++ b/overlay_static/js/app.js
@@ -594,6 +594,7 @@ const BEACH_NAME_MIN_FONT = 16;
 const BEACH_NAME_MIN_BAR = 260;
 const BEACH_NAME_MAX_BAR = 480;
 const BEACH_NAME_PADDING = 44;    // .name-bar horizontal padding (2 * 22px)
+let beachFontsHooked = false;
 
 // Measure the rendered width of a beach team name at a given font size with
 // an offscreen node, so the live (possibly clipped) element is untouched and
@@ -629,8 +630,8 @@ function fitBeachNames() {
 
     // The first measurement can land before the Montserrat webfont loads
     // (fallback metrics differ). Re-fit once it is ready, just once.
-    if (document.fonts && !window.__beachFontsHooked) {
-        window.__beachFontsHooked = true;
+    if (document.fonts && !beachFontsHooked) {
+        beachFontsHooked = true;
         document.fonts.ready.then(() => fitBeachNames());
     }
 

--- a/overlay_static/js/app.js
+++ b/overlay_static/js/app.js
@@ -279,6 +279,7 @@ function renderFullState(state) {
     withEl("home-name", el => { el.textContent = state.team_home.name; });
     withEl("away-name", el => { el.textContent = state.team_away.name; });
     equalizeNamePanels();
+    fitBeachNames();
 
     // 4b. Logo visibility toggle (from remote-scoreboard "Logos" setting).
     // Run before the per-logo URL branches so those have the final say on
@@ -400,6 +401,7 @@ function updateStateDiff(oldState, newState) {
     if (oldState.team_home.name !== newState.team_home.name ||
         oldState.team_away.name !== newState.team_away.name) {
         equalizeNamePanels();
+        fitBeachNames();
     }
 
     // Logo visibility toggle (runs before per-logo URL updates so the
@@ -490,6 +492,8 @@ function updateStateDiff(oldState, newState) {
         withEl("scoreboard-container", container => {
             container.classList.toggle("compact-mode", !!newState.match_info.show_only_current_set);
         });
+        // Re-fit beach names when they reappear leaving compact mode.
+        fitBeachNames();
     }
 
     // Set summary recap panel toggle / re-render. Re-render also on
@@ -573,6 +577,87 @@ function updateStateDiff(oldState, newState) {
     // helper restarts the keyframe via a forced reflow if the same
     // class re-applies on a rapid follow-up event.
     dispatchAlertTransitions(oldState, newState);
+}
+
+// ── Beach name fitting ───────────────────────────────────────────────
+// The beach board keeps both name bars symmetric. Rather than clipping a
+// long name with an ellipsis, widen both bars to fit the longer of the two
+// names, and only when that would exceed BEACH_NAME_MAX_BAR shrink the type
+// (down to BEACH_NAME_MIN_FONT) so the full name still shows. Both sides
+// always share the same width and font size.
+const BEACH_NAME_BASE_FONT = 29;  // matches .team-name font-size in beach.css
+const BEACH_NAME_MIN_FONT = 17;
+const BEACH_NAME_MIN_BAR = 260;
+const BEACH_NAME_MAX_BAR = 440;
+const BEACH_NAME_PADDING = 44;    // .name-bar horizontal padding (2 * 22px)
+
+// Measure the rendered width of a beach team name at a given font size with
+// an offscreen node, so the live (possibly clipped) element is untouched and
+// short names report their true width.
+function measureBeachName(text, fontSize) {
+    let m = document.getElementById("beach-name-measure");
+    if (!m) {
+        m = document.createElement("span");
+        m.id = "beach-name-measure";
+        m.style.position = "absolute";
+        m.style.left = "-9999px";
+        m.style.top = "0";
+        m.style.visibility = "hidden";
+        m.style.whiteSpace = "nowrap";
+        m.style.fontFamily = "'Montserrat', sans-serif";
+        m.style.fontWeight = "800";
+        m.style.textTransform = "uppercase";
+        m.style.letterSpacing = "1px";
+        document.body.appendChild(m);
+    }
+    m.style.fontSize = fontSize + "px";
+    m.textContent = text || "";
+    return m.offsetWidth;
+}
+
+function fitBeachNames() {
+    const container = document.getElementById("scoreboard-container");
+    const homeName = document.getElementById("home-name");
+    const awayName = document.getElementById("away-name");
+    if (!container || !homeName || !awayName) return;
+    // Only the beach template uses `.name-bar`; bail out for every other style.
+    if (!container.querySelector(".name-bar")) return;
+
+    // The first measurement can land before the Montserrat webfont loads
+    // (fallback metrics differ). Re-fit once it is ready, just once.
+    if (document.fonts && !window.__beachFontsHooked) {
+        window.__beachFontsHooked = true;
+        document.fonts.ready.then(() => fitBeachNames());
+    }
+
+    const homeText = homeName.textContent || "";
+    const awayText = awayName.textContent || "";
+
+    let fontSize = BEACH_NAME_BASE_FONT;
+    let maxText = Math.max(
+        measureBeachName(homeText, fontSize),
+        measureBeachName(awayText, fontSize)
+    );
+
+    // Shrink the type proportionally only when the longer name would overflow
+    // the widest bar we allow, never below the legibility floor.
+    const maxContent = BEACH_NAME_MAX_BAR - BEACH_NAME_PADDING;
+    if (maxText > maxContent) {
+        fontSize = Math.max(BEACH_NAME_MIN_FONT, fontSize * (maxContent / maxText));
+        maxText = Math.max(
+            measureBeachName(homeText, fontSize),
+            measureBeachName(awayText, fontSize)
+        );
+    }
+
+    homeName.style.fontSize = fontSize + "px";
+    awayName.style.fontSize = fontSize + "px";
+
+    const barWidth = Math.min(
+        BEACH_NAME_MAX_BAR,
+        Math.max(BEACH_NAME_MIN_BAR, Math.ceil(maxText) + BEACH_NAME_PADDING + 2)
+    );
+    container.style.setProperty("--name-bar-width", barWidth + "px");
 }
 
 function equalizeNamePanels() {

--- a/overlay_static/js/app.js
+++ b/overlay_static/js/app.js
@@ -586,9 +586,9 @@ function updateStateDiff(oldState, newState) {
 // (down to BEACH_NAME_MIN_FONT) so the full name still shows. Both sides
 // always share the same width and font size.
 const BEACH_NAME_BASE_FONT = 29;  // matches .team-name font-size in beach.css
-const BEACH_NAME_MIN_FONT = 17;
+const BEACH_NAME_MIN_FONT = 16;
 const BEACH_NAME_MIN_BAR = 260;
-const BEACH_NAME_MAX_BAR = 440;
+const BEACH_NAME_MAX_BAR = 480;
 const BEACH_NAME_PADDING = 44;    // .name-bar horizontal padding (2 * 22px)
 
 // Measure the rendered width of a beach team name at a given font size with
@@ -633,17 +633,20 @@ function fitBeachNames() {
     const homeText = homeName.textContent || "";
     const awayText = awayName.textContent || "";
 
+    // Shrink the type one step at a time, re-measuring each time, until the
+    // longer name fits the widest bar we allow (or we hit the legibility
+    // floor). We can't shrink proportionally in a single step because the
+    // fixed 1px letter-spacing does not scale with the font size, so a
+    // proportional guess lands a few pixels too wide and the name still
+    // clips — the measured loop accounts for it exactly.
+    const maxContent = BEACH_NAME_MAX_BAR - BEACH_NAME_PADDING;
     let fontSize = BEACH_NAME_BASE_FONT;
     let maxText = Math.max(
         measureBeachName(homeText, fontSize),
         measureBeachName(awayText, fontSize)
     );
-
-    // Shrink the type proportionally only when the longer name would overflow
-    // the widest bar we allow, never below the legibility floor.
-    const maxContent = BEACH_NAME_MAX_BAR - BEACH_NAME_PADDING;
-    if (maxText > maxContent) {
-        fontSize = Math.max(BEACH_NAME_MIN_FONT, fontSize * (maxContent / maxText));
+    while (maxText > maxContent && fontSize > BEACH_NAME_MIN_FONT) {
+        fontSize -= 1;
         maxText = Math.max(
             measureBeachName(homeText, fontSize),
             measureBeachName(awayText, fontSize)

--- a/overlay_static/js/app.js
+++ b/overlay_static/js/app.js
@@ -492,8 +492,12 @@ function updateStateDiff(oldState, newState) {
         withEl("scoreboard-container", container => {
             container.classList.toggle("compact-mode", !!newState.match_info.show_only_current_set);
         });
-        // Re-fit beach names when they reappear leaving compact mode.
-        fitBeachNames();
+        // Re-fit beach names only when they reappear leaving compact mode;
+        // entering it hides the names and CSS pins the bar width, so a
+        // re-fit there would be a wasted reflow.
+        if (!newState.match_info.show_only_current_set) {
+            fitBeachNames();
+        }
     }
 
     // Set summary recap panel toggle / re-render. Re-render also on


### PR DESCRIPTION
## Summary

Two related strands of work on the beach overlay:

### Shipped changes (overlay engine)
- `app.js`: fit the team-name bars to the longest name (measured step-by-step rather than scaled proportionally, since the fixed letter-spacing doesn't scale), and only re-fit when leaving compact mode.
- `beach.css`: per-team highlight colours and `color-mix` fallbacks.
- `CHANGELOG.md`: entry for the above.

### Design mockups (not wired into the engine yet)
Static previews under `docs/mockups/beach-twoline/` exploring a new "two-line" beach scoreboard layout, iterated over several rounds:
- `index.html` — base design: tall score cards on the outer edges flanking two stacked name bars (home top, away bottom). Per team, from its own score outward: sets → icon/name. Expanded mode shows the name only; simple mode shows the icon only (or just the sets numeral when a team has no logo). Serving is shown by the coloured line decorating that team's score card.
- `disambiguation.html` — comparison of techniques to make it explicit which score card belongs to which bar (row-aligned numeral, colour connector notch, half-height coloured edge, coloured numerals, combo).
- `fade.html` — the chosen approach: a short "fade tail" of extra space appended at each bar's inner end (toward the other team's score) that tapers to transparent via `mask-image`, detaching the bar from the wrong score without the fade ever touching the sets/name/logo content.

The mockups are previews for design sign-off; the two-line layout is not yet implemented as a real overlay style.

## Test plan
- Mockups are static HTML; open under `docs/mockups/beach-twoline/`.
- Engine changes (`app.js`, `beach.css`) covered by the existing beach overlay behaviour.

https://claude.ai/code/session_01BiEqtCyxnwrCKf6KiYcKGC

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiEqtCyxnwrCKf6KiYcKGC)_