### PR TITLE
fix: serialize overlay state persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ once a first tagged release ships.
 
 ### Fixed
 
+- **Concurrent overlay updates can no longer roll back persisted state.**
+  Mutations and atomic JSON writes are now ordered per overlay across both
+  synchronous and asynchronous callers, so a delayed older snapshot cannot
+  replace a newer one on disk. The shared persistence cores also keep the
+  sync and async paths on the same locking behavior. Fixes
+  [#429](https://github.com/JacoboSanchez/volley-overlay-control/issues/429).
+
 - **Screen readers now follow the selected language throughout the scoring
   controls.** Score, timeout, serve, dialog, and recent-action accessible
   labels and gesture instructions now use the six-locale catalog. Icon-only

--- a/app/overlay/state_store.py
+++ b/app/overlay/state_store.py
@@ -207,6 +207,10 @@ class OverlayStateStore:
         self._templates_dir = templates_dir
         self._overlays: dict[str, dict] = {}
         self._lock = threading.RLock()
+        # Serializes each overlay's mutation -> snapshot -> disk-write sequence
+        # without making unrelated overlays wait on one another. These locks
+        # are always acquired before ``self._lock``.
+        self._persistence_locks: dict[str, threading.Lock] = {}
         self._broadcast_callback: Callable | None = None
         self._available_styles: list | None = None
         self._renderable_styles: list | None = None
@@ -289,11 +293,10 @@ class OverlayStateStore:
         return state if state is not None else get_default_state()
 
     async def load_persisted_state_async(self, overlay_id: str) -> dict:
-        path = self.get_state_file_path(overlay_id)
-        state = await asyncio.to_thread(self._read_state_sync, path)
-        return state if state is not None else get_default_state()
+        return await asyncio.to_thread(self.load_persisted_state, overlay_id)
 
-    def save_persisted_state(self, overlay_id: str, state: dict) -> None:
+    def _save_persisted_state_unlocked(self, overlay_id: str, state: dict) -> None:
+        """Persist *state* while the caller holds the overlay's write lock."""
         path = self.get_state_file_path(overlay_id)
         self._stamp_meta(state, overlay_id)
         try:
@@ -303,13 +306,17 @@ class OverlayStateStore:
             # are filesystem-level (no space, permissions, missing dir).
             logger.warning("Failed to save state for '%s': %s", overlay_id, exc)
 
+    def save_persisted_state(self, overlay_id: str, state: dict) -> None:
+        with self._get_persistence_lock(overlay_id):
+            self._save_persisted_state_unlocked(overlay_id, state)
+
     async def save_persisted_state_async(self, overlay_id: str, state: dict) -> None:
-        path = self.get_state_file_path(overlay_id)
-        self._stamp_meta(state, overlay_id)
-        try:
-            await asyncio.to_thread(self._write_state_sync, path, state)
-        except OSError as exc:
-            logger.warning("Failed to save state for '%s': %s", overlay_id, exc)
+        await asyncio.to_thread(self.save_persisted_state, overlay_id, state)
+
+    def _get_persistence_lock(self, overlay_id: str) -> threading.Lock:
+        """Return the stable per-overlay lock used to order disk snapshots."""
+        with self._lock:
+            return self._persistence_locks.setdefault(overlay_id, threading.Lock())
 
     # -- In-memory context -------------------------------------------------
 
@@ -537,13 +544,14 @@ class OverlayStateStore:
         except ValueError:
             logger.warning("create_overlay rejected invalid id: %r", overlay_id)
             return False
-        with self._lock:
-            # Hold the (reentrant) lock across the existence check AND the
-            # write so two concurrent first-touches can't both write default
-            # state (the check-then-write was previously a TOCTOU race).
+        with self._get_persistence_lock(overlay_id), self._lock:
+            # Hold both locks across the existence check and write so two
+            # concurrent first-touches cannot both create default state.
             if os.path.exists(path):
                 return False
-            self.save_persisted_state(overlay_id, get_default_state())
+            self._save_persisted_state_unlocked(
+                overlay_id, get_default_state()
+            )
             self._output_key_cache[overlay_id] = overlay_id
             self._output_key_cache[self.get_output_key(overlay_id)] = overlay_id
         logger.info("Overlay '%s' created", overlay_id)
@@ -562,15 +570,16 @@ class OverlayStateStore:
             logger.warning("delete_overlay rejected invalid id: %r", overlay_id)
             return False
         existed = False
-        if os.path.exists(path):
-            os.remove(path)
-            existed = True
-        with self._lock:
-            if overlay_id in self._overlays:
-                del self._overlays[overlay_id]
+        with self._get_persistence_lock(overlay_id):
+            if os.path.exists(path):
+                os.remove(path)
                 existed = True
-            self._output_key_cache.pop(overlay_id, None)
-            self._output_key_cache.pop(self.get_output_key(overlay_id), None)
+            with self._lock:
+                if overlay_id in self._overlays:
+                    del self._overlays[overlay_id]
+                    existed = True
+                self._output_key_cache.pop(overlay_id, None)
+                self._output_key_cache.pop(self.get_output_key(overlay_id), None)
         if existed:
             logger.info("Overlay '%s' deleted", overlay_id)
         return existed
@@ -594,13 +603,16 @@ class OverlayStateStore:
         """
         if not self.overlay_exists(source_id):
             return False
-        if self.overlay_exists(target_id):
-            return False
         source_state = self.load_persisted_state(source_id)
-        self.save_persisted_state(target_id, copy.deepcopy(source_state))
-        with self._lock:
-            self._output_key_cache[target_id] = target_id
-            self._output_key_cache[self.get_output_key(target_id)] = target_id
+        with self._get_persistence_lock(target_id):
+            if self.overlay_exists(target_id):
+                return False
+            self._save_persisted_state_unlocked(
+                target_id, copy.deepcopy(source_state)
+            )
+            with self._lock:
+                self._output_key_cache[target_id] = target_id
+                self._output_key_cache[self.get_output_key(target_id)] = target_id
         logger.info("Overlay '%s' copied from '%s'", target_id, source_id)
         return True
 
@@ -621,9 +633,7 @@ class OverlayStateStore:
         customization: dict | None = None,
     ) -> None:
         """Persist raw model/customization data into the overlay state."""
-        with self._lock:
-            ctx = self.get_overlay_context(overlay_id)
-            state = ctx["state"]
+        def apply(state: dict) -> None:
             if model is not None:
                 state["raw_remote_model"] = model
             if customization is not None:
@@ -631,43 +641,50 @@ class OverlayStateStore:
                 ps = customization.get("preferredStyle")
                 if ps is not None:
                     state.setdefault("overlay_control", {})["preferredStyle"] = ps
-            snapshot = copy.deepcopy(state)
-        self.save_persisted_state(overlay_id, snapshot)
+
+        self._mutate_and_persist(overlay_id, apply)
         if self._broadcast_callback:
             self._broadcast_callback(overlay_id)
 
     # -- State updates -----------------------------------------------------
 
+    def _mutate_and_persist(
+        self, overlay_id: str, mutation: Callable[[dict], None],
+    ) -> None:
+        """Apply *mutation* and persist its snapshot in per-overlay order."""
+        with self._get_persistence_lock(overlay_id):
+            with self._lock:
+                state = self.get_overlay_context(overlay_id)["state"]
+                mutation(state)
+                snapshot = copy.deepcopy(state)
+            self._save_persisted_state_unlocked(overlay_id, snapshot)
+
+    def _update_state_and_persist(self, overlay_id: str, payload: dict) -> None:
+        """Shared implementation for synchronous and asynchronous updates."""
+        def apply(state: dict) -> None:
+            deep_merge(state, payload)
+            _replace_subtrees(state, payload)
+            normalize_state(state)
+
+        self._mutate_and_persist(overlay_id, apply)
+
     async def update_state(self, overlay_id: str, payload: dict) -> None:
         """Deep-merge *payload* into overlay state, normalize, persist, broadcast."""
-        with self._lock:
-            ctx = self.get_overlay_context(overlay_id)
-            deep_merge(ctx["state"], payload)
-            _replace_subtrees(ctx["state"], payload)
-            normalize_state(ctx["state"])
-            snapshot = copy.deepcopy(ctx["state"])
-        await self.save_persisted_state_async(overlay_id, snapshot)
+        await asyncio.to_thread(self._update_state_and_persist, overlay_id, payload)
         if self._broadcast_callback:
             self._broadcast_callback(overlay_id)
 
     def update_state_sync(self, overlay_id: str, payload: dict) -> None:
         """Synchronous version of :meth:`update_state`."""
-        with self._lock:
-            ctx = self.get_overlay_context(overlay_id)
-            deep_merge(ctx["state"], payload)
-            _replace_subtrees(ctx["state"], payload)
-            normalize_state(ctx["state"])
-            snapshot = copy.deepcopy(ctx["state"])
-        self.save_persisted_state(overlay_id, snapshot)
+        self._update_state_and_persist(overlay_id, payload)
         if self._broadcast_callback:
             self._broadcast_callback(overlay_id)
 
     def set_visibility(self, overlay_id: str, show: bool) -> None:
         """Update ``overlay_control.show_main_scoreboard``."""
-        with self._lock:
-            ctx = self.get_overlay_context(overlay_id)
-            ctx["state"].setdefault("overlay_control", {})["show_main_scoreboard"] = show
-            snapshot = copy.deepcopy(ctx["state"])
-        self.save_persisted_state(overlay_id, snapshot)
+        def apply(state: dict) -> None:
+            state.setdefault("overlay_control", {})["show_main_scoreboard"] = show
+
+        self._mutate_and_persist(overlay_id, apply)
         if self._broadcast_callback:
             self._broadcast_callback(overlay_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ def isolate_overlay_store(tmp_path_factory):
     saved = {
         "_data_dir": overlay_state_store._data_dir,
         "_overlays": overlay_state_store._overlays,
+        "_persistence_locks": overlay_state_store._persistence_locks,
         "_output_key_cache": overlay_state_store._output_key_cache,
         "_available_styles": overlay_state_store._available_styles,
         "_renderable_styles": overlay_state_store._renderable_styles,
@@ -54,6 +55,7 @@ def isolate_overlay_store(tmp_path_factory):
     }
     overlay_state_store._data_dir = str(seed_dir)
     overlay_state_store._overlays = {}
+    overlay_state_store._persistence_locks = {}
     overlay_state_store._output_key_cache = {}
     overlay_state_store._available_styles = None
     overlay_state_store._renderable_styles = None
@@ -64,6 +66,7 @@ def isolate_overlay_store(tmp_path_factory):
 
     overlay_state_store._data_dir = saved["_data_dir"]
     overlay_state_store._overlays = saved["_overlays"]
+    overlay_state_store._persistence_locks = saved["_persistence_locks"]
     overlay_state_store._output_key_cache = saved["_output_key_cache"]
     overlay_state_store._available_styles = saved["_available_styles"]
     overlay_state_store._renderable_styles = saved["_renderable_styles"]

--- a/tests/test_state_store_persistence_order.py
+++ b/tests/test_state_store_persistence_order.py
@@ -1,0 +1,103 @@
+"""Regression tests for per-overlay snapshot persistence ordering."""
+
+import asyncio
+import threading
+
+import pytest
+
+# Keep the established import order used by the state-store test modules.
+from app.api import action_log  # noqa: F401
+from app.overlay.state_store import OverlayStateStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return OverlayStateStore(
+        data_dir=str(tmp_path / "data"),
+        templates_dir=str(tmp_path / "tpl"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_async_updates_cannot_persist_an_older_snapshot(
+    store,
+    monkeypatch,
+):
+    """A delayed first write must not overwrite a later async update."""
+    oid = "async-order"
+    assert store.create_overlay(oid) is True
+
+    real_write = store._write_state_sync
+    first_write_started = threading.Event()
+    second_write_finished = threading.Event()
+
+    def delayed_write(path, state):
+        points = state["team_home"]["points"]
+        if points == 1:
+            first_write_started.set()
+            second_write_finished.wait(timeout=0.5)
+        real_write(path, state)
+        if points == 2:
+            second_write_finished.set()
+
+    monkeypatch.setattr(store, "_write_state_sync", delayed_write)
+
+    first = asyncio.create_task(
+        store.update_state(
+            oid,
+            {"team_home": {"points": 1}},
+        )
+    )
+    assert await asyncio.to_thread(first_write_started.wait, 2)
+    second = asyncio.create_task(
+        store.update_state(
+            oid,
+            {"team_home": {"points": 2}},
+        )
+    )
+    await asyncio.gather(first, second)
+
+    persisted = store.load_persisted_state(oid)
+    assert persisted["team_home"]["points"] == 2
+    assert store.get_state(oid)["team_home"]["points"] == 2
+
+
+def test_sync_update_and_visibility_write_in_mutation_order(store, monkeypatch):
+    """Visibility cannot reach disk and then be replaced by an older snapshot."""
+    oid = "sync-order"
+    assert store.create_overlay(oid) is True
+
+    real_write = store._write_state_sync
+    first_write_started = threading.Event()
+    visibility_write_finished = threading.Event()
+
+    def delayed_write(path, state):
+        visible = state["overlay_control"]["show_main_scoreboard"]
+        if visible:
+            first_write_started.set()
+            visibility_write_finished.wait(timeout=0.5)
+        real_write(path, state)
+        if not visible:
+            visibility_write_finished.set()
+
+    monkeypatch.setattr(store, "_write_state_sync", delayed_write)
+
+    first = threading.Thread(
+        target=store.update_state_sync,
+        args=(oid, {"team_home": {"points": 1}}),
+    )
+    first.start()
+    assert first_write_started.wait(timeout=2)
+
+    second = threading.Thread(target=store.set_visibility, args=(oid, False))
+    second.start()
+    first.join(timeout=3)
+    second.join(timeout=3)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    persisted = store.load_persisted_state(oid)
+    assert persisted["team_home"]["points"] == 1
+    assert persisted["overlay_control"]["show_main_scoreboard"] is False
+    state = store.get_state(oid)
+    assert state["overlay_control"]["show_main_scoreboard"] is False


### PR DESCRIPTION
## Summary

- serialize each overlay’s mutation → snapshot → atomic JSON write sequence with a stable per-overlay lock
- route raw config, visibility, sync updates, async updates, create/copy/delete, and direct saves through the same persistence ordering
- collapse duplicated async load/save/update implementations into thin thread-offload wrappers over shared synchronous cores
- add deterministic async and mixed sync/visibility race regressions
- document the fix under `Unreleased`

## Root cause

`OverlayStateStore` protected only the in-memory mutation and snapshot with its `RLock`, then released that lock before writing the snapshot. Concurrent callers could therefore write a newer snapshot first and an older delayed snapshot second, leaving disk behind memory and rolling state back after restart. Atomic replacement prevented torn JSON but did not preserve write order.

## Impact

Updates to one overlay now reach disk in mutation order, while different overlays retain independent persistence locks and can write concurrently. The async API keeps blocking file I/O off the event loop.

Fixes #429

## Validation

- `pytest tests/ --cov=app --cov-report=term-missing` — 1,200 tests passed; 86.46% coverage
- `ruff check .`
- `mypy app/`
- targeted state-store suite — 31 tests passed
- `git diff --check`