### PR TITLE
Unwrap configurator's configuration envelope in remote config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ once a first tagged release ships.
 
 ### Fixed
 
+- **Remote config (`REMOTE_CONFIG_URL`) now accepts the configurator's
+  `{"configuration": {...}}` envelope.** The
+  [volleyball-scoreboard-configurator](https://github.com/JacoboSanchez/volleyball-scoreboard-configurator/)
+  exports the config wrapped in a top-level `configuration` key, but the
+  app read the JSON as a flat env-var mapping — so every setting
+  (`APP_TEAMS`, `APP_THEMES`, `PREDEFINED_OVERLAYS`, …) was looked up at
+  the wrong level, silently fell through to defaults, and the configured
+  teams never appeared. The loader now unwraps a lone `configuration`
+  envelope transparently while still accepting a plain flat object.
+
 - **Score digits now centre vertically in every font.** The ten
   selectable score-button fonts ship wildly inconsistent vertical
   metrics (declared ascents from 0.58em to 1.03em), which browsers

--- a/app/env_vars_manager.py
+++ b/app/env_vars_manager.py
@@ -78,12 +78,16 @@ class EnvVarsManager:
         wrapped in a ``{"configuration": {...}}`` envelope, so unwrap that
         single key transparently; otherwise the nested config keys (e.g.
         ``APP_TEAMS``) would never be found and the app would silently fall
-        back to its defaults. Any other shape is returned unchanged.
+        back to its defaults.
+
+        Always returns a dict: a non-dict payload (a JSON list, string or
+        bool the endpoint might serve) is dropped to ``{}`` so later
+        ``cache.get(...)`` lookups can't raise ``AttributeError``.
         """
-        if (
-            isinstance(payload, dict)
-            and set(payload) == {"configuration"}
-            and isinstance(payload["configuration"], dict)
-        ):
-            return payload["configuration"]
+        if not isinstance(payload, dict):
+            return {}
+        if len(payload) == 1 and "configuration" in payload:
+            inner = payload["configuration"]
+            if isinstance(inner, dict):
+                return inner
         return payload

--- a/app/env_vars_manager.py
+++ b/app/env_vars_manager.py
@@ -64,7 +64,26 @@ class EnvVarsManager:
                     response = requests.get(remote_config_url, timeout=5)
                     logger.debug("Remote config response status: %s", response.status_code)
                     response.raise_for_status()
-                    cls._remote_config_cache = response.json()
+                    cls._remote_config_cache = cls._unwrap_remote_config(response.json())
                 except (requests.exceptions.RequestException, json.JSONDecodeError):
                     logger.exception("Error loading remote configuration")
                     cls._remote_config_cache = {}
+
+    @staticmethod
+    def _unwrap_remote_config(payload):
+        """Return the flat env-var mapping from a remote config payload.
+
+        The remote config is expected to be a flat ``{KEY: value}`` object
+        whose keys are env-var names. The companion configurator exports it
+        wrapped in a ``{"configuration": {...}}`` envelope, so unwrap that
+        single key transparently; otherwise the nested config keys (e.g.
+        ``APP_TEAMS``) would never be found and the app would silently fall
+        back to its defaults. Any other shape is returned unchanged.
+        """
+        if (
+            isinstance(payload, dict)
+            and set(payload) == {"configuration"}
+            and isinstance(payload["configuration"], dict)
+        ):
+            return payload["configuration"]
+        return payload

--- a/tests/test_env_vars_manager.py
+++ b/tests/test_env_vars_manager.py
@@ -81,6 +81,18 @@ class TestEnvVarsManager(unittest.TestCase):
 
         self.assertEqual(EnvVarsManager.get_env_var('TEST_VAR'), 'flat_value')
 
+    @patch.dict(os.environ, {"REMOTE_CONFIG_URL": "http://fake-url.com/config.json", "TEST_VAR": "local_value"})
+    @patch('requests.get')
+    def test_remote_config_non_dict_payload_falls_back_to_local(self, mock_get):
+        # A valid-JSON-but-non-dict payload (list/str/bool) must not crash
+        # later cache.get() lookups; it is dropped so local env is used.
+        mock_response = Mock()
+        mock_response.json.return_value = ["not", "a", "dict"]
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        self.assertEqual(EnvVarsManager.get_env_var('TEST_VAR'), 'local_value')
+
     @patch.dict(os.environ, {"REMOTE_CONFIG_URL": "http://invalid-url.com/config.json", "TEST_VAR": "local_value"})
     @patch('requests.get')
     def test_invalid_remote_url(self, mock_get):

--- a/tests/test_env_vars_manager.py
+++ b/tests/test_env_vars_manager.py
@@ -55,6 +55,32 @@ class TestEnvVarsManager(unittest.TestCase):
         # Assert that the remote value is returned
         self.assertEqual(value, 'remote_value')
 
+    @patch.dict(os.environ, {"REMOTE_CONFIG_URL": "http://fake-url.com/config.json"})
+    @patch('requests.get')
+    def test_remote_config_wrapped_in_configuration_envelope(self, mock_get):
+        # The companion configurator exports a {"configuration": {...}} envelope.
+        remote_config = {'configuration': {'TEST_VAR': 'remote_value'}}
+        mock_response = Mock()
+        mock_response.json.return_value = remote_config
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        # The nested env var is resolved as if it were at the top level.
+        self.assertEqual(EnvVarsManager.get_env_var('TEST_VAR'), 'remote_value')
+
+    @patch.dict(os.environ, {"REMOTE_CONFIG_URL": "http://fake-url.com/config.json"})
+    @patch('requests.get')
+    def test_remote_config_envelope_with_extra_keys_not_unwrapped(self, mock_get):
+        # A "configuration" key alongside other top-level keys is ambiguous,
+        # so it is treated as a literal flat config (left unwrapped).
+        remote_config = {'configuration': {'NESTED': 'x'}, 'TEST_VAR': 'flat_value'}
+        mock_response = Mock()
+        mock_response.json.return_value = remote_config
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        self.assertEqual(EnvVarsManager.get_env_var('TEST_VAR'), 'flat_value')
+
     @patch.dict(os.environ, {"REMOTE_CONFIG_URL": "http://invalid-url.com/config.json", "TEST_VAR": "local_value"})
     @patch('requests.get')
     def test_invalid_remote_url(self, mock_get):


### PR DESCRIPTION
## Problem

When importing config from a `REMOTE_CONFIG_URL` endpoint, none of the configured teams (nor any other setting) were applied — the app fell back to the default `Local` / `Visitante` teams.

The companion [volleyball-scoreboard-configurator](https://github.com/JacoboSanchez/volleyball-scoreboard-configurator/) exports the config wrapped in a top-level `configuration` key:

```json
{"configuration": {"APP_TEAMS": "...", "APP_THEMES": "...", ...}}
```

But `EnvVarsManager._load_remote_config_if_needed` stored `response.json()` directly as the env-var cache, so lookups like `get_env_var('APP_TEAMS')` searched the top level, found only `configuration`, and silently fell through to defaults. This affected **every** remote setting (`APP_TEAMS`, `APP_THEMES`, `PREDEFINED_OVERLAYS`, `MATCH_SETS`, …), not just the teams.

## Fix

Added `_unwrap_remote_config()`, applied to the fetched JSON:

- If the payload is **only** `{"configuration": {...}}` (exactly one key, dict value), it is unwrapped and the inner mapping is used.
- Any other shape (a plain flat object, or `configuration` alongside other top-level keys) is returned unchanged — **backwards compatible**.

## Tests

- `test_remote_config_wrapped_in_configuration_envelope` — nested env var resolves through the envelope.
- `test_remote_config_envelope_with_extra_keys_not_unwrapped` — ambiguous shape stays flat.
- Full `tests/test_env_vars_manager.py`, `test_customization.py`, `test_app_config.py` pass (38). `ruff` + `mypy` clean.

CHANGELOG entry added under `Fixed`.

https://claude.ai/code/session_0147MQiiVqS586s2zwcYVExz

---
_Generated by [Claude Code](https://claude.ai/code/session_0147MQiiVqS586s2zwcYVExz)_