### PR TITLE
fix(deps): bump click to 8.3.3 (PYSEC-2026-2132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ once a first tagged release ships.
   whenever the browser next re-reads the manifest (roughly on relaunch),
   so a just-created overlay can take a launch or two to appear.
 
+### Security
+
+- **Bump `click` 8.3.2 → 8.3.3** to clear PYSEC-2026-2132, a known
+  vulnerability that `pip-audit --strict` began failing CI on once the
+  advisory was published. `click` is a transitive runtime dependency
+  (pulled in via `uvicorn`); the patch release is API-compatible.
+
 ## [6.2.0] - 2026-07-11
 
 ### Added

--- a/requirements.lock
+++ b/requirements.lock
@@ -14,7 +14,7 @@ certifi==2026.2.25
     # via requests
 charset-normalizer==3.4.7
     # via requests
-click==8.3.2
+click==8.3.3
     # via uvicorn
 fastapi==0.137.2
     # via -r requirements.txt


### PR DESCRIPTION
## Summary

Bump the `click` transitive dependency from 8.3.2 to 8.3.3 in `requirements.lock` to clear **PYSEC-2026-2132**. This advisory started failing the "Security scanners" (`pip-audit --strict`) job on `main` once it was published — a time-triggered failure unrelated to the code merged just before it.

## Changes

- `requirements.lock`: `click==8.3.2` → `click==8.3.3` (transitive runtime dep, pulled in via `uvicorn`).
- `CHANGELOG.md`: `Security` entry under `## [Unreleased]`.

## Implementation notes

- `click` is a transitive runtime dependency; `uvicorn` requires `click>=7.0`, so the 8.3.3 patch is API-compatible. 8.3.3 is the fix version OSV/`pip-audit` lists for the advisory.
- Hand-edited the single pinned line (the lock carries no hashes) instead of regenerating with `uv pip compile`, so no other transitive versions move — the minimal, Dependabot-equivalent change.
- `click` is **not** pinned in `requirements-dev.lock`, so no change is needed there.

## Test plan

- [x] `pip-audit -r requirements.lock --strict` → *No known vulnerabilities found*
- [x] `pip-audit -r requirements-dev.lock --strict` → *No known vulnerabilities found*
- [x] `python -c "import app.bootstrap"` imports cleanly with `click` 8.3.3; `uvicorn` (which needs `click>=7.0`) imports fine
- Lockfile-only change — no `app/` or `frontend/` code is touched, so the ruff / mypy / pytest / frontend gates are unaffected (CI runs them regardless).

## Checklist

- [x] Added a `CHANGELOG.md` entry under `## [Unreleased]` (`Security`)
- [x] No screenshots needed (no operator-facing surface changed)
- [x] Docs unaffected (dependency-only change)
- [x] No secrets, credentials, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147auZFBTpH4iZthZ9rWoXf

---
_Generated by [Claude Code](https://claude.ai/code/session_0147auZFBTpH4iZthZ9rWoXf)_