### PR TITLE
Fix reflective XSS in match report locale tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Security
+
+- **Locale tags are now escaped and canonicalised before reaching
+  server-rendered HTML** (CodeQL `py/reflective-xss`, alert #57). The
+  match report interpolated the locale resolved from `?lang=` /
+  `Accept-Language` into `<html lang="…">` without escaping. The value
+  was already constrained to the six supported tags, so the page was not
+  exploitable, but the request-derived string travelled all the way to
+  the response. The report now HTML-escapes the tag at the template
+  boundary (as the matches-index page already did), and both
+  `resolve_locale` and the overlay's `_normalise_locale` return the
+  constant out of `SUPPORTED_LOCALES` instead of a substring of the
+  request, so no consumer of a resolved locale can ever echo
+  attacker-controlled bytes.
+
 ## [6.1.2] - 2026-07-11
 
 ### Changed

--- a/app/match_report.py
+++ b/app/match_report.py
@@ -227,7 +227,12 @@ def match_report(
     permalink = f"/match/{match_id}/report"
 
     rendered = _REPORT_TEMPLATE.format(
-        locale=locale,
+        # ``locale`` derives from the ``?lang=`` param / ``Accept-Language``
+        # header and lands in the ``<html lang="…">`` attribute — escape it
+        # like every other request-derived kwarg (and like the matches-index
+        # page already does) so the template line can never reflect
+        # attacker bytes.
+        locale=html.escape(locale, quote=True),
         title=html.escape(_t(locale, "title", label=match_label)),
         match_label=html.escape(match_label),
         match_id=html.escape(payload.get("match_id", match_id)),

--- a/app/match_report_i18n.py
+++ b/app/match_report_i18n.py
@@ -472,9 +472,15 @@ def resolve_locale(accept_language: str | None) -> str:
                     q = 0.0
         primary = tag.split("-", 1)[0].lower()
         if primary in SUPPORTED_LOCALES:
+            # Return the constant out of SUPPORTED_LOCALES rather than the
+            # header-derived substring: consumers interpolate the resolved
+            # tag into HTML (``<html lang="…">``), so the value must never
+            # be attacker-controlled bytes even if the parsing above ever
+            # widens what it accepts.
+            canonical = SUPPORTED_LOCALES[SUPPORTED_LOCALES.index(primary)]
             # Higher q first; preserve declaration order on ties so that
             # ``es,en`` picks ``es`` not ``en`` when both have q=1.
-            candidates.append((-q, index, primary))
+            candidates.append((-q, index, canonical))
     if not candidates:
         return DEFAULT_LOCALE
     candidates.sort()

--- a/app/overlay/locale.py
+++ b/app/overlay/locale.py
@@ -19,7 +19,12 @@ def _normalise_locale(raw: str | None) -> str | None:
     if not raw or not isinstance(raw, str):
         return None
     candidate = raw.strip().lower()[:2]
-    return candidate if candidate in SUPPORTED_LOCALES else None
+    if candidate not in SUPPORTED_LOCALES:
+        return None
+    # Return the constant, not the request-derived slice — the resolved
+    # tag is interpolated into overlay HTML, so it must never carry
+    # attacker-controlled bytes (same rationale as ``resolve_locale``).
+    return SUPPORTED_LOCALES[SUPPORTED_LOCALES.index(candidate)]
 
 
 def _resolve_overlay_locale(

--- a/tests/test_match_report.py
+++ b/tests/test_match_report.py
@@ -317,6 +317,25 @@ class TestMatchReport:
         assert response.status_code == 200
         assert "Set a set" in response.text
 
+    def test_hostile_lang_never_reflects_into_markup(
+        self, client, archived_match,
+    ):
+        """Regression for CodeQL ``py/reflective-xss``: the resolved
+        locale flows into ``<html lang="…">`` unquoted, so a hostile
+        ``?lang=`` / ``Accept-Language`` must both fall back to a
+        supported tag and never echo attacker bytes into the page.
+        """
+        payload = '"><script>alert(1)</script>'
+        response = client.get(
+            f"/match/{archived_match}/report",
+            params={"lang": payload},
+            headers={"Accept-Language": f"{payload}, es;q=0.9"},
+        )
+        assert response.status_code == 200
+        assert "<script>alert(1)" not in response.text
+        # The malformed tags fall through to the ``es`` header entry.
+        assert 'lang="es"' in response.text
+
     def test_renders_final_score(self, client, archived_match):
         response = client.get(f"/match/{archived_match}/report")
         # Set scores 3-1; the winner is implicit from those plus the


### PR DESCRIPTION
## Summary

Fix a CodeQL `py/reflective-xss` alert by ensuring locale tags resolved from request parameters (`?lang=` / `Accept-Language` headers) are never echoed into HTML unescaped. While the values were already constrained to supported locales, the request-derived strings travelled to the response; now we return constants from `SUPPORTED_LOCALES` and HTML-escape at the template boundary.

## Changes

- Match report now HTML-escapes the resolved locale before interpolating into `<html lang="…">` attribute
- `resolve_locale()` returns the canonical constant from `SUPPORTED_LOCALES` instead of a request-derived substring
- Overlay's `_normalise_locale()` similarly returns the constant instead of a slice of the input
- Added regression test verifying hostile `?lang=` and `Accept-Language` payloads don't reflect into markup

## Implementation notes

The vulnerability was theoretical (locale values were already constrained to six supported tags), but the fix follows defense-in-depth principles:

1. **HTML escaping at template boundary**: Matches the pattern already used in the matches-index page and other request-derived values in the report template
2. **Constant canonicalisation**: Both `resolve_locale()` and `_normalise_locale()` now return the exact constant from `SUPPORTED_LOCALES` rather than a substring/slice of the request, ensuring no consumer can ever echo attacker-controlled bytes
3. **Consistent approach**: Applied the same fix to both the main report and overlay locale resolution paths

## Test plan

- [x] Added `test_hostile_lang_never_reflects_into_markup()` regression test covering both `?lang=` param and `Accept-Language` header with XSS payloads
- [x] Existing locale resolution tests continue to pass
- [x] CI (ruff, mypy, pytest) passes

## Checklist

- [x] Added `CHANGELOG.md` entry under `## [Unreleased]` with Security section
- [ ] No screenshot changes needed (no operator-facing surface changed)
- [ ] No docs updates needed (internal security fix)
- [ ] No secrets committed

https://claude.ai/code/session_0171sQYNe57xqYH7DPK9XqWa