### PR TITLE
fix: localize scoring accessibility labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ once a first tagged release ships.
 
 ### Fixed
 
+- **Screen readers now follow the selected language throughout the scoring
+  controls.** Score, timeout, serve, dialog, and recent-action accessible
+  labels and gesture instructions now use the six-locale catalog. Icon-only
+  HUD controls expose translated names and pressed state without announcing
+  Material icon ligatures, and a source guard rejects new hard-coded
+  accessible text. Fixes
+  [#436](https://github.com/JacoboSanchez/volley-overlay-control/issues/436).
+
 - **Scoring a point no longer re-reads and re-parses the entire audit
   log.** `GameService.add_point` writes its audit record *before* building
   the state response, and that write bumps the log version the live-stats

--- a/frontend/src/components/CenterPanel.tsx
+++ b/frontend/src/components/CenterPanel.tsx
@@ -121,6 +121,16 @@ function CenterPanel({
   const setsById = { 1: state.team_1.sets, 2: state.team_2.sets } as const;
   // Already gated by the "show logos" toggle upstream — null when off.
   const logosById = { 1: team1Logo, 2: team2Logo } as const;
+  const teamNamesById = {
+    1:
+      asString(customization?.['Team 1 Name']) ||
+      asString(customization?.['Team 1 Text Name']) ||
+      t('scoreboard.team', { team: 1 }),
+    2:
+      asString(customization?.['Team 2 Name']) ||
+      asString(customization?.['Team 2 Text Name']) ||
+      t('scoreboard.team', { team: 2 }),
+  } as const;
 
   return (
     <div className={`center-panel${compactLandscape ? ' center-panel-compact' : ''}`}>
@@ -144,7 +154,7 @@ function CenterPanel({
               {logosById[leftId] && (
                 <img
                   src={logosById[leftId]}
-                  alt={`Team ${leftId}`}
+                  alt={teamNamesById[leftId]}
                   className="team-logo"
                   data-testid={`team-${leftId}-logo`}
                 />
@@ -163,7 +173,7 @@ function CenterPanel({
               {logosById[rightId] && (
                 <img
                   src={logosById[rightId]}
-                  alt={`Team ${rightId}`}
+                  alt={teamNamesById[rightId]}
                   className="team-logo"
                   data-testid={`team-${rightId}-logo`}
                 />
@@ -209,7 +219,9 @@ function CenterPanel({
             aria-pressed={sidesSwapped}
             data-testid="swap-sides-button"
           >
-            <span className="material-icons">swap_horiz</span>
+            <span className="material-icons" aria-hidden="true">
+              swap_horiz
+            </span>
           </button>
         )}
         <MatchAlertIndicator state={state} isPortrait={isPortrait} sidesSwapped={sidesSwapped} />
@@ -246,11 +258,11 @@ function CenterPanel({
           team1Color={btnColorA}
           team1TextColor={btnTextA}
           team1Logo={logosById[1] || null}
-          team1Name={asString(customization?.['Team 1 Name']) || 'Team 1'}
+          team1Name={teamNamesById[1]}
           team2Color={btnColorB}
           team2TextColor={btnTextB}
           team2Logo={logosById[2] || null}
-          team2Name={asString(customization?.['Team 2 Name']) || 'Team 2'}
+          team2Name={teamNamesById[2]}
         />
       )}
     </div>

--- a/frontend/src/components/ControlButtons.tsx
+++ b/frontend/src/components/ControlButtons.tsx
@@ -117,7 +117,9 @@ export default function ControlButtons({
           title={t('ctrl.reset')}
           data-testid="reset-button"
         >
-          <span className="material-icons">restart_alt</span>
+          <span className="material-icons" aria-hidden="true">
+            restart_alt
+          </span>
           <span>{t('ctrl.reset')}</span>
         </button>
       ) : (
@@ -127,7 +129,9 @@ export default function ControlButtons({
           title={t('ctrl.startMatch')}
           data-testid="start-match-button"
         >
-          <span className="material-icons">play_arrow</span>
+          <span className="material-icons" aria-hidden="true">
+            play_arrow
+          </span>
           <span>{t('ctrl.startMatch')}</span>
         </button>
       )}
@@ -141,7 +145,9 @@ export default function ControlButtons({
           title={t('ctrl.viewReport')}
           data-testid="view-report-button"
         >
-          <span className="material-icons">description</span>
+          <span className="material-icons" aria-hidden="true">
+            description
+          </span>
           <span>{t('ctrl.viewReport')}</span>
         </a>
       )}
@@ -158,7 +164,9 @@ export default function ControlButtons({
           data-testid="onair-indicator"
         >
           <span className="control-onair-dot" />
-          <span className="material-icons">podcasts</span>
+          <span className="material-icons" aria-hidden="true">
+            podcasts
+          </span>
           <span className="control-onair-count">{obsClients}</span>
         </span>
       )}
@@ -173,9 +181,12 @@ export default function ControlButtons({
         onClick={onUndoLast}
         disabled={!canUndo}
         title={t('ctrl.undoLast')}
+        aria-label={t('ctrl.undoLast')}
         data-testid="undo-button"
       >
-        <span className="material-icons">undo</span>
+        <span className="material-icons" aria-hidden="true">
+          undo
+        </span>
       </button>
 
       <button
@@ -186,9 +197,13 @@ export default function ControlButtons({
         }}
         onClick={onToggleSimpleMode}
         title={simpleMode ? t('ctrl.fullScoreboard') : t('ctrl.simpleScoreboard')}
+        aria-label={t('ctrl.simpleScoreboard')}
+        aria-pressed={simpleMode}
         data-testid="simple-mode-button"
       >
-        <span className="material-icons">{simpleMode ? 'window' : 'grid_on'}</span>
+        <span className="material-icons" aria-hidden="true">
+          {simpleMode ? 'window' : 'grid_on'}
+        </span>
       </button>
 
       <button
@@ -199,9 +214,13 @@ export default function ControlButtons({
         }}
         onClick={onTogglePreview}
         title={showPreview ? t('ctrl.hidePreview') : t('ctrl.showPreview')}
+        aria-label={t('links.preview')}
+        aria-pressed={showPreview}
         data-testid="preview-button"
       >
-        <span className="material-icons">{showPreview ? 'tv' : 'tv_off'}</span>
+        <span className="material-icons" aria-hidden="true">
+          {showPreview ? 'tv' : 'tv_off'}
+        </span>
       </button>
 
       {setSummaryEnabled && onToggleSetSummary && (
@@ -217,10 +236,13 @@ export default function ControlButtons({
           }}
           onClick={onToggleSetSummary}
           title={t('setSummary.toggle')}
+          aria-label={t('setSummary.toggle')}
           aria-pressed={!!setSummaryActive}
           data-testid="set-summary-button"
         >
-          <span className="material-icons">summarize</span>
+          <span className="material-icons" aria-hidden="true">
+            summarize
+          </span>
         </button>
       )}
 
@@ -232,9 +254,13 @@ export default function ControlButtons({
         }}
         onClick={onToggleVisibility}
         title={visible ? t('ctrl.hideOverlay') : t('ctrl.showOverlay')}
+        aria-label={t('ctrl.overlayVisibility')}
+        aria-pressed={visible}
         data-testid="visibility-button"
       >
-        <span className="material-icons">{visible ? 'visibility' : 'visibility_off'}</span>
+        <span className="material-icons" aria-hidden="true">
+          {visible ? 'visibility' : 'visibility_off'}
+        </span>
       </button>
     </div>
   );

--- a/frontend/src/components/Dialog.tsx
+++ b/frontend/src/components/Dialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, ReactNode } from 'react';
+import { useI18n } from '../i18n';
 
 export interface DialogProps {
   /** Whether the dialog is currently visible. */
@@ -29,6 +30,7 @@ export default function Dialog({
   ariaLabelledBy,
   children,
 }: DialogProps) {
+  const { t } = useI18n();
   const cardRef = useRef<HTMLDivElement>(null);
 
   // Focus the card on the open transition only. Splitting this from the
@@ -101,7 +103,7 @@ export default function Dialog({
         type="button"
         className="dialog-backdrop"
         onClick={onClose}
-        aria-label="Close dialog"
+        aria-label={t('dialog.close')}
         tabIndex={-1}
       />
       <div

--- a/frontend/src/components/PointsHistoryStrip.tsx
+++ b/frontend/src/components/PointsHistoryStrip.tsx
@@ -1,6 +1,7 @@
 import type { RecentEvent } from '../hooks/useRecentEvents';
 import { getReadableOnSurface } from '../utils/contrast';
 import { useSurfaceColor } from '../hooks/useSurfaceColor';
+import { useI18n, type Translate } from '../i18n';
 
 // Markers are non-text UI shapes — WCAG AA only requires 3:1 here.
 const MARKER_MIN_RATIO = 3;
@@ -34,14 +35,14 @@ const POINT_TYPE_ABBR: Record<string, string> = {
   opp_error: 'E',
 };
 
-// Readable words for screen readers, so the aria-label never announces
-// the raw programmatic token (e.g. "opp_error"). Matches the
-// English-only convention of this strip's other aria-labels.
-const POINT_TYPE_ARIA: Record<string, string> = {
-  ace: 'ace',
-  kill: 'kill',
-  block: 'block',
-  opp_error: 'opponent error',
+// Translation keys for the full words announced by screen readers, so
+// the aria-label never exposes a raw programmatic token such as
+// ``opp_error``.
+const POINT_TYPE_ARIA_KEYS: Record<string, string> = {
+  ace: 'pointType.ace',
+  kill: 'pointType.kill',
+  block: 'pointType.block',
+  opp_error: 'pointType.opp_error',
 };
 
 function ClockIcon() {
@@ -118,20 +119,22 @@ function chipContent(ev: RecentEvent) {
   }
 }
 
-function chipAriaLabel(ev: RecentEvent, teamName: string): string {
+function chipAriaLabel(ev: RecentEvent, teamName: string, t: Translate): string {
   switch (ev.kind) {
-    case 'point_add':
-      return ev.pointType
-        ? `${teamName}: +1 (${POINT_TYPE_ARIA[ev.pointType] ?? ev.pointType})`
-        : `${teamName}: +1`;
+    case 'point_add': {
+      if (!ev.pointType) return t('history.chip.point', { team: teamName });
+      const typeKey = POINT_TYPE_ARIA_KEYS[ev.pointType];
+      const type = typeKey ? t(typeKey) : ev.pointType;
+      return t('history.chip.typedPoint', { team: teamName, type });
+    }
     case 'set_won':
-      return `${teamName}: set won`;
+      return t('history.chip.setWon', { team: teamName });
     case 'match_won':
-      return `${teamName}: match won`;
+      return t('history.chip.matchWon', { team: teamName });
     case 'timeout':
-      return `${teamName}: timeout`;
+      return t('history.chip.timeout', { team: teamName });
     case 'manual':
-      return `${teamName}: manual ${ev.value ?? 0}`;
+      return t('history.chip.manual', { team: teamName, value: ev.value ?? 0 });
   }
 }
 
@@ -142,6 +145,7 @@ interface RowProps {
   textColor: string;
   logo: string | null;
   name: string;
+  t: Translate;
 }
 
 function Row({
@@ -151,6 +155,7 @@ function Row({
   textColor,
   logo,
   name,
+  t,
   surface,
 }: RowProps & { surface: string }) {
   const markerColor = getReadableOnSurface(color, surface, MARKER_MIN_RATIO);
@@ -177,7 +182,7 @@ function Row({
                 className={`phs-chip phs-chip-${ev.kind}`}
                 style={{ backgroundColor: color, color: textColor }}
                 data-testid={`phs-chip-${team}-${i}`}
-                aria-label={chipAriaLabel(ev, name)}
+                aria-label={chipAriaLabel(ev, name, t)}
               >
                 {chipContent(ev)}
               </span>
@@ -201,6 +206,7 @@ export default function PointsHistoryStrip({
   team2Name,
   swapped = false,
 }: PointsHistoryStripProps) {
+  const { t } = useI18n();
   const surface = useSurfaceColor();
   if (events.length === 0) return null;
   const rows = [
@@ -212,6 +218,7 @@ export default function PointsHistoryStrip({
       textColor={team1TextColor}
       logo={team1Logo}
       name={team1Name}
+      t={t}
       surface={surface}
     />,
     <Row
@@ -222,6 +229,7 @@ export default function PointsHistoryStrip({
       textColor={team2TextColor}
       logo={team2Logo}
       name={team2Name}
+      t={t}
       surface={surface}
     />,
   ];
@@ -230,7 +238,7 @@ export default function PointsHistoryStrip({
     <div
       className="points-history-strip"
       data-testid="points-history-strip"
-      aria-label="Recent actions"
+      aria-label={t('history.recentActions')}
     >
       {rows}
     </div>

--- a/frontend/src/components/TeamPanel.tsx
+++ b/frontend/src/components/TeamPanel.tsx
@@ -224,7 +224,6 @@ function TeamPanel({
               color: readableServeColor,
               opacity: isServing ? 1 : 0.4,
               cursor: 'pointer',
-              fontSize: '2rem',
               border: 'none',
               background: 'transparent',
               padding: 0,
@@ -232,7 +231,7 @@ function TeamPanel({
             onClick={() => onChangeServe(teamId)}
             data-testid={`team-${teamId}-serve`}
           >
-            <span className="material-icons" aria-hidden="true">
+            <span className="material-icons" aria-hidden="true" style={{ fontSize: '2rem' }}>
               sports_volleyball
             </span>
           </button>

--- a/frontend/src/components/TeamPanel.tsx
+++ b/frontend/src/components/TeamPanel.tsx
@@ -7,6 +7,7 @@ import { toNumber, asString } from '../utils/coerce';
 import { getReadableOnSurface } from '../utils/contrast';
 import { useDoubleTap } from '../hooks/useDoubleTap';
 import { useSurfaceColor } from '../hooks/useSurfaceColor';
+import { useI18n } from '../i18n';
 
 export interface TeamPanelProps {
   teamId: 1 | 2;
@@ -76,6 +77,7 @@ function TeamPanel({
   onDoubleTapTimeout,
   onLongPressScore,
 }: TeamPanelProps) {
+  const { t } = useI18n();
   const score = toNumber(teamState?.scores?.[`set_${currentSet}`]);
   const timeouts = teamState?.timeouts ?? 0;
   const isServing = teamState?.serving ?? false;
@@ -110,8 +112,8 @@ function TeamPanel({
   const teamNameLabel =
     asString(customization?.[`Team ${teamId} Name`]) ||
     asString(customization?.[`Team ${teamId} Text Name`]) ||
-    `Team ${teamId === 1 ? 'A' : 'B'}`;
-  const scoreAriaLabel = `${teamNameLabel} score ${score}`;
+    t('scoreboard.team', { team: teamId });
+  const scoreAriaLabel = t('scoreboard.score', { team: teamNameLabel, score });
   const scoreDescId = `team-${teamId}-score-help`;
 
   const timeoutDots: ReactElement[] = [];
@@ -158,7 +160,7 @@ function TeamPanel({
             {safeIconLogo && (
               <img
                 src={safeIconLogo}
-                alt={`Team ${teamId}`}
+                alt={teamNameLabel}
                 className="team-logo"
                 data-testid={`team-${teamId}-logo`}
               />
@@ -186,7 +188,7 @@ function TeamPanel({
           data-testid={`team-${teamId}-score`}
         />
         <span id={scoreDescId} className="visually-hidden">
-          Tap to add point, double-tap to undo, long-press to set value.
+          {t('scoreboard.scoreHelp')}
         </span>
         <div className={isPortrait ? 'team-side-col' : 'team-side-row'}>
           <div className={isPortrait ? 'team-side-group-col' : 'team-side-group-row'}>
@@ -194,14 +196,16 @@ function TeamPanel({
               className="timeout-button"
               style={{ borderColor: readableTimeoutColor, color: readableTimeoutColor }}
               {...timeoutHandlers}
-              aria-label={`Team ${teamId} timeout`}
+              aria-label={t('scoreboard.timeout', { team: teamNameLabel })}
               aria-describedby={`team-${teamId}-timeout-help`}
               data-testid={`team-${teamId}-timeout`}
             >
-              <span className="material-icons">timer</span>
+              <span className="material-icons" aria-hidden="true">
+                timer
+              </span>
             </button>
             <span id={`team-${teamId}-timeout-help`} className="visually-hidden">
-              Tap to add timeout, double-tap to undo.
+              {t('scoreboard.timeoutHelp')}
             </span>
             <div
               className={`timeout-dots ${isPortrait ? 'timeout-dots-col' : 'timeout-dots-row'}`}
@@ -213,8 +217,8 @@ function TeamPanel({
           {!isPortrait && <div className="spacer" />}
           <button
             type="button"
-            className="material-icons serve-icon"
-            aria-label={`Team ${teamId} serve`}
+            className="serve-icon"
+            aria-label={t('scoreboard.serve', { team: teamNameLabel })}
             aria-pressed={isServing}
             style={{
               color: readableServeColor,
@@ -228,7 +232,9 @@ function TeamPanel({
             onClick={() => onChangeServe(teamId)}
             data-testid={`team-${teamId}-serve`}
           >
-            sports_volleyball
+            <span className="material-icons" aria-hidden="true">
+              sports_volleyball
+            </span>
           </button>
         </div>
       </div>

--- a/frontend/src/i18n/translations.ts
+++ b/frontend/src/i18n/translations.ts
@@ -15,12 +15,14 @@ export const translations: Record<string, TranslationDict> = {
     // Dialog
     'dialog.ok': 'OK',
     'dialog.cancel': 'Cancel',
+    'dialog.close': 'Close dialog',
     'dialog.setScore': 'Set score — Team {team}',
     'dialog.setSets': 'Set sets won — Team {team}',
 
     // Control buttons
     'ctrl.hideOverlay': 'Hide overlay',
     'ctrl.showOverlay': 'Show overlay',
+    'ctrl.overlayVisibility': 'Overlay visibility',
     'ctrl.hideControls': 'Hide controls',
     'ctrl.showControls': 'Show controls',
     'board.invalidLink.title': 'This control link is no longer valid',
@@ -81,6 +83,7 @@ export const translations: Record<string, TranslationDict> = {
 
     // Recent-audit drawer (Phase 4.2)
     'history.title': 'History',
+    'history.recentActions': 'Recent actions',
     'history.close': 'Close history',
     'history.refresh': 'Refresh',
     'history.empty': 'No recent actions yet.',
@@ -97,6 +100,12 @@ export const translations: Record<string, TranslationDict> = {
     'history.action.reset': 'Reset',
     'history.action.unknown': '(unknown action)',
     'history.action.undoSuffix': ' (undone)',
+    'history.chip.point': '{team}: +1',
+    'history.chip.typedPoint': '{team}: +1 ({type})',
+    'history.chip.setWon': '{team}: set won',
+    'history.chip.matchWon': '{team}: match won',
+    'history.chip.timeout': '{team}: timeout',
+    'history.chip.manual': '{team}: manual {value}',
     'history.legend.pointT1': 'Point T1',
     'history.legend.pointT2': 'Point T2',
     'history.legend.set': 'Set won',
@@ -194,6 +203,12 @@ export const translations: Record<string, TranslationDict> = {
     'rules.autoSwapSidesHint':
       'Mirror the scoreboard and overlays on set changes and mid-set switch points.',
     'scoreboard.swapSides': 'Swap sides',
+    'scoreboard.team': 'Team {team}',
+    'scoreboard.score': '{team}, score {score}',
+    'scoreboard.scoreHelp': 'Tap to add a point, double-tap to undo, or long-press to set a value.',
+    'scoreboard.timeout': '{team}, timeout',
+    'scoreboard.timeoutHelp': 'Tap to add a timeout or double-tap to undo.',
+    'scoreboard.serve': '{team}, serve',
     'rules.sideSwitchInN': 'Side switch in {n}',
     'rules.mode.table_tennis': 'Table tennis',
     'rules.bestOf.7': 'Best of 7',
@@ -870,12 +885,14 @@ export const translations: Record<string, TranslationDict> = {
     // Dialog
     'dialog.ok': 'OK',
     'dialog.cancel': 'Cancelar',
+    'dialog.close': 'Cerrar diálogo',
     'dialog.setScore': 'Puntuación — Equipo {team}',
     'dialog.setSets': 'Sets ganados — Equipo {team}',
 
     // Control buttons
     'ctrl.hideOverlay': 'Ocultar overlay',
     'ctrl.showOverlay': 'Mostrar overlay',
+    'ctrl.overlayVisibility': 'Visibilidad del overlay',
     'ctrl.hideControls': 'Ocultar controles',
     'ctrl.showControls': 'Mostrar controles',
     'board.invalidLink.title': 'Este enlace de control ya no es válido',
@@ -937,6 +954,7 @@ export const translations: Record<string, TranslationDict> = {
 
     // Recent-audit drawer (Phase 4.2)
     'history.title': 'Historial',
+    'history.recentActions': 'Acciones recientes',
     'history.close': 'Cerrar historial',
     'history.refresh': 'Actualizar',
     'history.empty': 'Sin acciones recientes.',
@@ -953,6 +971,12 @@ export const translations: Record<string, TranslationDict> = {
     'history.action.reset': 'Reinicio',
     'history.action.unknown': '(acción desconocida)',
     'history.action.undoSuffix': ' (deshecho)',
+    'history.chip.point': '{team}: +1',
+    'history.chip.typedPoint': '{team}: +1 ({type})',
+    'history.chip.setWon': '{team}: set ganado',
+    'history.chip.matchWon': '{team}: partido ganado',
+    'history.chip.timeout': '{team}: tiempo muerto',
+    'history.chip.manual': '{team}: ajuste manual {value}',
     'history.legend.pointT1': 'Punto E1',
     'history.legend.pointT2': 'Punto E2',
     'history.legend.set': 'Set ganado',
@@ -1051,6 +1075,13 @@ export const translations: Record<string, TranslationDict> = {
     'rules.autoSwapSidesHint':
       'Refleja el marcador y los overlays en los cambios de set y en los puntos de cambio de campo.',
     'scoreboard.swapSides': 'Cambiar de lado',
+    'scoreboard.team': 'Equipo {team}',
+    'scoreboard.score': '{team}, puntuación {score}',
+    'scoreboard.scoreHelp':
+      'Toca para sumar un punto, toca dos veces para deshacer o mantén pulsado para establecer un valor.',
+    'scoreboard.timeout': '{team}, tiempo muerto',
+    'scoreboard.timeoutHelp': 'Toca para sumar un tiempo muerto o toca dos veces para deshacer.',
+    'scoreboard.serve': '{team}, saque',
     'rules.sideSwitchInN': 'Cambio de lado en {n}',
     'rules.mode.table_tennis': 'Tenis de mesa',
     'rules.bestOf.7': 'Al mejor de 7',
@@ -1733,12 +1764,14 @@ export const translations: Record<string, TranslationDict> = {
     // Dialog
     'dialog.ok': 'OK',
     'dialog.cancel': 'Cancelar',
+    'dialog.close': 'Fechar diálogo',
     'dialog.setScore': 'Pontuação — Equipa {team}',
     'dialog.setSets': 'Sets ganhos — Equipa {team}',
 
     // Control buttons
     'ctrl.hideOverlay': 'Ocultar overlay',
     'ctrl.showOverlay': 'Mostrar overlay',
+    'ctrl.overlayVisibility': 'Visibilidade do overlay',
     'ctrl.hideControls': 'Ocultar controlos',
     'ctrl.showControls': 'Mostrar controlos',
     'board.invalidLink.title': 'Esta ligação de controlo já não é válida',
@@ -1800,6 +1833,7 @@ export const translations: Record<string, TranslationDict> = {
 
     // Recent-audit drawer (Phase 4.2)
     'history.title': 'Histórico',
+    'history.recentActions': 'Ações recentes',
     'history.close': 'Fechar histórico',
     'history.refresh': 'Atualizar',
     'history.empty': 'Sem ações recentes.',
@@ -1816,6 +1850,12 @@ export const translations: Record<string, TranslationDict> = {
     'history.action.reset': 'Reinício',
     'history.action.unknown': '(ação desconhecida)',
     'history.action.undoSuffix': ' (desfeito)',
+    'history.chip.point': '{team}: +1',
+    'history.chip.typedPoint': '{team}: +1 ({type})',
+    'history.chip.setWon': '{team}: set ganho',
+    'history.chip.matchWon': '{team}: jogo ganho',
+    'history.chip.timeout': '{team}: tempo morto',
+    'history.chip.manual': '{team}: ajuste manual {value}',
     'history.legend.pointT1': 'Ponto E1',
     'history.legend.pointT2': 'Ponto E2',
     'history.legend.set': 'Set ganho',
@@ -1914,6 +1954,14 @@ export const translations: Record<string, TranslationDict> = {
     'rules.autoSwapSidesHint':
       'Espelha o placar e os overlays nas mudanças de set e nos pontos de troca de quadra.',
     'scoreboard.swapSides': 'Trocar de lado',
+    'scoreboard.team': 'Equipa {team}',
+    'scoreboard.score': '{team}, pontuação {score}',
+    'scoreboard.scoreHelp':
+      'Toque para adicionar um ponto, toque duas vezes para desfazer ou mantenha premido para definir um valor.',
+    'scoreboard.timeout': '{team}, tempo morto',
+    'scoreboard.timeoutHelp':
+      'Toque para adicionar um tempo morto ou toque duas vezes para desfazer.',
+    'scoreboard.serve': '{team}, saque',
     'rules.sideSwitchInN': 'Troca de lado em {n}',
     'rules.mode.table_tennis': 'Tênis de mesa',
     'rules.bestOf.7': 'À melhor de 7',
@@ -2588,12 +2636,14 @@ export const translations: Record<string, TranslationDict> = {
     // Dialog
     'dialog.ok': 'OK',
     'dialog.cancel': 'Annulla',
+    'dialog.close': 'Chiudi finestra',
     'dialog.setScore': 'Punteggio — Squadra {team}',
     'dialog.setSets': 'Set vinti — Squadra {team}',
 
     // Control buttons
     'ctrl.hideOverlay': 'Nascondi overlay',
     'ctrl.showOverlay': 'Mostra overlay',
+    'ctrl.overlayVisibility': 'Visibilità overlay',
     'ctrl.hideControls': 'Nascondi controlli',
     'ctrl.showControls': 'Mostra controlli',
     'board.invalidLink.title': 'Questo link di controllo non è più valido',
@@ -2655,6 +2705,7 @@ export const translations: Record<string, TranslationDict> = {
 
     // Recent-audit drawer (Phase 4.2)
     'history.title': 'Cronologia',
+    'history.recentActions': 'Azioni recenti',
     'history.close': 'Chiudi cronologia',
     'history.refresh': 'Aggiorna',
     'history.empty': 'Nessuna azione recente.',
@@ -2671,6 +2722,12 @@ export const translations: Record<string, TranslationDict> = {
     'history.action.reset': 'Reset',
     'history.action.unknown': '(azione sconosciuta)',
     'history.action.undoSuffix': ' (annullato)',
+    'history.chip.point': '{team}: +1',
+    'history.chip.typedPoint': '{team}: +1 ({type})',
+    'history.chip.setWon': '{team}: set vinto',
+    'history.chip.matchWon': '{team}: partita vinta',
+    'history.chip.timeout': '{team}: time-out',
+    'history.chip.manual': '{team}: modifica manuale {value}',
     'history.legend.pointT1': 'Punto S1',
     'history.legend.pointT2': 'Punto S2',
     'history.legend.set': 'Set vinto',
@@ -2769,6 +2826,13 @@ export const translations: Record<string, TranslationDict> = {
     'rules.autoSwapSidesHint':
       'Specchia tabellone e overlay ai cambi di set e ai punti di cambio campo.',
     'scoreboard.swapSides': 'Cambia lato',
+    'scoreboard.team': 'Squadra {team}',
+    'scoreboard.score': '{team}, punteggio {score}',
+    'scoreboard.scoreHelp':
+      'Tocca per aggiungere un punto, tocca due volte per annullare o tieni premuto per impostare un valore.',
+    'scoreboard.timeout': '{team}, time-out',
+    'scoreboard.timeoutHelp': 'Tocca per aggiungere un time-out o tocca due volte per annullare.',
+    'scoreboard.serve': '{team}, servizio',
     'rules.sideSwitchInN': 'Cambio campo tra {n}',
     'rules.mode.table_tennis': 'Ping pong',
     'rules.bestOf.7': 'Al meglio di 7',
@@ -3443,12 +3507,14 @@ export const translations: Record<string, TranslationDict> = {
     // Dialog
     'dialog.ok': 'OK',
     'dialog.cancel': 'Annuler',
+    'dialog.close': 'Fermer la boîte de dialogue',
     'dialog.setScore': 'Score — Équipe {team}',
     'dialog.setSets': 'Sets gagnés — Équipe {team}',
 
     // Control buttons
     'ctrl.hideOverlay': 'Masquer l’overlay',
     'ctrl.showOverlay': 'Afficher l’overlay',
+    'ctrl.overlayVisibility': 'Visibilité de l’overlay',
     'ctrl.hideControls': 'Masquer les commandes',
     'ctrl.showControls': 'Afficher les commandes',
     'board.invalidLink.title': 'Ce lien de contrôle n’est plus valide',
@@ -3510,6 +3576,7 @@ export const translations: Record<string, TranslationDict> = {
 
     // Recent-audit drawer (Phase 4.2)
     'history.title': 'Historique',
+    'history.recentActions': 'Actions récentes',
     'history.close': 'Fermer l’historique',
     'history.refresh': 'Actualiser',
     'history.empty': 'Aucune action récente.',
@@ -3526,6 +3593,12 @@ export const translations: Record<string, TranslationDict> = {
     'history.action.reset': 'Réinitialisation',
     'history.action.unknown': '(action inconnue)',
     'history.action.undoSuffix': ' (annulé)',
+    'history.chip.point': '{team} : +1',
+    'history.chip.typedPoint': '{team} : +1 ({type})',
+    'history.chip.setWon': '{team} : set gagné',
+    'history.chip.matchWon': '{team} : match gagné',
+    'history.chip.timeout': '{team} : temps mort',
+    'history.chip.manual': '{team} : réglage manuel {value}',
     'history.legend.pointT1': 'Point É1',
     'history.legend.pointT2': 'Point É2',
     'history.legend.set': 'Set gagné',
@@ -3625,6 +3698,14 @@ export const translations: Record<string, TranslationDict> = {
     'rules.autoSwapSidesHint':
       'Inverse le tableau et les overlays aux changements de set et aux points de changement de côté.',
     'scoreboard.swapSides': 'Changer de côté',
+    'scoreboard.team': 'Équipe {team}',
+    'scoreboard.score': '{team}, score {score}',
+    'scoreboard.scoreHelp':
+      'Touchez pour ajouter un point, touchez deux fois pour annuler ou maintenez appuyé pour définir une valeur.',
+    'scoreboard.timeout': '{team}, temps mort',
+    'scoreboard.timeoutHelp':
+      'Touchez pour ajouter un temps mort ou touchez deux fois pour annuler.',
+    'scoreboard.serve': '{team}, service',
     'rules.sideSwitchInN': 'Changement de côté dans {n}',
     'rules.mode.table_tennis': 'Tennis de table',
     'rules.bestOf.7': 'Au meilleur des 7',
@@ -4305,12 +4386,14 @@ export const translations: Record<string, TranslationDict> = {
     // Dialog
     'dialog.ok': 'OK',
     'dialog.cancel': 'Abbrechen',
+    'dialog.close': 'Dialog schließen',
     'dialog.setScore': 'Punktestand — Team {team}',
     'dialog.setSets': 'Gewonnene Sätze — Team {team}',
 
     // Control buttons
     'ctrl.hideOverlay': 'Overlay ausblenden',
     'ctrl.showOverlay': 'Overlay einblenden',
+    'ctrl.overlayVisibility': 'Overlay-Sichtbarkeit',
     'ctrl.hideControls': 'Steuerung ausblenden',
     'ctrl.showControls': 'Steuerung einblenden',
     'board.invalidLink.title': 'Dieser Steuerungslink ist nicht mehr gültig',
@@ -4372,6 +4455,7 @@ export const translations: Record<string, TranslationDict> = {
 
     // Recent-audit drawer (Phase 4.2)
     'history.title': 'Verlauf',
+    'history.recentActions': 'Letzte Aktionen',
     'history.close': 'Verlauf schließen',
     'history.refresh': 'Aktualisieren',
     'history.empty': 'Noch keine Aktionen.',
@@ -4388,6 +4472,12 @@ export const translations: Record<string, TranslationDict> = {
     'history.action.reset': 'Reset',
     'history.action.unknown': '(unbekannte Aktion)',
     'history.action.undoSuffix': ' (rückgängig)',
+    'history.chip.point': '{team}: +1',
+    'history.chip.typedPoint': '{team}: +1 ({type})',
+    'history.chip.setWon': '{team}: Satz gewonnen',
+    'history.chip.matchWon': '{team}: Spiel gewonnen',
+    'history.chip.timeout': '{team}: Auszeit',
+    'history.chip.manual': '{team}: manuell {value}',
     'history.legend.pointT1': 'Punkt T1',
     'history.legend.pointT2': 'Punkt T2',
     'history.legend.set': 'Satzgewinn',
@@ -4487,6 +4577,13 @@ export const translations: Record<string, TranslationDict> = {
     'rules.autoSwapSidesHint':
       'Spiegelt Anzeigetafel und Overlays bei Satzwechseln und Seitenwechselpunkten.',
     'scoreboard.swapSides': 'Seiten tauschen',
+    'scoreboard.team': 'Team {team}',
+    'scoreboard.score': '{team}, Punktestand {score}',
+    'scoreboard.scoreHelp':
+      'Tippen fügt einen Punkt hinzu, Doppeltippen macht rückgängig und Gedrückthalten legt einen Wert fest.',
+    'scoreboard.timeout': '{team}, Auszeit',
+    'scoreboard.timeoutHelp': 'Tippen fügt eine Auszeit hinzu, Doppeltippen macht sie rückgängig.',
+    'scoreboard.serve': '{team}, Aufschlag',
     'rules.sideSwitchInN': 'Seitenwechsel in {n}',
     'rules.mode.table_tennis': 'Tischtennis',
     'rules.bestOf.7': 'Best of 7',

--- a/frontend/src/test/CenterPanel.test.tsx
+++ b/frontend/src/test/CenterPanel.test.tsx
@@ -24,6 +24,7 @@ const defaultProps = {
 describe('CenterPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
   });
 
   it('returns null when state is null', () => {
@@ -81,6 +82,21 @@ describe('CenterPanel', () => {
     );
     expect(screen.getByTestId('team-1-logo')).toHaveAttribute('src', 'logo1.png');
     expect(screen.getByTestId('team-2-logo')).toHaveAttribute('src', 'logo2.png');
+  });
+
+  it('uses localized fallback team names for logo alt text', () => {
+    localStorage.setItem('volley_lang', 'es');
+    renderWithI18n(
+      <CenterPanel
+        {...defaultProps}
+        customization={null}
+        team1Logo="logo1.png"
+        team2Logo="logo2.png"
+        isPortrait={false}
+      />,
+    );
+    expect(screen.getByTestId('team-1-logo')).toHaveAttribute('alt', 'Equipo 1');
+    expect(screen.getByTestId('team-2-logo')).toHaveAttribute('alt', 'Equipo 2');
   });
 
   it('hides logos when they are turned off, regardless of the customization', () => {

--- a/frontend/src/test/ControlButtons.test.tsx
+++ b/frontend/src/test/ControlButtons.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent } from '@testing-library/react';
 import { I18nProvider } from '../i18n';
 import { SettingsProvider } from '../hooks/useSettings';
@@ -21,6 +21,10 @@ const defaultProps = {
 };
 
 describe('ControlButtons', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('renders the in-game control buttons', () => {
     renderWithI18n(<ControlButtons {...defaultProps} />);
     expect(screen.getByTestId('visibility-button')).toBeInTheDocument();
@@ -215,5 +219,34 @@ describe('ControlButtons', () => {
       <ControlButtons {...defaultProps} matchFinished lastMatchId="m1" showReportLink={false} />,
     );
     expect(screen.queryByTestId('view-report-button')).toBeNull();
+  });
+
+  it('localizes icon-only controls and exposes toggle state', () => {
+    localStorage.setItem('volley_lang', 'es');
+    const { container } = renderWithI18n(
+      <ControlButtons
+        {...defaultProps}
+        visible
+        simpleMode
+        showPreview={false}
+        setSummaryEnabled
+        setSummaryActive={false}
+        onToggleSetSummary={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('undo-button')).toHaveAccessibleName('Deshacer última acción');
+    expect(screen.getByTestId('simple-mode-button')).toHaveAccessibleName('Marcador simple');
+    expect(screen.getByTestId('simple-mode-button')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('preview-button')).toHaveAccessibleName('Vista previa');
+    expect(screen.getByTestId('preview-button')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByTestId('visibility-button')).toHaveAccessibleName('Visibilidad del overlay');
+    expect(screen.getByTestId('visibility-button')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTestId('set-summary-button')).toHaveAccessibleName(
+      'Mostrar resumen del set en el overlay',
+    );
+    for (const icon of container.querySelectorAll('.material-icons')) {
+      expect(icon).toHaveAttribute('aria-hidden', 'true');
+    }
   });
 });

--- a/frontend/src/test/Dialog.test.tsx
+++ b/frontend/src/test/Dialog.test.tsx
@@ -1,8 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Dialog from '../components/Dialog';
+import { renderWithI18n } from './helpers';
 
 describe('Dialog', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('renders nothing when closed', () => {
     render(
       <Dialog open={false} onClose={() => {}} ariaLabel="Test dialog">
@@ -63,6 +68,16 @@ describe('Dialog', () => {
     );
     fireEvent.click(screen.getByLabelText('Close dialog'));
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('localizes the backdrop accessible name', () => {
+    localStorage.setItem('volley_lang', 'es');
+    renderWithI18n(
+      <Dialog open onClose={() => {}} ariaLabel="Prueba">
+        <p>Contenido</p>
+      </Dialog>,
+    );
+    expect(screen.getByRole('button', { name: 'Cerrar diálogo' })).toBeInTheDocument();
   });
 
   it('does not listen for Escape after closing', () => {

--- a/frontend/src/test/PointsHistoryStrip.test.tsx
+++ b/frontend/src/test/PointsHistoryStrip.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import PointsHistoryStrip from '../components/PointsHistoryStrip';
 import type { RecentEvent } from '../hooks/useRecentEvents';
+import { renderWithI18n } from './helpers';
 
 const COMMON = {
   team1Color: '#1a73e8',
@@ -130,5 +131,26 @@ describe('PointsHistoryStrip', () => {
     );
     expect(screen.getByTestId('phs-chip-1-0')).toHaveAttribute('aria-label', 'Home: set won');
     expect(screen.getByTestId('phs-chip-2-1')).toHaveAttribute('aria-label', 'Away: match won');
+  });
+
+  it('localizes the strip and every computed event label', () => {
+    localStorage.setItem('volley_lang', 'es');
+    renderWithI18n(
+      strip([
+        { ts: 1, team: 1, kind: 'point_add', pointType: 'kill' },
+        { ts: 2, team: 1, kind: 'set_won' },
+        { ts: 3, team: 2, kind: 'match_won' },
+        { ts: 4, team: 2, kind: 'timeout' },
+        { ts: 5, team: 1, kind: 'manual', value: 7 },
+      ]),
+    );
+
+    expect(screen.getByTestId('points-history-strip')).toHaveAccessibleName('Acciones recientes');
+    expect(screen.getByTestId('phs-chip-1-0')).toHaveAccessibleName('Home: +1 (Ataque)');
+    expect(screen.getByTestId('phs-chip-1-1')).toHaveAccessibleName('Home: set ganado');
+    expect(screen.getByTestId('phs-chip-2-2')).toHaveAccessibleName('Away: partido ganado');
+    expect(screen.getByTestId('phs-chip-2-3')).toHaveAccessibleName('Away: tiempo muerto');
+    expect(screen.getByTestId('phs-chip-1-4')).toHaveAccessibleName('Home: ajuste manual 7');
+    localStorage.clear();
   });
 });

--- a/frontend/src/test/TeamPanel.test.tsx
+++ b/frontend/src/test/TeamPanel.test.tsx
@@ -61,6 +61,7 @@ describe('TeamPanel', () => {
     const serve = screen.getByTestId('team-1-serve');
     expect(serve).toBeInTheDocument();
     expect(serve.style.opacity).toBe('1');
+    expect(serve.querySelector('.material-icons')).toHaveStyle({ fontSize: '2rem' });
   });
 
   it('renders serve icon dimmed when not serving', () => {

--- a/frontend/src/test/TeamPanel.test.tsx
+++ b/frontend/src/test/TeamPanel.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import TeamPanel, { TeamPanelProps } from '../components/TeamPanel';
 import type { TeamState } from '../api/client';
-import { mockGameState } from './helpers';
+import { mockGameState, renderWithI18n } from './helpers';
 
 const baseTeamState: TeamState = {
   sets: 1,
@@ -41,6 +41,7 @@ describe('TeamPanel', () => {
   });
   afterEach(() => {
     vi.useRealTimers();
+    localStorage.clear();
   });
 
   it('renders score for current set', () => {
@@ -206,5 +207,28 @@ describe('TeamPanel', () => {
     );
     const img = screen.getByTestId('team-1-logo') as HTMLImageElement;
     expect(img.src).toContain('https://example.com/logo.png');
+  });
+
+  it('localizes scoring-control names and gesture descriptions', () => {
+    localStorage.setItem('volley_lang', 'es');
+    renderWithI18n(
+      <TeamPanel
+        {...defaultProps}
+        isPortrait={true}
+        iconLogo="https://example.com/logo.png"
+        customization={{ 'Team 1 Name': 'Lobos' }}
+      />,
+    );
+
+    expect(screen.getByTestId('team-1-score')).toHaveAccessibleName('Lobos, puntuación 15');
+    expect(screen.getByTestId('team-1-score')).toHaveAccessibleDescription(
+      'Toca para sumar un punto, toca dos veces para deshacer o mantén pulsado para establecer un valor.',
+    );
+    expect(screen.getByTestId('team-1-timeout')).toHaveAccessibleName('Lobos, tiempo muerto');
+    expect(screen.getByTestId('team-1-timeout')).toHaveAccessibleDescription(
+      'Toca para sumar un tiempo muerto o toca dos veces para deshacer.',
+    );
+    expect(screen.getByTestId('team-1-serve')).toHaveAccessibleName('Lobos, saque');
+    expect(screen.getByTestId('team-1-logo')).toHaveAttribute('alt', 'Lobos');
   });
 });

--- a/frontend/src/test/i18n-keys.test.ts
+++ b/frontend/src/test/i18n-keys.test.ts
@@ -8,6 +8,8 @@
  *    must exist in the English catalog, so a missing key can never leak the
  *    raw key string to the UI (dynamic template-literal keys are exercised
  *    by their components' own tests).
+ * 3. Accessible text is catalogued — literal aria-label / alt attributes and
+ *    visually-hidden English text cannot bypass `t()`.
  */
 import { describe, it, expect } from 'vitest';
 import { translations } from '../i18n/translations';
@@ -55,5 +57,23 @@ describe('translation catalog', () => {
     expect(used.size).toBeGreaterThan(100); // sanity: the scan found real usage
     const unresolved = [...used].filter((k) => !enKeys.has(k)).sort();
     expect(unresolved).toEqual([]);
+  });
+
+  it('does not hard-code user-facing accessible text in JSX', () => {
+    const violations: string[] = [];
+    for (const [path, text] of Object.entries(sources)) {
+      for (const match of text.matchAll(/\b(?:aria-label|alt)\s*=\s*"([^"]*[A-Za-z][^"]*)"/g)) {
+        violations.push(`${path}: ${match[1]}`);
+      }
+      for (const match of text.matchAll(/\b(?:aria-label|alt)\s*=\s*'([^']*[A-Za-z][^']*)'/g)) {
+        violations.push(`${path}: ${match[1]}`);
+      }
+      for (const match of text.matchAll(
+        /<[^>]+\bclassName\s*=\s*["'][^"']*\bvisually-hidden\b[^"']*["'][^>]*>\s*([A-Za-z][^<{]*)/g,
+      )) {
+        violations.push(`${path}: ${match[1]?.trim()}`);
+      }
+    }
+    expect(violations.sort()).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- route scoring-control names and gesture descriptions through the six-locale catalog
- give icon-only HUD controls translated accessible names and pressed state while hiding decorative Material icon ligatures
- localize recent-action announcements, including computed event and point-type labels
- add rendered Spanish accessibility regressions and a source guard against hard-coded accessible text
- document the fix under `Unreleased`

## Why

Several screen-reader-only strings bypassed `t()`, so operators using a non-English locale still heard English instructions on the primary scoring controls. Icon-only controls could also announce Material icon ligature names instead of their intended action and did not consistently expose toggle state.

Fixes #436

## Validation

- `npm run test:coverage` — 87 files, 830 tests passed; coverage thresholds passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`