### PR TITLE
Add PWA app shortcuts to signed-in user's overlays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,7 +296,7 @@ All `/api/v1/*` user routes require the `vsession` cookie (`require_user`); admi
 | `/metrics` | Prometheus exposition (unauthenticated; aggregates only) |
 | `/health` | Health check — returns `200 OK` with timestamp |
 | `/sw.js` | PWA service worker (from frontend build) |
-| `/manifest.webmanifest` | PWA manifest (from frontend build) |
+| `/manifest.webmanifest` | PWA manifest — served dynamically from the frontend build: `APP_TITLE` name, optional per-board `?oid=`/`?u=` variants, and (for a signed-in owner, via the `vsession` cookie) their overlays as long-press app `shortcuts` |
 
 For the complete authentication matrix see [AUTHENTICATION.md](AUTHENTICATION.md).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Added
+
+- **PWA app shortcuts to your overlays.** Long-pressing the installed
+  app icon on Android (or opening the jump list on desktop Chrome/Edge)
+  now lists the signed-in owner's overlays, each launching straight into
+  its control board (`/board?oid=<id>`). The manifest is fetched with
+  credentials (`crossorigin="use-credentials"`, via vite-plugin-pwa
+  `useCredentials`), so `GET /manifest.webmanifest` personalises the
+  `shortcuts` array from the `vsession` cookie — an anonymous request
+  gets none, and one account's overlays never surface in another's
+  manifest (the response carries `Vary: Cookie` + `Cache-Control:
+  private`). The list is capped at the first 10 overlays (ordered by id;
+  Android's launcher only surfaces a handful). Shortcuts refresh
+  whenever the browser next re-reads the manifest (roughly on relaunch),
+  so a just-created overlay can take a launch or two to appear.
+
 ## [6.2.0] - 2026-07-11
 
 ### Added

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -16,12 +16,13 @@ from functools import lru_cache
 from pathlib import Path
 from urllib.parse import quote
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
+from sqlalchemy.orm import Session
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.api import api_router
@@ -36,8 +37,10 @@ from app.api.routes.metrics import router as metrics_router
 from app.app_config import get_app_title
 from app.auth.bootstrap import ensure_admin_bootstrap
 from app.auth.routes import auth_router
+from app.auth.sessions import COOKIE_NAME
 from app.config_validator import validate_config
 from app.db import migrate as db_migrate
+from app.db.engine import get_db
 from app.match_history import match_history_router
 from app.match_report import match_report_router
 from app.security_bootstrap import run_security_bootstrap
@@ -154,6 +157,72 @@ def _board_manifest(base: dict, title: str, u: str | None, oid: str) -> dict:
         {"src": "icon-board-512x512.png", "sizes": "512x512", "type": "image/png",
          "purpose": "any maskable"},
     ]
+    return manifest
+
+
+# Cap on how many overlays are advertised as manifest ``shortcuts``. Android
+# launchers surface only the first few (~4) of a manifest's shortcuts on a
+# long-press; desktop Chrome shows more in the jump list. Keep the list short
+# so the per-user manifest stays small — the browser re-fetches it in the
+# background to refresh the shortcuts, so a fat list is paid for repeatedly.
+_MAX_MANIFEST_SHORTCUTS = 10
+
+
+def _overlay_shortcuts(db: Session, cookie_token: str | None) -> list[dict]:
+    """PWA app shortcuts for the *signed-in* user's overlays.
+
+    Rendered under the installed app icon on a long-press (Android launcher)
+    or in the desktop jump list, each opening ``/board?oid=<oid>``. Built only
+    from the authenticated ``vsession`` cookie — never the ``?u=`` bookmark
+    param — so one account's overlay list can never surface in a manifest
+    served for another user's public board. Any failure degrades to "no
+    shortcuts": a 500 from this route would block PWA installation entirely.
+    """
+    if not cookie_token:
+        return []
+    try:
+        from app.auth import sessions
+        from app.overlays_service import list_overlays
+
+        user = sessions.resolve_session(db, cookie_token)
+        if user is None:
+            return []
+        overlays = list_overlays(db, user.id)
+    except Exception:
+        logger.exception("Failed to build PWA manifest shortcuts")
+        return []
+
+    shortcuts: list[dict] = []
+    for overlay in overlays[:_MAX_MANIFEST_SHORTCUTS]:
+        oid = overlay.oid
+        shortcut: dict = {
+            "name": oid,
+            "short_name": oid,
+            "url": f"/board?oid={quote(oid, safe='')}",
+            "icons": [
+                {"src": "icon-board-192x192.png", "sizes": "192x192",
+                 "type": "image/png"},
+            ],
+        }
+        if overlay.description:
+            shortcut["description"] = overlay.description
+        shortcuts.append(shortcut)
+    return shortcuts
+
+
+def _with_overlay_shortcuts(
+    content: dict, db: Session, cookie_token: str | None,
+) -> dict:
+    """Return *content* plus a ``shortcuts`` array, or *content* unchanged.
+
+    Copies before writing so the ``lru_cache``d base manifest dict from
+    :func:`_render_manifest` is never mutated.
+    """
+    shortcuts = _overlay_shortcuts(db, cookie_token)
+    if not shortcuts:
+        return content
+    manifest = dict(content)
+    manifest["shortcuts"] = shortcuts
     return manifest
 
 
@@ -336,11 +405,11 @@ def _register_system_endpoints(application: FastAPI) -> None:
         return manifest if manifest.is_file() else None
 
     @application.get("/manifest.webmanifest")
-    def serve_webmanifest(request: Request):
-        # ``request`` (not declared query params) keeps the OpenAPI signature
-        # unchanged so schema.d.ts needn't be regenerated. ``?u=&oid=`` (public
-        # bookmark) and ``?oid=`` (owner board) are optional, opt-in per-board
-        # variants; bare requests get the app-wide manifest exactly as before.
+    def serve_webmanifest(request: Request, db: Session = Depends(get_db)):
+        # ``request``/``db`` (not declared query params) keep the OpenAPI
+        # signature unchanged so schema.d.ts needn't be regenerated. ``?u=&oid=``
+        # (public bookmark) and ``?oid=`` (owner board) are optional, opt-in
+        # per-board variants; bare requests get the app-wide manifest.
         source = _vite_manifest_path()
         if source is None:
             return JSONResponse({"error": "manifest not available"}, status_code=404)
@@ -350,10 +419,16 @@ def _register_system_endpoints(application: FastAPI) -> None:
         oid = request.query_params.get("oid")
         if oid and _BOARD_TOKEN_RE.match(oid) and (not u or _BOARD_TOKEN_RE.match(u)):
             content = _board_manifest(content, title, u or None, oid)
+        # Personalise with the signed-in owner's overlays as long-press app
+        # shortcuts. Needs the ``vsession`` cookie, which the browser only sends
+        # when the manifest <link> carries ``crossorigin="use-credentials"``
+        # (vite-plugin-pwa ``useCredentials: true``). ``Vary: Cookie`` +
+        # ``private`` keep one user's shortcuts out of another's cached manifest.
+        content = _with_overlay_shortcuts(content, db, request.cookies.get(COOKIE_NAME))
         return JSONResponse(
             content=content,
             media_type="application/manifest+json",
-            headers={"Cache-Control": "no-cache"},
+            headers={"Cache-Control": "private, no-cache", "Vary": "Cookie"},
         )
 
     @application.get("/manifest.json")

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -51,6 +51,13 @@ export default defineConfig(async () => ({
     ...(await maybeCompression()),
     VitePWA({
       registerType: 'autoUpdate',
+      // Emit ``<link rel="manifest" crossorigin="use-credentials">`` so the
+      // browser sends the ``vsession`` cookie when it (re)fetches the
+      // manifest. The backend reads that cookie to personalise the manifest's
+      // ``shortcuts`` with the signed-in user's overlays (the Android
+      // long-press / desktop jump-list app shortcuts). Without credentials the
+      // manifest request is anonymous and no per-user shortcuts appear.
+      useCredentials: true,
       includeAssets: ['fonts/**/*', 'icon.svg', 'icon-board.svg'],
       manifest: {
         name: 'Volley Scoreboard',

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -216,6 +216,65 @@ def test_manifest_route_serves_per_board_variant(tmp_path, monkeypatch):
         ] == "/"
 
 
+def test_manifest_route_adds_signed_in_overlay_shortcuts(tmp_path, monkeypatch, db_session):
+    """The signed-in owner's overlays become manifest ``shortcuts`` — the app
+    shortcuts Android surfaces on a long-press of the installed icon. Built
+    from the ``vsession`` cookie only: an anonymous request gets none, and one
+    account's overlays never leak into another's manifest."""
+    import app.bootstrap as bootstrap
+    from app import overlays_service
+    from tests.conftest import login_client, make_user
+
+    frontend = tmp_path / "dist"
+    frontend.mkdir()
+    (frontend / "manifest.webmanifest").write_text(
+        '{"name": "Volley", "short_name": "Volley", "start_url": "/", "icons": []}',
+        encoding="utf-8",
+    )
+    (frontend / "index.html").write_text("<title>x</title>", encoding="utf-8")
+    monkeypatch.setattr(bootstrap, "FRONTEND_DIR", frontend)
+    _render_manifest.cache_clear()
+
+    with TestClient(bootstrap.create_app()) as client:
+        # Anonymous: no personalised shortcuts.
+        assert "shortcuts" not in client.get("/manifest.webmanifest").json()
+
+        # Sign in and give the owner two overlays (one described).
+        login_client(client, db_session, username="alex")
+        overlays_service.create_overlay(
+            db_session, client.test_user_id, "liga", description="Liga local"
+        )
+        overlays_service.create_overlay(db_session, client.test_user_id, "copa")
+        db_session.commit()
+
+        res = client.get("/manifest.webmanifest")
+        assert "Cookie" in res.headers.get("Vary", "")
+        shortcuts = res.json()["shortcuts"]
+        # Ordered by oid (list_overlays orders by oid): copa, liga.
+        assert [s["url"] for s in shortcuts] == [
+            "/board?oid=copa", "/board?oid=liga",
+        ]
+        assert [s["name"] for s in shortcuts] == ["copa", "liga"]
+        by_oid = {s["name"]: s for s in shortcuts}
+        assert by_oid["liga"]["description"] == "Liga local"
+        assert "description" not in by_oid["copa"]  # absent when unset
+        assert shortcuts[0]["icons"][0]["src"] == "icon-board-192x192.png"
+
+        # A per-board manifest variant keeps the owner's shortcuts too.
+        board = client.get("/manifest.webmanifest", params={"oid": "liga"}).json()
+        assert board["start_url"] == "/board?oid=liga"
+        assert [s["url"] for s in board["shortcuts"]] == [
+            "/board?oid=copa", "/board?oid=liga",
+        ]
+
+        # A second account's overlays must never leak into alex's manifest.
+        bob = make_user(db_session, "bob")
+        overlays_service.create_overlay(db_session, bob.id, "bobonly")
+        db_session.commit()
+        urls = [s["url"] for s in client.get("/manifest.webmanifest").json()["shortcuts"]]
+        assert "/board?oid=bobonly" not in urls
+
+
 def test_conf_survives_malformed_numeric_env(monkeypatch):
     """MATCH_GAME_POINTS=abc must degrade to the default with a warning,
     not crash Conf() (and with it every session init)."""


### PR DESCRIPTION
## Summary

Personalise the PWA manifest with the signed-in owner's overlays as app shortcuts, appearing on long-press of the installed icon (Android) or in the desktop jump list (Chrome/Edge). Each shortcut launches directly into the overlay's control board.

## Changes

- **PWA manifest now includes personalised shortcuts** for the signed-in user's overlays (up to 10, ordered by ID), each linking to `/board?oid=<id>`
- **Manifest fetched with credentials** via `crossorigin="use-credentials"` in vite-plugin-pwa config, enabling the backend to read the `vsession` cookie
- **Anonymous requests get no shortcuts**; one account's overlays never leak into another's manifest (response carries `Vary: Cookie` + `Cache-Control: private`)
- **Shortcuts refresh on browser relaunch** when the manifest is re-fetched, so newly created overlays appear after a launch or two

## Implementation notes

The `/manifest.webmanifest` endpoint now:
1. Accepts a database session via dependency injection (`Depends(get_db)`)
2. Reads the `vsession` cookie from the request
3. Resolves the authenticated user and fetches their overlays
4. Builds a `shortcuts` array with icon, name, description (if set), and URL
5. Returns the manifest with appropriate cache headers for per-user content

The implementation gracefully degrades: any failure building shortcuts (missing cookie, invalid session, database error) returns an empty shortcuts array rather than failing the entire manifest request, which would block PWA installation.

Shortcuts are capped at 10 because Android launchers only surface ~4 on long-press, and the browser re-fetches the manifest in the background to refresh them, so a large list is paid for repeatedly.

## Test plan

- [x] Added comprehensive test (`test_manifest_route_adds_signed_in_overlay_shortcuts`) covering:
  - Anonymous requests get no shortcuts
  - Signed-in user sees their overlays as shortcuts
  - Overlay descriptions are included when set
  - Per-board manifest variants include the owner's shortcuts
  - One account's overlays don't leak into another's manifest
- [x] Updated `CHANGELOG.md` with user-visible feature description
- [x] Updated `AGENTS.md` to document the dynamic manifest endpoint
- [x] Configured vite-plugin-pwa with `useCredentials: true`

## Checklist

- [x] Added `CHANGELOG.md` entry under `## [Unreleased]`
- [x] Updated `AGENTS.md` to document the personalised manifest endpoint
- [x] No secrets or credentials committed

https://claude.ai/code/session_0147auZFBTpH4iZthZ9rWoXf