### PR TITLE
Release 5.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+## [5.5.0] - 2026-05-31
+
 ### Added
 
 - **New `beach_twoline` overlay style.** A two-line variant of the beach


### PR DESCRIPTION
## Summary

Release prep for **5.5.0**. Rolls the accumulated `[Unreleased]` changelog entries into a dated `## [5.5.0] - 2026-05-31` section (leaving a fresh empty `[Unreleased]` on top).

A minor bump over 5.4.4 — all additive, no breaking changes. Highlights since 5.4.4:
- New `beach` and `beach_twoline` overlay styles.
- Opt-in per-point classification (scouting tags) with spectator-page, set-summary recap, and match-report stats.
- Config "Behavior" section split into Display / Statistics / Set summary / General.
- Live-stats memoised against the audit-log version; whole-package `mypy` scope.

## Notes
- Only `CHANGELOG.md` changes (the version section header). `pyproject.toml` / `frontend/package.json` are static placeholders in this repo — the release version lives in the git tag + changelog.
- The `v5.5.0` tag and GitHub Release will be created from `main` once this merges.

https://claude.ai/code/session_01BiEqtCyxnwrCKf6KiYcKGC

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiEqtCyxnwrCKf6KiYcKGC)_