### PR TITLE
Fix PWA manifest caching for main-screen installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ once a first tagged release ships.
   whenever the browser next re-reads the manifest (roughly on relaunch),
   so a just-created overlay can take a launch or two to appear.
 
+### Fixed
+
+- **PWA installed from the main screen now gets the personalised
+  manifest.** The service worker precached the static build-time copy of
+  `manifest.webmanifest` and answered the bare manifest URL from that
+  cache, so installing from the app root (clean URL) froze the anonymous
+  manifest — no per-user overlay `shortcuts`, and the `APP_TITLE` rename
+  was lost too. Board installs only escaped because their `?oid=` query
+  string bypassed the precache's exact-URL match. The manifest is now
+  excluded from the service-worker precache so every manifest (re)fetch
+  reaches `GET /manifest.webmanifest`, and a main-screen install lists
+  the signed-in owner's overlays in the long-press / jump-list shortcuts
+  just like a board install. Existing installations pick the fix up on
+  their next service-worker update, no reinstall needed.
+
 ### Security
 
 - **Bump `click` 8.3.2 → 8.3.3** to clear PYSEC-2026-2132, a known

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -24,6 +24,38 @@ async function maybeCompression() {
   }
 }
 
+// The backend serves /manifest.webmanifest itself (APP_TITLE rename,
+// per-board start_url variants, and — for a signed-in owner — their
+// overlays as app `shortcuts`, personalised via the vsession cookie; see
+// app/bootstrap.py). vite-plugin-pwa unconditionally adds the static
+// build-time manifest to the service worker precache, and the SW answers
+// bare /manifest.webmanifest fetches from that cache — so a PWA installed
+// from the main screen froze the anonymous build-time manifest (no
+// shortcuts, default title). Board installs only escaped because their
+// ?oid= query string defeats the precache's exact-URL match. Strip the
+// manifest from the precache so every manifest fetch reaches the backend:
+// the manifest is install metadata the browser re-reads over the network,
+// never something the installed app needs offline.
+function serveManifestFromNetwork() {
+  let pwaApi;
+  return {
+    name: 'serve-manifest-from-network',
+    apply: 'build',
+    configResolved(config) {
+      pwaApi = config.plugins.find((p) => p.name === 'vite-plugin-pwa')?.api;
+    },
+    // buildStart runs after every configResolved hook (where the PWA
+    // plugin computes its precache additions) and before its closeBundle
+    // hook generates sw.js — the one window where the precache entry list
+    // is both complete and still editable.
+    buildStart() {
+      pwaApi?.extendManifestEntries((entries) => entries.filter(
+        (entry) => (typeof entry === 'string' ? entry : entry.url) !== 'manifest.webmanifest',
+      ));
+    },
+  };
+}
+
 async function maybeVisualizer() {
   if (!analyze) return null;
   try {
@@ -143,6 +175,7 @@ export default defineConfig(async () => ({
         ],
       },
     }),
+    serveManifestFromNetwork(),
   ],
   server: {
     port: 3000,

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -47,11 +47,15 @@ function serveManifestFromNetwork() {
     // buildStart runs after every configResolved hook (where the PWA
     // plugin computes its precache additions) and before its closeBundle
     // hook generates sw.js — the one window where the precache entry list
-    // is both complete and still editable.
+    // is both complete and still editable. Match by path basename rather
+    // than the exact string so a prefixed entry (e.g. under a non-root
+    // Vite `base`) can't dodge the filter, without also catching
+    // unrelated names that merely end in "manifest.webmanifest".
     buildStart() {
-      pwaApi?.extendManifestEntries((entries) => entries.filter(
-        (entry) => (typeof entry === 'string' ? entry : entry.url) !== 'manifest.webmanifest',
-      ));
+      pwaApi?.extendManifestEntries((entries) => entries.filter((entry) => {
+        const url = typeof entry === 'string' ? entry : entry.url;
+        return url.split('/').pop() !== 'manifest.webmanifest';
+      }));
     },
   };
 }


### PR DESCRIPTION
## Summary

Exclude `manifest.webmanifest` from the service worker precache so that every manifest fetch reaches the backend, ensuring PWA installations from the main screen receive the personalized manifest with user-specific overlays and correct app title.

## Changes

- **PWA installed from the main screen now gets the personalised manifest.** Previously, the service worker precached the static build-time copy of `manifest.webmanifest` and answered bare manifest URL requests from that cache, freezing the anonymous manifest for main-screen installs (no per-user overlay shortcuts, lost `APP_TITLE` rename). Board installs escaped this because their `?oid=` query string bypassed the precache's exact-URL match. The manifest is now excluded from the precache so every manifest fetch reaches `GET /manifest.webmanifest`, and main-screen installs now list the signed-in owner's overlays in shortcuts just like board installs. Existing installations pick up the fix on their next service-worker update.

## Implementation notes

A new Vite plugin `serveManifestFromNetwork()` hooks into the PWA plugin's precache generation during the `buildStart` phase — after the PWA plugin computes its precache entries but before it generates the service worker. The plugin filters out any precache entry matching `manifest.webmanifest`, ensuring the manifest is always fetched from the network rather than served from the cache.

This approach preserves the PWA plugin's normal operation while surgically removing just the manifest from the precache list, allowing the backend to serve personalized manifests based on authentication state and board context.

## Test plan

- [ ] `cd frontend && npm run lint`
- [ ] `cd frontend && npm run typecheck`
- [ ] `cd frontend && npm run test:coverage`
- [ ] Manual smoke test: Install PWA from main screen while signed in, verify overlay shortcuts appear in the app's jump list / long-press menu

## Checklist

- [x] Added a `CHANGELOG.md` entry under `## [Unreleased]`
- [ ] Regenerated screenshots if an operator-facing surface changed
- [ ] Updated relevant docs if behaviour changed
- [ ] No secrets, credentials, or `.env` files committed

https://claude.ai/code/session_016ZnTdtKf5phGE3cgY8t4dA