### PR TITLE
Collapse pylons to their own edges on hide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ once a first tagged release ships.
 
 ### Fixed
 
+- **Pylons hide animation now collapses each panel to its own screen edge.**
+  Hiding the scoreboard slid the whole frame sideways, which read wrong for the
+  edge-pinned `pylons` / `pylons_gradient` styles (the two panels drifted off in
+  the same direction). They now exit symmetrically — the home panel collapses to
+  the left edge, the away panel to the right — while other styles keep the
+  existing slide-and-fade.
+
 - **Vertical-anchor selection is now persisted.** `verticalAnchor` was missing
   from the `ALLOWED_CUSTOMIZATION_KEYS` allow-list, so `PUT /customization`
   silently dropped it — the operator could pick top/center/bottom and save, but

--- a/overlay_static/js/app.js
+++ b/overlay_static/js/app.js
@@ -530,6 +530,38 @@ function updateLogoVisibility(showLogos) {
     if (scoreboard) scoreboard.classList.toggle('no-logos', !showLogos);
 }
 
+// Show/hide the scoreboard with a style-appropriate transition.
+//
+// Most styles are a single block, so they slide sideways off-frame and
+// fade. Edge-pinned styles (pylons) are a full-frame pair docked to the
+// left/right edges via ``data-fixed-geometry`` — sliding the whole frame
+// sideways reads wrong, so instead each panel collapses to ITS OWN edge:
+// the home panel exits left, the away panel exits right. The container
+// itself stays put and opaque (pylons.css starts it at opacity:0, which
+// the visible branch raises here just like the generic path does).
+function applyScoreboardVisibility(container, show) {
+    if (container.dataset.fixedGeometry !== undefined) {
+        gsap.set(container, { x: 0, opacity: 1 });
+        const home = container.querySelector('.pylon-home');
+        const away = container.querySelector('.pylon-away');
+        if (show) {
+            const panels = [home, away].filter(Boolean);
+            if (panels.length) {
+                gsap.to(panels, { xPercent: 0, opacity: 1, duration: 0.8, ease: "power3.out" });
+            }
+        } else {
+            if (home) gsap.to(home, { xPercent: -120, opacity: 0, duration: 0.5, ease: "power2.in" });
+            if (away) gsap.to(away, { xPercent: 120, opacity: 0, duration: 0.5, ease: "power2.in" });
+        }
+        return;
+    }
+    if (show) {
+        gsap.to(container, { x: 0, opacity: 1, duration: 0.8, ease: "power3.out" });
+    } else {
+        gsap.to(container, { x: -100, opacity: 0, duration: 0.5, ease: "power2.in" });
+    }
+}
+
 function renderFullState(state, rawState) {
     rawState = rawState || state;
     // 1. Overlay Visibility & Geometry
@@ -539,11 +571,7 @@ function renderFullState(state, rawState) {
     }
 
     withEl("scoreboard-container", container => {
-        if (state.overlay_control.show_main_scoreboard) {
-            gsap.to(container, { x: 0, opacity: 1, duration: 0.8, ease: "power3.out" });
-        } else {
-            gsap.to(container, { x: -100, opacity: 0, duration: 0.5, ease: "power2.in" });
-        }
+        applyScoreboardVisibility(container, state.overlay_control.show_main_scoreboard);
         // Compact mode toggle (used by compact overlay to hide name/history)
         container.classList.toggle("compact-mode", !!state.match_info.show_only_current_set);
     });
@@ -664,11 +692,7 @@ function updateStateDiff(oldState, newState, oldRawState, newRawState) {
     // Visibility
     if (oldState.overlay_control.show_main_scoreboard !== newState.overlay_control.show_main_scoreboard) {
         withEl("scoreboard-container", container => {
-            if (newState.overlay_control.show_main_scoreboard) {
-                gsap.to(container, { x: 0, opacity: 1, duration: 0.8, ease: "power3.out" });
-            } else {
-                gsap.to(container, { x: -100, opacity: 0, duration: 0.5, ease: "power2.in" });
-            }
+            applyScoreboardVisibility(container, newState.overlay_control.show_main_scoreboard);
         });
     }
 


### PR DESCRIPTION
## Problem

Hiding the scoreboard slid the whole `#scoreboard-container` sideways (`x: -100`) and faded. For the edge-pinned `pylons` / `pylons_gradient` styles the container spans the full frame with one panel docked to **each** screen edge, so sliding the frame sideways moved both panels in the same direction instead of each collapsing to its own edge.

## Fix

Extract the show/hide transition into `applyScoreboardVisibility(container, show)`:
- **Edge-pinned styles** (marked `data-fixed-geometry`): animate the panels independently — the `.pylon-home` panel exits left, the `.pylon-away` panel exits right (and slide back in on show). The container stays put and opaque.
- **Other styles**: keep the existing slide-and-fade.

Both the full-render (`renderFullState`) and the diff code paths now route through the same helper, so the behaviour is consistent however the visibility change arrives.

## Notes
- `node --check` passes on `app.js`. The overlay engine JS isn't covered by the vitest suite, and a hide animation isn't visible in the static screenshots, so no snapshot regen.
- Verifiable by toggling overlay visibility on a `pylons` / `pylons_gradient` source: the two panels should now retract to their respective edges.

https://claude.ai/code/session_01YELbbc8VazFeJmcKSJMXMD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YELbbc8VazFeJmcKSJMXMD)_