### PR TITLE
fix: pass all dotenv settings through Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,9 @@
 # Secrets (passwords, tokens) MUST NOT be committed alongside this template.
 
 # ---- Network ----------------------------------------------------------------
-# Host port to expose the container on. ``80`` is the default for production
-# behind a reverse proxy; pick something like ``8080`` for local dev.
+# Host port to expose the container on. ``80`` is the default for production;
+# pick ``8080`` for local dev, or bind only to loopback when a reverse proxy on
+# the same host is the sole ingress: ``EXTERNAL_PORT=127.0.0.1:8080``.
 EXTERNAL_PORT=8080
 
 # Internal listen port — match the value in the Dockerfile HEALTHCHECK if you

--- a/.env.traefik.example
+++ b/.env.traefik.example
@@ -52,6 +52,15 @@ SESSION_TTL_HOURS=
 # healthcheck still passes, e.g.  ${TRAEFIK_HOST},localhost,127.0.0.1
 TRUSTED_HOSTS=
 
+# docker-compose.traefik.yml passes every setting in this file through to the
+# app. Common HTTPS hardening examples are shown below; the complete list and
+# defaults live in .env.example.
+# SECURITY_HSTS_SECONDS=31536000
+# CORS_ALLOWED_ORIGINS=https://scoreboard.example.com
+# AUTH_RATE_LIMIT_MAX_FAILURES=10
+# AUTH_RATE_LIMIT_WINDOW_SECONDS=60
+# AUTH_RATE_LIMIT_BLOCK_SECONDS=60
+
 # GET /metrics is unauthenticated (aggregates only).
 
 # Open the print match-report routes (/match/{id}/report) to anonymous reads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ once a first tagged release ships.
 
 ### Fixed
 
+- **Docker Compose no longer drops unlisted application settings from
+  `.env`.** Both the host-port and Traefik deployment files now pass the full
+  optional `.env` through to the container, including security headers, auth
+  rate limits, request caps, icon limits, webhook retries, WebSocket limits,
+  and future settings. Environment documentation guards now also catch stale
+  example entries and indirect `_env_*` readers. Fixes
+  [#445](https://github.com/JacoboSanchez/volley-overlay-control/issues/445).
+
 - **Concurrent overlay updates can no longer roll back persisted state.**
   Mutations and atomic JSON writes are now ordered per overlay across both
   synchronous and asynchronous callers, so a delayed older snapshot cannot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ once a first tagged release ships.
   `.env`.** Both the host-port and Traefik deployment files now pass the full
   optional `.env` through to the container, including security headers, auth
   rate limits, request caps, icon limits, webhook retries, WebSocket limits,
-  and future settings. Environment documentation guards now also catch stale
+  and future settings. This optional-file support requires Docker Compose
+  2.24.0 or newer. Environment documentation guards now also catch stale
   example entries and indirect `_env_*` readers. Fixes
   [#445](https://github.com/JacoboSanchez/volley-overlay-control/issues/445).
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -540,7 +540,9 @@ The API router installs its own lifespan (`app/api/routes/lifespan.py`):
 For a static, boot-time setting:
 
 1. Add the field to `app/conf.py`.
-2. Add the env var to `docker-compose.yml` and `README.md`.
+2. Document the env var in `.env.example` and, when operator-facing enough for
+   the main configuration table, `README.md`. Both shipped Compose files load
+   `.env` directly, so they do not maintain separate variable allow-lists.
 
 For an operator-toggleable setting that should persist (DB wins after first
 boot, like `REGISTRATION_OPEN`): add a key + accessor in

--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ WebSocket at `/ws/{public_token}`.
 
 The Dockerfile uses a multi-stage build: Node.js builds the React frontend, then the result is copied into the Python image. No separate frontend container or nginx is needed.
 
+> Requires **Docker Compose 2.24.0+**. Both shipped Compose files use the
+> `env_file.required` attribute introduced in that release so `.env` can stay
+> optional; legacy `docker-compose` and older v2 plugins are not supported.
+>
 > Deploying behind a **Traefik** reverse proxy? Use [`docker-compose.traefik.yml`](docker-compose.traefik.yml) + [`.env.traefik.example`](.env.traefik.example) instead — it publishes the app through Traefik (TLS, HTTP→HTTPS redirect, WebSocket pass-through) with no host ports, SQLite on a volume by default and an optional PostgreSQL service.
 
 1.  Create a `.env` file (everything here is optional; Compose passes every

--- a/README.md
+++ b/README.md
@@ -189,18 +189,22 @@ The Dockerfile uses a multi-stage build: Node.js builds the React frontend, then
 
 > Deploying behind a **Traefik** reverse proxy? Use [`docker-compose.traefik.yml`](docker-compose.traefik.yml) + [`.env.traefik.example`](.env.traefik.example) instead — it publishes the app through Traefik (TLS, HTTP→HTTPS redirect, WebSocket pass-through) with no host ports, SQLite on a volume by default and an optional PostgreSQL service.
 
-1.  Create a `.env` file (everything here is optional):
+1.  Create a `.env` file (everything here is optional; Compose passes every
+    entry through to the app, so advanced settings do not need a matching
+    `docker-compose.yml` edit):
     ```env
     EXTERNAL_PORT=80
     APP_TITLE=MyScoreboard
     # DATABASE_URL=postgresql+psycopg://user:pass@host/db  # default: SQLite under data/
     ```
+    To expose the container only to a reverse proxy on the same host, use
+    `EXTERNAL_PORT=127.0.0.1:8080`.
 2.  Run Docker Compose:
     ```bash
-    docker-compose up -d
+    docker compose up -d
     ```
 3.  **Claim the first admin:** read the one-time bootstrap token from the
-    startup log (`docker-compose logs app` — logged at `WARNING`), open
+    startup log (`docker compose logs app` — logged at `WARNING`), open
     `/claim-admin`, and create the first administrator. The SQLite database,
     session secret and bootstrap/overlay-server token files all live under
     `data/`, so persist that directory across container restarts.

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -31,6 +31,11 @@ services:
       context: ./
       dockerfile: Dockerfile
     restart: unless-stopped
+    # Load every app knob from .env; the explicit entries below only provide
+    # deployment-specific defaults/overrides such as secure cookies behind TLS.
+    env_file:
+      - path: .env
+        required: false
     environment:
       APP_PORT: ${APP_PORT:-8080}
       APP_TITLE: ${APP_TITLE:-Scoreboard}
@@ -55,6 +60,9 @@ services:
       # Public base URL used to build OBS-friendly overlay links.
       OVERLAY_PUBLIC_URL: https://${TRAEFIK_HOST}
       # ---- Hardening (optional) ----
+      # All hardening knobs from .env.example (SECURITY_*, CORS_ALLOWED_ORIGINS,
+      # AUTH_RATE_LIMIT_*, REQUEST_MAX_BODY_BYTES, etc.) are already passed
+      # through by env_file above; only Traefik-specific guidance stays here.
       # Host-header allow-list. Traefik already routes only ${TRAEFIK_HOST} here,
       # so this is optional defence-in-depth. If you set it, include localhost so
       # the in-container healthcheck still passes, e.g.
@@ -70,8 +78,8 @@ services:
       # ---- Logging ----
       LOGGING_LEVEL: ${LOGGING_LEVEL:-warning}
       LOG_FORMAT: ${LOG_FORMAT:-text}
-      # See .env.example / docker-compose.yml for the full list of optional
-      # knobs (overlays.uno, custom overlay backend, webhooks, etc.).
+      # See .env.example for the full list of optional app knobs. New settings
+      # added there do not need a matching entry in this Compose file.
     volumes:
       # SQLite DB + session secret + bootstrap / overlay-server tokens.
       - overlay_data:/app/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,12 @@ services:
       context: ./
       dockerfile: Dockerfile
     restart: always
+    # Pass every documented app setting through without maintaining a second
+    # hand-written allow-list here. The file stays optional so defaults still
+    # work for operators who launch Compose without creating .env first.
+    env_file:
+      - path: .env
+        required: false
     ports:
       - ${EXTERNAL_PORT:-80}:${APP_PORT:-8080}
     environment:

--- a/tests/test_compose_env.py
+++ b/tests/test_compose_env.py
@@ -1,0 +1,21 @@
+"""Regression guards for Docker Compose environment pass-through."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMPOSE_FILES = (
+    "docker-compose.yml",
+    "docker-compose.traefik.yml",
+)
+
+
+@pytest.mark.parametrize("filename", COMPOSE_FILES)
+def test_app_service_loads_optional_dotenv(filename):
+    document = yaml.safe_load(
+        (REPO_ROOT / filename).read_text(encoding="utf-8")
+    )
+    env_files = document["services"]["app"]["env_file"]
+    assert {"path": ".env", "required": False} in env_files

--- a/tests/test_compose_env.py
+++ b/tests/test_compose_env.py
@@ -19,3 +19,8 @@ def test_app_service_loads_optional_dotenv(filename):
     )
     env_files = document["services"]["app"]["env_file"]
     assert {"path": ".env", "required": False} in env_files
+
+
+def test_optional_env_file_compose_version_is_documented():
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    assert "Docker Compose 2.24.0+" in readme

--- a/tests/test_env_docs.py
+++ b/tests/test_env_docs.py
@@ -13,21 +13,25 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Variables intentionally undocumented: test-only knobs, values managed by
 # the runtime itself, or vars surfaced through other docs.
-#
-# Empty by design. The guard only inspects reads under ``app/``, so a var
-# the backend never reads can never reach this check — an entry here would
-# be inert and, worse, could imply the runtime honours something it does
-# not. ``PUID``/``PGID`` used to sit here described as "set by
-# docker-entrypoint.sh"; the entrypoint never read them (it hardcodes
-# uid/gid 1000), so both the compose knob and this entry were removed.
 ALLOWLIST: set[str] = set()
 
-# Also matches the local ``_env*("NAME", default)`` helper wrappers used in
-# app/constants.py and the middlewares, so indirected reads cannot slip past
-# the docs guard.
+# Variables consumed by Docker Compose itself rather than the application.
+COMPOSE_ONLY = {
+    "DOCKER_LOG_MAX_FILE",
+    "DOCKER_LOG_MAX_SIZE",
+    "EXTERNAL_PORT",
+}
+
+# Also matches local ``_env_*("NAME", default)`` helper wrappers used in the
+# constants, settings, logging, and middleware modules. The reverse guard
+# below makes a newly-documented variable fail as stale if a new helper naming
+# pattern is not represented here.
 _READ_PATTERN = re.compile(
-    r"(?:get_env_var|get_bool_env|environ\.get|getenv|environ\[|_env(?:_int|_float(?:_nonneg)?)?)"
+    r"(?:get_env_var|get_bool_env|environ\.get|getenv|environ\[|_env(?:_[a-z]+)*)"
     r"\(?\s*\(?\s*['\"]([A-Z][A-Z0-9_]+)['\"]"
+)
+_EXAMPLE_DECLARATION_PATTERN = re.compile(
+    r"(?m)^\s*#?\s*([A-Z][A-Z0-9_]+)\s*="
 )
 
 
@@ -55,4 +59,15 @@ def test_every_env_var_is_documented():
         "Environment variables read by the backend but missing from "
         f"README.md / .env.example: {sorted(undocumented)}. Document them "
         "or add them to the allowlist in tests/test_env_docs.py."
+    )
+
+
+def test_every_example_env_var_is_used_or_compose_only():
+    example = (REPO_ROOT / ".env.example").read_text(encoding="utf-8")
+    documented = set(_EXAMPLE_DECLARATION_PATTERN.findall(example))
+    stale = documented - _env_vars_read_by_app() - COMPOSE_ONLY
+    assert not stale, (
+        "Environment variables declared in .env.example but not read by the "
+        f"backend or Compose: {sorted(stale)}. Remove stale knobs or teach "
+        "the read-pattern guard about the helper that consumes them."
     )


### PR DESCRIPTION
## Summary

- load the optional project `.env` into the app service in both shipped Compose files
- retain the existing deployment-specific defaults and document loopback-only host binding
- add regression coverage for Compose pass-through and both directions of environment-variable documentation drift

## Root cause

The Compose files maintained hand-written environment allow-lists. Any backend setting omitted from those lists was silently discarded even when operators set it in `.env`, including security headers, authentication rate limits, request caps, WebSocket limits, icon limits, and webhook retry settings.

## Impact

Operators can now use every documented application setting from `.env` without adding a matching Compose entry. The file remains optional, so default Compose startup still works without one.

Fixes #445

## Validation

- `pytest tests/ --cov=app --cov-report=term-missing` — 1,203 passed, 86.46% coverage
- `ruff check .`
- `mypy`
- `docker compose -f docker-compose.yml config --quiet`
- `docker compose --env-file .env.traefik.example -f docker-compose.traefik.yml config --quiet`
- `git diff --check`