### PR TITLE
Document streaming position presets in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,28 @@ CUSTOMIZATION_CACHE_TTL_SECONDS=
 REMOTE_CONFIG_URL=
 
 APP_TEAMS=
+
+# JSON map of named configuration presets surfaced (read-only) in the
+# control UI's Config → Presets list. Each entry is
+# ``"Name": {customization key: value}`` and may carry any allow-listed
+# customization keys (team names/colors/logos, overlay style, and the
+# position/size keys ``Width`` / ``Height`` / ``Left-Right`` / ``Up-Down``).
+# Only the keys present are applied, so a position-only preset just moves
+# and scales the overlay without touching colors or style.
+#
+# Position/size coordinate system (in-process custom overlays, 1080p):
+#   Width      -> scale = Width / 30 (Width 30 = 1.0x)
+#   Left-Right -> -50 = left edge ... +50 = right edge
+#   Up-Down    -> -50 = top edge ... +50 = bottom edge
+#   Height     -> stored but does not affect placement
+#
+# Example: six streaming position presets. Corners are tuned for a compact
+# two-line style (e.g. ``original``); the right/bottom anchors depend on the
+# rendered box size, so nudge ``Left-Right`` / ``Up-Down`` if you use a wider
+# style or long team names. The centred presets are tuned for the near-full
+# width ``ribbon`` style. For a centred "team on each side" look, select the
+# ``pylons`` style instead — it pins itself to both edges and ignores position.
+# APP_THEMES={"Esquina superior izquierda":{"Width":24,"Height":10,"Left-Right":-47.5,"Up-Down":-45.6},"Esquina superior derecha":{"Width":24,"Height":10,"Left-Right":28.9,"Up-Down":-45.6},"Esquina inferior izquierda":{"Width":24,"Height":10,"Left-Right":-47.5,"Up-Down":38.1},"Esquina inferior derecha":{"Width":24,"Height":10,"Left-Right":28.9,"Up-Down":38.1},"Centrado superior (1 linea)":{"Width":30,"Height":10,"Left-Right":-21.4,"Up-Down":-46.3},"Centrado inferior (1 linea)":{"Width":30,"Height":10,"Left-Right":-21.4,"Up-Down":40.2}}
 APP_THEMES=
 REST_USER_AGENT=
 

--- a/.env.example
+++ b/.env.example
@@ -122,7 +122,7 @@ APP_TEAMS=
 # style or long team names. The centred presets are tuned for the near-full
 # width ``ribbon`` style. For a centred "team on each side" look, select the
 # ``pylons`` style instead — it pins itself to both edges and ignores position.
-# APP_THEMES={"Esquina superior izquierda":{"Width":24,"Height":10,"Left-Right":-47.5,"Up-Down":-45.6},"Esquina superior derecha":{"Width":24,"Height":10,"Left-Right":28.9,"Up-Down":-45.6},"Esquina inferior izquierda":{"Width":24,"Height":10,"Left-Right":-47.5,"Up-Down":38.1},"Esquina inferior derecha":{"Width":24,"Height":10,"Left-Right":28.9,"Up-Down":38.1},"Centrado superior (1 linea)":{"Width":30,"Height":10,"Left-Right":-21.4,"Up-Down":-46.3},"Centrado inferior (1 linea)":{"Width":30,"Height":10,"Left-Right":-21.4,"Up-Down":40.2}}
+# APP_THEMES={"Esquina superior izquierda":{"Width":24,"Height":10,"Left-Right":-47.5,"Up-Down":-45.6},"Esquina superior derecha":{"Width":24,"Height":10,"Left-Right":28.9,"Up-Down":-45.6},"Esquina inferior izquierda":{"Width":24,"Height":10,"Left-Right":-47.5,"Up-Down":38.1},"Esquina inferior derecha":{"Width":24,"Height":10,"Left-Right":28.9,"Up-Down":38.1},"Centrado superior (1 línea)":{"Width":30,"Height":10,"Left-Right":-21.4,"Up-Down":-46.3},"Centrado inferior (1 línea)":{"Width":30,"Height":10,"Left-Right":-21.4,"Up-Down":40.2}}
 APP_THEMES=
 REST_USER_AGENT=
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ once a first tagged release ships.
 
 ### Added
 
+- **Documented streaming position presets in `.env.example`.** The
+  `APP_THEMES` env var (already surfaced read-only under Config →
+  Presets) now ships a documented example of six position-only
+  presets for a 1080p stream — four screen corners plus centred
+  top/bottom single-line placements — alongside an explanation of the
+  `Width` / `Height` / `Left-Right` / `Up-Down` coordinate system.
+  Config-only; no code change.
+
 - **Side switching across every live view.** A swap button in the
   scoreboard centre column flips which team renders left/right on
   the operator UI, on all 22 OBS overlay styles (behind a quick


### PR DESCRIPTION
Add a commented APP_THEMES example with six position-only presets for a
1080p stream (four screen corners plus centred top/bottom single-line
placements) and an explanation of the Width/Height/Left-Right/Up-Down
coordinate system. Config-only; no code change.

https://claude.ai/code/session_01Atr8ufKvK1Qm7Qf2465Aab