### PR TITLE
docs(changelog): stage v6.0.1 release notes under [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ once a first tagged release ships.
   three are regenerated from their SVG source via
   `frontend/scripts/regenerate-icons.sh`.
 
+### Dependencies
+
+- **Backend runtime:** `fastapi` `>=0.137.1` → `>=0.139.0`, `sqlalchemy`
+  `>=2.0` → `>=2.0.51`, `psycopg[binary]` `>=3.2` → `>=3.3.4`, and
+  `python-multipart` `>=0.0.20` → `>=0.0.32`.
+- **Backend dev/test:** `pytest` `>=9.1.0` → `>=9.1.1`.
+- **Frontend:** `vite` `8.0.16` → `8.1.0`, `@vitejs/plugin-react` `6.0.2`
+  → `6.0.3`, and `globals` `17.6.0` → `17.7.0`.
+- **CI (GitHub Actions):** `actions/checkout` `6` → `7`,
+  `docker/build-push-action` `7.2.0` → `7.3.0`, `docker/login-action`
+  `4.2.0` → `4.4.0`, and `docker/metadata-action` `6.1.0` → `6.2.0`.
+
 ## [6.0.0] - 2026-07-08
 
 > [!WARNING]


### PR DESCRIPTION
## Summary

Stages the changelog notes for the **v6.0.1** release under `## [Unreleased]` so the `Cut release` workflow can cut, tag, and publish it. This documents the changes already merged to `main` since v6.0.0 — the icon change and the dependabot dependency bumps that were merged without changelog entries.

## Changes

- **Changed** — sport-agnostic board install ("Add to Home Screen") icon, now a neutral scoreboard instead of a volleyball, with PNG raster siblings shipped (already staged from #402).
- **Fixed** — regenerated stale base app icon rasters (`icon-192x192.png`, `icon-512x512.png`, `apple-touch-icon.png`) that still carried the old volleyball art (already staged from #402).
- **Dependencies** (new section) — documents the dependabot bumps merged since v6.0.0:
  - Backend runtime: `fastapi` `>=0.139.0`, `sqlalchemy` `>=2.0.51`, `psycopg[binary]` `>=3.3.4`, `python-multipart` `>=0.0.32`
  - Backend dev/test: `pytest` `>=9.1.1`
  - Frontend: `vite` `8.1.0`, `@vitejs/plugin-react` `6.0.3`, `globals` `17.7.0`
  - CI: `actions/checkout` `7`, `docker/build-push-action` `7.3.0`, `docker/login-action` `4.4.0`, `docker/metadata-action` `6.2.0`

## Implementation notes

`[Unreleased]` is intentionally left **uncut** — the canonical `Cut release` workflow (`.github/workflows/release.yml`) performs the version cut, commit, tag, GitHub Release, and Docker build on `main`. Verified that `python scripts/release/cut_changelog.py 6.0.1 --dry-run` succeeds against this state.

## Test plan

- [x] `python scripts/release/cut_changelog.py 6.0.1 --dry-run` succeeds (release cut is unblocked)
- [ ] N/A — changelog-only change (no code, no operator-facing surface, no API)

## Checklist

- [x] `CHANGELOG.md` entries under `## [Unreleased]`
- [x] No screenshot changes needed (no operator-facing surface changed)
- [x] No secrets, credentials, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tvQhj4SzfyX6mszjoGk3Z

---
_Generated by [Claude Code](https://claude.ai/code/session_015tvQhj4SzfyX6mszjoGk3Z)_