### PR TITLE
Fix: persist verticalAnchor so the position switch actually applies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ once a first tagged release ships.
   the vertical-anchor control for edge-pinned styles, instead of showing the
   theme selector for every custom overlay with more than one style.
 
+### Fixed
+
+- **Vertical-anchor selection is now persisted.** `verticalAnchor` was missing
+  from the `ALLOWED_CUSTOMIZATION_KEYS` allow-list, so `PUT /customization`
+  silently dropped it — the operator could pick top/center/bottom and save, but
+  the overlay never moved. Added it to the allow-list (and the `style` preset
+  category) so the choice round-trips to the overlay and into saved presets.
+
 ## [5.6.1] - 2026-06-12
 
 ### Added

--- a/app/api/preset_categories.py
+++ b/app/api/preset_categories.py
@@ -50,6 +50,7 @@ _KEYS_BY_CATEGORY: dict[str, tuple[str, ...]] = {
     "style": (
         "preferredStyle",
         "overlayTheme",
+        "verticalAnchor",
         "Logos",
         "Gradient",
         "Color 1",

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -174,6 +174,10 @@ ALLOWED_CUSTOMIZATION_KEYS = {
     # Applied by app.js as a body class on styles that define the
     # matching palette; a ``?theme=`` URL override takes precedence.
     'overlayTheme',
+    # Vertical anchor for edge-pinned styles (pylons): '' (center),
+    # 'top' or 'bottom'. Applied by app.js as a ``data-vertical-anchor``
+    # attribute; an ``?anchor=`` URL override takes precedence.
+    'verticalAnchor',
     # Operator UI locale, broadcast to OBS-embedded overlays (whose URL
     # is fixed in the streaming app and cannot carry ``?lang=``).
     'locale',

--- a/frontend/src/components/PresetPicker.tsx
+++ b/frontend/src/components/PresetPicker.tsx
@@ -44,6 +44,7 @@ const KEYS_BY_CATEGORY: Record<CategoryId, readonly string[]> = {
   style: [
     'preferredStyle',
     'overlayTheme',
+    'verticalAnchor',
     'Logos',
     'Gradient',
     'Color 1',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -265,6 +265,13 @@ class TestGameService:
         result = GameService.update_customization(session, new_data)
         assert result.success is True
 
+    def test_update_customization_persists_vertical_anchor(self, session):
+        # Regression: ``verticalAnchor`` (edge-pinned pylons placement) must
+        # survive the allow-list filter so the overlay actually receives it.
+        result = GameService.update_customization(session, {"verticalAnchor": "top"})
+        assert result.success is True
+        assert session.customization.get_model().get("verticalAnchor") == "top"
+
     def test_update_customization_accepts_supported_locale(self, session):
         result = GameService.update_customization(session, {"locale": "es"})
         assert result.success is True


### PR DESCRIPTION
## Bug

The vertical-anchor control (top/center/bottom for the edge-pinned `pylons` / `pylons_gradient` styles) shipped in #372, but **selecting an option and saving did nothing** — the overlay never moved.

## Root cause

`PUT /customization` filters the incoming payload to `ALLOWED_CUSTOMIZATION_KEYS` (`app/api/schemas.py`) and **silently drops** any key not on the list. `verticalAnchor` was added to the React UI (`OverlaySection`) and to `app.js`, but never to the backend allow-list — so it was stripped on save, never persisted to `raw_remote_customization`, and never broadcast to the overlay. (`overlayTheme`, the sibling control, was on the list, which is why it worked.)

## Fix

- Add `verticalAnchor` to `ALLOWED_CUSTOMIZATION_KEYS`.
- Slot it into the `style` preset category in `app/api/preset_categories.py` — the import-time partition check (and `tests/test_presets_operator.py`) requires every allowed key to belong to exactly one category. This also makes the choice round-trip through saved presets.
- Mirror it in the frontend `PresetPicker` catalogue (`KEYS_BY_CATEGORY.style`).
- Add a regression test asserting `verticalAnchor` survives `update_customization`.

## Tests
- `tests/test_api.py` (new `test_update_customization_persists_vertical_anchor`), `tests/test_presets_operator.py`, `tests/test_style_capabilities.py`: green. `ruff` clean.
- Frontend `format:check`, `typecheck`, `PresetPicker` tests: green.
- OpenAPI schema: no drift.

https://claude.ai/code/session_01YELbbc8VazFeJmcKSJMXMD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YELbbc8VazFeJmcKSJMXMD)_