### PR TITLE
Extend the rate limiter to capability-token routes (#432)

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -330,14 +330,50 @@ operators don't need to opt in.
 
 ### 6.1 `AuthRateLimitMiddleware` — brute-force backstop
 
-Located in `app/api/middleware/auth_rate_limit.py`. Watches the
-`/api/v1/` prefix (the `/auth/login` and `/auth/claim-admin`
-endpoints are the meaningful targets now; a stale `/manage` prefix is
-also still listed but matches no live route); when a response carries a
-401 or 403 status, the caller's IP is recorded in a sliding-window
-counter. Once the bucket exceeds the configured threshold the next
-request from that IP is short-circuited with `429 Too Many
-Requests` and a `Retry-After` header before reaching the handler.
+Located in `app/api/middleware/auth_rate_limit.py`. Watches two
+surfaces, each with its **own keyspace** and its own set of statuses
+that count as a failure:
+
+| Surface | Paths | Counted as failure |
+| :--- | :--- | :--- |
+| `api` | `/api/v1/*` | 401, 403 |
+| `capability` | `/overlay/*`, `/follow/*`, `/match/*` | 401, 403, **404** |
+
+404 counts on the capability surface because an unknown capability
+token is reported as "not found" (`app/overlay/routes.py`) — it is the
+only signal a token-guessing attempt produces. It deliberately does
+**not** count on `/api/v1/`, where a 404 is an ordinary missing
+resource and counting it would lock operators out during normal
+navigation.
+
+Buckets are keyed on `(surface, IP)`, not IP alone. A single shared
+bucket would mean 403s collected by somebody's SPA against `/api/v1/`
+could take an on-air `/overlay/` browser source off the air — trading a
+brute-force risk for an availability one. Split keyspaces let a surface
+throttle only itself.
+
+When a response carries one of the surface's failure statuses, the
+caller's IP is recorded in a sliding-window counter. Once the bucket
+exceeds the configured threshold the next matching request from that IP
+is short-circuited with `429 Too Many Requests` and a `Retry-After`
+header before reaching the handler, and
+`voc_rate_limit_blocks_total{surface}` is incremented so a lockout is
+visible in `/metrics` rather than hiding as a `status="429"` label on
+the latency histogram.
+
+Three surfaces are deliberately **not** watched:
+
+* **`/ws/*` and the control WebSocket** — a handshake arrives as ASGI
+  scope type `websocket`, not `http`, so this middleware structurally
+  cannot observe it. Listing the prefix would imply protection that does
+  not exist.
+* **`/media/**`** — carries no credential (filenames embed a content
+  hash). The exposure is request *volume*, which a failure-based limiter
+  does nothing about, while counting its 404s would risk blocking a
+  venue's icons after an ordinary delete. Volume limiting belongs at the
+  proxy.
+* **`/metrics`** — the concern there is that it is unauthenticated, not
+  that it is brute-forceable.
 The bucket is reset only by the sliding window — non-failure
 responses are intentionally ignored so an attacker cannot launder
 failures by interleaving login attempts (`POST /api/v1/auth/login`)
@@ -355,13 +391,23 @@ all legitimate users.
 
 | Env var | Default | Meaning |
 | :--- | :--- | :--- |
-| `AUTH_RATE_LIMIT_MAX_FAILURES` | `10` | 401/403 responses per window before blocking |
+| `AUTH_RATE_LIMIT_MAX_FAILURES` | `10` | failure responses per window before blocking |
 | `AUTH_RATE_LIMIT_WINDOW_SECONDS` | `60` | sliding-window length |
 | `AUTH_RATE_LIMIT_BLOCK_SECONDS` | `60` | how long the IP stays blocked once the threshold trips |
+
+These are read per call, so setting them at any point takes effect —
+they used to be evaluated at module import, which made them apply only
+if the variable was set before the first import.
 
 State is process-local. Multi-replica deployments should still front
 the app with a layer-7 limiter (Cloudflare, Nginx, etc.) — this
 middleware is the single-replica self-hosted backstop.
+
+Note also that keying on IP cannot distinguish several operators behind
+one NAT from a single attacker. The split keyspaces bound the blast
+radius and the metric makes a lockout visible, but that tradeoff is
+inherent to per-IP limiting; a deployment with many operators behind one
+address should raise `AUTH_RATE_LIMIT_MAX_FAILURES` accordingly.
 
 ### 6.2 `TrustedHostMiddleware` — Host-header poisoning defence (opt-in)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ once a first tagged release ships.
 
 ## [Unreleased]
 
+### Security
+
+- **The rate limiter now covers the capability-token routes, and counts
+  the status a token miss actually returns.** It watched only `/api/v1/`
+  and counted only 401/403 — but an unknown `public_token` on
+  `/overlay/*` or `/follow/*` is reported as **404**, so token guessing
+  incremented nothing at all and was never throttled. A second `capability`
+  surface now covers `/overlay/*`, `/follow/*` and `/match/*`, counting
+  401/403/404. `/api/v1/` still ignores 404, where it means an ordinary
+  missing resource rather than a credential probe.
+
+  Buckets are keyed on `(surface, IP)` rather than IP alone. This is what
+  makes widening the watched set safe: with one shared bucket, 403s
+  collected by somebody's SPA against `/api/v1/` could have taken an
+  on-air `/overlay/` browser source off the air — trading a brute-force
+  risk for an availability one.
+
+  `/ws/*`, `/media/**` and `/metrics` are deliberately still unwatched,
+  and `AUTHENTICATION.md` now says why for each: a WebSocket handshake is
+  ASGI scope type `websocket` and is structurally invisible to this
+  middleware; `/media` carries no credential, so counting its 404s would
+  risk blocking a venue's icons after an ordinary delete without
+  addressing the actual concern (volume); and `/metrics` needs
+  authentication, not throttling.
+
+- **`AUTH_RATE_LIMIT_*` overrides now take effect.** They were evaluated
+  at module import, so they only applied if the variable was set before
+  the limiter was first imported — a footgun in tests and embedded use,
+  and the reason the existing suite had to `importlib.reload` the module
+  to change a limit. They are read per call now.
+
+### Added
+
+- **`voc_rate_limit_blocks_total{surface}`** — counts requests
+  short-circuited with 429. Previously a brute-force attempt and a
+  shared-NAT lockout of legitimate operators were indistinguishable in
+  `/metrics`: both were just a `status="429"` label on the latency
+  histogram, so an operator could not alert on either.
+
 ### Fixed
 
 - **Scoring a point no longer re-reads and re-parses the entire audit

--- a/app/api/middleware/auth_rate_limit.py
+++ b/app/api/middleware/auth_rate_limit.py
@@ -1,28 +1,62 @@
-"""Per-IP rate limiter for authenticated and admin endpoints.
+"""Per-IP failure limiter for credential-bearing and capability-token routes.
 
-Watches every request whose path matches one of the configured
-prefixes; a 401 or 403 response increments the per-IP failure
-counter, and once a bucket exceeds ``_MAX_FAILURES`` within
-``_WINDOW_SECONDS`` the next request from that IP is short-circuited
-with ``429 Too Many Requests`` before reaching the handler.
+Watches every HTTP request whose path matches a configured surface. A
+response whose status is one of that surface's *failure statuses*
+increments the per-(surface, IP) counter, and once a bucket exceeds
+``AUTH_RATE_LIMIT_MAX_FAILURES`` within ``AUTH_RATE_LIMIT_WINDOW_SECONDS``
+the next matching request from that IP is short-circuited with
+``429 Too Many Requests`` before reaching the handler.
 
-This guards the credential-bearing surfaces against brute force:
+Two surfaces are watched, with **separate keyspaces**:
 
-* ``POST /api/v1/auth/login`` and ``/auth/claim-admin`` — credential checks.
-* ``GET /api/v1/admin/*`` and the rest of the admin CRUD (cookie + role).
-* every ``/api/v1/`` route protected by the session-cookie dependency.
+``api``
+    ``/api/v1/*`` — the cookie-session and admin CRUD routes. Failures are
+    401/403: an explicit authorization refusal.
 
-A successful response is intentionally ignored — the bucket is reset
-only by the sliding window expiring old failures. This prevents an
-attacker from laundering failed login attempts by interleaving them
-with hits to a public endpoint under the same prefix (e.g.
-``/api/v1/auth/context``). See ``_record_outcome`` for the full
-rationale.
+``capability``
+    ``/overlay/*``, ``/follow/*`` and ``/match/*`` — addressed by an
+    unguessable token rather than a session. A wrong token here surfaces as
+    **404** (`app/overlay/routes.py`) or 401 (`app/match_report_access.py`),
+    so this surface counts 401/403/404. Before this existed, token guessing
+    incremented nothing at all: the limiter only watched ``/api/v1/`` and
+    only counted 401/403.
 
-All state is process-local — clusters with multiple replicas should
-front the app with a layer-7 limiter (Cloudflare, Nginx, etc.) that
-shares state. The in-process limiter is a defence-in-depth backstop
-for self-hosted single-replica deployments.
+Keying buckets on ``(surface, ip)`` rather than ``ip`` alone is the
+load-bearing detail. A single shared bucket would mean that widening the
+watched set could take an on-air ``/overlay/`` browser source off the air
+because somebody's SPA collected 403s against ``/api/v1/`` — trading a
+brute-force risk for an availability one. With split keyspaces a surface
+can only throttle itself.
+
+A successful response is intentionally ignored — the bucket is reset only
+by the sliding window expiring old failures. This prevents an attacker
+from laundering failed login attempts by interleaving them with hits to a
+public endpoint under the same prefix. See ``_record_outcome``.
+
+Deliberately **not** watched:
+
+``/ws/*`` and the control WebSocket
+    A WebSocket handshake arrives as ASGI scope type ``websocket``, not
+    ``http``, so this middleware structurally cannot observe it. Listing
+    the prefix would imply protection that does not exist.
+
+``/media/**``
+    Carries no credential — its filenames embed a content hash. The
+    exposure there is request *volume*, which a failure-based limiter does
+    nothing about, while counting its 404s would risk blocking a venue's
+    icons after an ordinary delete. Volume limiting belongs at the proxy.
+
+``/metrics``
+    The concern there is that it is unauthenticated, not that it is
+    brute-forceable. Tracked separately.
+
+All state is process-local — clusters with multiple replicas should front
+the app with a layer-7 limiter (Cloudflare, Nginx, etc.) that shares
+state. This is a defence-in-depth backstop for self-hosted single-replica
+deployments. Note also that a per-IP limiter cannot distinguish several
+operators behind one NAT from a single attacker; the split keyspaces bound
+the blast radius, and ``voc_rate_limit_blocks_total`` makes a lockout
+visible, but the tradeoff is inherent to keying on IP.
 """
 
 from __future__ import annotations
@@ -33,10 +67,26 @@ import time
 from collections import OrderedDict, deque
 from collections.abc import Iterable
 
-# Tunables — kept generous so legitimate operator workflows
-# (e.g. an admin clicking through several account pages) never trip the
-# limit, but tight enough that an unattended attacker is throttled within
-# seconds. Override via env vars if needed.
+_MAX_CLIENTS = 4096
+
+# Surface name -> (watched path prefixes, statuses that count as a failure).
+#
+# Listed explicitly rather than derived, so a future unauthenticated route
+# that happens to live under a watched prefix does not silently pull
+# failures from elsewhere into its bucket.
+_API_SURFACE = "api"
+_CAPABILITY_SURFACE = "capability"
+
+_SURFACES: tuple[tuple[str, tuple[str, ...], frozenset[int]], ...] = (
+    (_API_SURFACE, ("/api/v1/",), frozenset({401, 403})),
+    (
+        _CAPABILITY_SURFACE,
+        ("/overlay/", "/follow/", "/match/"),
+        # 404 included: an unknown capability token is reported as "not
+        # found", so it is the only signal a guessing attempt produces.
+        frozenset({401, 403, 404}),
+    ),
+)
 
 
 def _env_int(name: str, default: int) -> int:
@@ -49,17 +99,22 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-_MAX_FAILURES = _env_int("AUTH_RATE_LIMIT_MAX_FAILURES", 10)
-_WINDOW_SECONDS = float(_env_int("AUTH_RATE_LIMIT_WINDOW_SECONDS", 60))
-_BLOCK_SECONDS = float(_env_int("AUTH_RATE_LIMIT_BLOCK_SECONDS", 60))
-_MAX_CLIENTS = 4096
+# Read per call rather than at import. The tunables are documented as env
+# overrides, but evaluating them at import time meant they only applied if
+# the variable was set before this module was first imported — which made
+# them a footgun in tests and in embedded use, and forced the test suite to
+# ``importlib.reload`` this module to change a limit. os.environ lookups are
+# dict hits, and these are only consulted on a failure or a block.
+def _max_failures() -> int:
+    return _env_int("AUTH_RATE_LIMIT_MAX_FAILURES", 10)
 
-# Path prefixes that this limiter watches. Listed explicitly so a future
-# unauthenticated route that happens to live under /api/v1/ does not
-# silently pull failures from elsewhere into its bucket.
-_WATCHED_PREFIXES: tuple[str, ...] = (
-    "/api/v1/",
-)
+
+def _window_seconds() -> float:
+    return float(_env_int("AUTH_RATE_LIMIT_WINDOW_SECONDS", 60))
+
+
+def _block_seconds() -> float:
+    return float(_env_int("AUTH_RATE_LIMIT_BLOCK_SECONDS", 60))
 
 
 class _Bucket:
@@ -70,7 +125,9 @@ class _Bucket:
         self.blocked_until: float = 0.0
 
 
-_buckets: OrderedDict[str, _Bucket] = OrderedDict()
+# Keyed by (surface, ip) — see the module docstring for why the surface is
+# part of the key.
+_buckets: OrderedDict[tuple[str, str], _Bucket] = OrderedDict()
 _lock = asyncio.Lock()
 
 
@@ -101,53 +158,59 @@ def _path_is_watched(path: str, watched: Iterable[str]) -> bool:
     return any(path == p or path.startswith(p) for p in watched)
 
 
-def _trim_failures_locked(bucket: _Bucket, now: float) -> None:
-    cutoff = now - _WINDOW_SECONDS
+def _resolve_surface(path: str) -> tuple[str, frozenset[int]] | None:
+    """Return the ``(surface, failure_statuses)`` watching *path*, if any."""
+    for name, prefixes, failure_statuses in _SURFACES:
+        if _path_is_watched(path, prefixes):
+            return name, failure_statuses
+    return None
+
+
+def _trim_failures_locked(bucket: _Bucket, now: float, window: float) -> None:
+    cutoff = now - window
     while bucket.failures and bucket.failures[0] < cutoff:
         bucket.failures.popleft()
 
 
-async def _is_blocked(ip: str) -> bool:
-    """Return True if the bucket for *ip* is currently blocked."""
+async def _is_blocked(key: tuple[str, str]) -> bool:
+    """Return True if the bucket for *key* is currently blocked."""
     now = time.monotonic()
     async with _lock:
-        bucket = _buckets.get(ip)
+        bucket = _buckets.get(key)
         if bucket is None:
             return False
-        _buckets.move_to_end(ip)
-        if bucket.blocked_until > now:
-            return True
-        return False
+        _buckets.move_to_end(key)
+        return bucket.blocked_until > now
 
 
-async def _record_outcome(ip: str, status_code: int) -> None:
-    """Update the bucket for *ip* based on the response *status_code*.
+async def _record_outcome(
+    key: tuple[str, str], status_code: int, failure_statuses: frozenset[int],
+) -> None:
+    """Update the bucket for *key* based on the response *status_code*.
 
-    A 401/403 appends a failure timestamp (and may flip the bucket
-    into the blocked state). Any other status is ignored: an attacker
-    can hit unauthenticated endpoints under the same prefix
-    (``/api/v1/admin/status``, ``/manage`` itself) to draw a 200, so
-    "200 clears the bucket" would let them launder failures and
-    bypass the limit. The sliding window already evicts old failures
-    once they fall out of ``_WINDOW_SECONDS``, which is the only
-    legitimate reset path.
+    A status in *failure_statuses* appends a failure timestamp (and may flip
+    the bucket into the blocked state). Any other status is ignored: an
+    attacker can hit unauthenticated endpoints under the same prefix to draw
+    a 200, so "200 clears the bucket" would let them launder failures and
+    bypass the limit. The sliding window already evicts old failures once
+    they fall out of the window, which is the only legitimate reset path.
     """
-    if status_code not in (401, 403):
+    if status_code not in failure_statuses:
         return
     now = time.monotonic()
     async with _lock:
-        bucket = _buckets.get(ip)
+        bucket = _buckets.get(key)
         if bucket is None:
             bucket = _Bucket()
-            _buckets[ip] = bucket
+            _buckets[key] = bucket
             if len(_buckets) > _MAX_CLIENTS:
                 _buckets.popitem(last=False)
         else:
-            _buckets.move_to_end(ip)
-        _trim_failures_locked(bucket, now)
+            _buckets.move_to_end(key)
+        _trim_failures_locked(bucket, now, _window_seconds())
         bucket.failures.append(now)
-        if len(bucket.failures) >= _MAX_FAILURES:
-            bucket.blocked_until = now + _BLOCK_SECONDS
+        if len(bucket.failures) >= _max_failures():
+            bucket.blocked_until = now + _block_seconds()
 
 
 def _reset_for_tests() -> None:
@@ -156,24 +219,28 @@ def _reset_for_tests() -> None:
 
 
 class AuthRateLimitMiddleware:
-    """Pure-ASGI middleware enforcing the per-IP failure limit."""
+    """Pure-ASGI middleware enforcing the per-(surface, IP) failure limit."""
 
     def __init__(self, app) -> None:
         self.app = app
 
     async def __call__(self, scope, receive, send):
+        # WebSocket handshakes arrive as scope type "websocket" and are not
+        # observable here — see the module docstring.
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
 
-        path = scope.get("path", "") or ""
-        if not _path_is_watched(path, _WATCHED_PREFIXES):
+        resolved = _resolve_surface(scope.get("path", "") or "")
+        if resolved is None:
             await self.app(scope, receive, send)
             return
+        surface, failure_statuses = resolved
 
-        ip = _client_ip(scope)
+        key = (surface, _client_ip(scope))
 
-        if await _is_blocked(ip):
+        if await _is_blocked(key):
+            _record_block(surface)
             await _send_429(send)
             return
 
@@ -186,7 +253,17 @@ class AuthRateLimitMiddleware:
 
         await self.app(scope, receive, send_wrapper)
         if status_holder["code"]:
-            await _record_outcome(ip, status_holder["code"])
+            await _record_outcome(key, status_holder["code"], failure_statuses)
+
+
+def _record_block(surface: str) -> None:
+    """Count the 429 without letting a metrics problem break the refusal."""
+    try:
+        from app.metrics import record_rate_limit_block
+
+        record_rate_limit_block(surface)
+    except Exception:  # pragma: no cover - defensive
+        pass
 
 
 async def _send_429(send) -> None:
@@ -200,7 +277,7 @@ async def _send_429(send) -> None:
         "headers": [
             (b"content-type", b"application/json"),
             (b"content-length", str(len(body)).encode("latin-1")),
-            (b"retry-after", str(int(_BLOCK_SECONDS)).encode("latin-1")),
+            (b"retry-after", str(int(_block_seconds())).encode("latin-1")),
             (b"cache-control", b"no-store"),
         ],
     })

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -138,6 +138,15 @@ webhook_dead_letter_size = Gauge(
     "Records currently parked in data/webhooks_dead_letter.jsonl.",
 )
 
+rate_limit_blocks_total = Counter(
+    "voc_rate_limit_blocks_total",
+    "Requests short-circuited with 429 by the per-IP failure limiter, "
+    "labelled by watched surface. Without this a brute-force attempt and a "
+    "shared-NAT lockout of legitimate operators look identical from the "
+    "outside — both are just a status=429 label on the latency histogram.",
+    labelnames=("surface",),
+)
+
 
 # ---------------------------------------------------------------------------
 # Helpers used from hot paths (kept tiny so the bookkeeping cost stays
@@ -170,3 +179,8 @@ def set_active_sessions(count: int) -> None:
 def set_dead_letter_size(count: int) -> None:
     """Refresh the webhook dead-letter gauge after a write/clear."""
     webhook_dead_letter_size.set(count)
+
+
+def record_rate_limit_block(surface: str) -> None:
+    """Count one 429 emitted by the per-IP failure limiter."""
+    rate_limit_blocks_total.labels(surface=surface or "unknown").inc()

--- a/tests/test_security_enhancements.py
+++ b/tests/test_security_enhancements.py
@@ -349,6 +349,137 @@ def test_rate_limit_ignores_unwatched_paths(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Rate limiter: capability-token surface, split keyspaces, live tunables
+# ---------------------------------------------------------------------------
+
+
+def _limiter_app(routes: dict[str, int]) -> TestClient:
+    """App whose *routes* map a path to the status it always returns."""
+    app = FastAPI()
+    app.add_middleware(AuthRateLimitMiddleware)
+    for path, status in routes.items():
+        def _make(status_code: int):
+            def _handler():
+                from fastapi import HTTPException
+                raise HTTPException(status_code=status_code, detail="nope")
+            return _handler
+        app.get(path)(_make(status))
+    return TestClient(app)
+
+
+def test_tunables_are_read_without_reimporting_the_module(monkeypatch):
+    """Env overrides must apply to an already-imported limiter.
+
+    The tunables used to be evaluated at import time, so a limit set after
+    first import silently did nothing — which is why the older tests above
+    have to ``importlib.reload``. No reload here on purpose: that is the
+    behaviour under test.
+    """
+    auth_rate_limit._reset_for_tests()
+    monkeypatch.setenv("AUTH_RATE_LIMIT_MAX_FAILURES", "2")
+    monkeypatch.setenv("AUTH_RATE_LIMIT_BLOCK_SECONDS", "45")
+
+    client = _limiter_app({"/api/v1/thing": 401})
+    assert client.get("/api/v1/thing").status_code == 401
+    assert client.get("/api/v1/thing").status_code == 401
+    res = client.get("/api/v1/thing")
+    assert res.status_code == 429
+    # Retry-After also comes from the live value, not an import-time copy.
+    assert res.headers["retry-after"] == "45"
+
+
+def test_capability_surface_counts_404_token_misses(monkeypatch):
+    """An unknown overlay token is a 404, and must now be throttled.
+
+    ``/overlay/<token>`` reports an unknown capability token as 404
+    (app/overlay/routes.py), and the limiter previously watched only
+    ``/api/v1/`` and counted only 401/403 — so token guessing incremented
+    nothing whatsoever.
+    """
+    auth_rate_limit._reset_for_tests()
+    monkeypatch.setenv("AUTH_RATE_LIMIT_MAX_FAILURES", "3")
+
+    client = _limiter_app({"/overlay/{token}": 404})
+    for _ in range(3):
+        assert client.get("/overlay/guess").status_code == 404
+    assert client.get("/overlay/guess").status_code == 429
+
+
+def test_api_surface_still_ignores_404(monkeypatch):
+    """404 must stay harmless on /api/v1/ — there it is a missing resource,
+    not a credential probe, so counting it would lock operators out for
+    ordinary navigation."""
+    auth_rate_limit._reset_for_tests()
+    monkeypatch.setenv("AUTH_RATE_LIMIT_MAX_FAILURES", "3")
+
+    client = _limiter_app({"/api/v1/missing": 404})
+    for _ in range(20):
+        assert client.get("/api/v1/missing").status_code == 404
+
+
+def test_surfaces_have_separate_keyspaces(monkeypatch):
+    """Exhausting one surface must not throttle the other.
+
+    This is what makes widening the watched set safe: a shared per-IP bucket
+    would let 403s from somebody's SPA take an on-air /overlay/ browser
+    source down with it.
+    """
+    auth_rate_limit._reset_for_tests()
+    monkeypatch.setenv("AUTH_RATE_LIMIT_MAX_FAILURES", "3")
+
+    client = _limiter_app({"/api/v1/thing": 401, "/overlay/{token}": 404})
+
+    for _ in range(3):
+        client.get("/api/v1/thing")
+    assert client.get("/api/v1/thing").status_code == 429
+    # Same IP, different surface — must still be served.
+    assert client.get("/overlay/tok").status_code == 404
+
+
+def test_blocks_are_counted_per_surface(monkeypatch):
+    """A 429 increments voc_rate_limit_blocks_total{surface}.
+
+    Without it a brute-force attempt and a shared-NAT lockout of real
+    operators are indistinguishable in /metrics.
+    """
+    pytest.importorskip("prometheus_client")
+    auth_rate_limit._reset_for_tests()
+    monkeypatch.setenv("AUTH_RATE_LIMIT_MAX_FAILURES", "2")
+
+    from app.metrics import rate_limit_blocks_total
+
+    def _count() -> float:
+        return rate_limit_blocks_total.labels(surface="capability")._value.get()
+
+    before = _count()
+    client = _limiter_app({"/follow/{token}": 404})
+    for _ in range(2):
+        client.get("/follow/tok")
+    assert client.get("/follow/tok").status_code == 429
+    assert _count() == before + 1
+
+
+def test_websocket_scope_is_passed_through(monkeypatch):
+    """The limiter must not attempt to gate a WebSocket handshake.
+
+    A handshake arrives as ASGI scope type "websocket", which this
+    middleware deliberately ignores — the docstring says so rather than
+    implying /ws/ is covered.
+    """
+    auth_rate_limit._reset_for_tests()
+    seen = []
+
+    async def inner(scope, receive, send):
+        seen.append(scope["type"])
+
+    mw = AuthRateLimitMiddleware(inner)
+    import asyncio as _asyncio
+
+    _asyncio.run(mw({"type": "websocket", "path": "/ws/tok"}, None, None))
+    assert seen == ["websocket"]
+
+
+# ---------------------------------------------------------------------------
 # Logo URL allow-list
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The per-IP failure limiter watched only `/api/v1/` and counted only 401/403 — but an unknown `public_token` on `/overlay/*` or `/follow/*` is reported as **404**, so capability-token guessing incremented nothing at all and was never throttled. This adds a second watched surface for those routes, keyed separately so widening the scope cannot take a live overlay off the air.

Fixes #432.

## Changes

- **Capability-token routes are now rate limited.** A new `capability` surface covers `/overlay/*`, `/follow/*` and `/match/*`, counting 401/403/**404**. Verified against the real app: five guesses at `/overlay/<bad-token>` went from `[404, 404, 404, 404, 404]` to `[404, 404, 404, 429, 429]`.
- **`/api/v1/` still ignores 404**, where it means an ordinary missing resource rather than a credential probe. Counting it there would lock operators out during normal navigation.
- **Buckets are keyed on `(surface, IP)`**, not IP alone, so a surface can only throttle itself.
- **`AUTH_RATE_LIMIT_*` overrides now take effect.** They were evaluated at module import, so they only applied if set before the limiter was first imported.
- **New metric `voc_rate_limit_blocks_total{surface}`** counting 429s.
- `AUTHENTICATION.md` §6.1 rewritten to describe both surfaces, and to record why three paths are deliberately left unwatched.

## Implementation notes

**The keyspace split is the load-bearing decision, not a tidy-up.** Simply adding the capability prefixes to the existing single per-IP bucket would have been actively harmful: 403s collected by somebody's SPA against `/api/v1/` could then take an **on-air `/overlay/` browser source off the air** mid-match — trading a brute-force risk for an availability one. `test_surfaces_have_separate_keyspaces` pins this, and I confirmed end-to-end that a capability lockout leaves `/api/v1/` reachable (401, not 429).

A legitimately configured venue is never at risk on the new surface: a working OBS source presents a valid token and gets 200s, which never increment.

**Three items from the issue are deliberately *not* fixed**, with the reasoning now in `AUTHENTICATION.md` rather than left implicit:

- **`/ws/*`** — a WebSocket handshake arrives as ASGI scope type `websocket`, not `http`, so this middleware structurally cannot observe it. Listing the prefix would imply protection that does not exist. The issue text was wrong to suggest it was coverable here; `test_websocket_scope_is_passed_through` pins the pass-through.
- **`/media/**`** — carries no credential (filenames embed a content hash). The exposure is request *volume*, which a failure-based limiter does nothing about, while counting its 404s would risk blocking a venue's icons after an ordinary delete. Volume limiting belongs at the proxy.
- **`/metrics`** — the concern is that it is unauthenticated (#447), not that it is brute-forceable.

The issue's fourth point — shared-NAT lockout — is **reduced, not eliminated**. Keying on IP fundamentally cannot distinguish several operators behind one NAT from one attacker. The split keyspaces bound the blast radius and the new metric makes a lockout visible instead of hiding it as a `status="429"` label on the latency histogram, but the tradeoff is inherent; the docs now say so and point at raising the threshold.

**Reviewers may want to focus on** the `_SURFACES` ordering in `auth_rate_limit.py` — it is scanned in order and `/api/v1/matches/*` must resolve to the `api` surface rather than `capability`, which it does because `/api/v1/` is listed first.

Each of the four new behaviours was confirmed to **fail** against the previous implementation before being kept.

## Test plan

- [x] `ruff check .`
- [x] `mypy`
- [x] `pytest tests/ --cov=app --cov-fail-under=70` — 1204 passed (up from 1198), coverage 86.29%
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run test:coverage` — 824 passed
- [x] Manual smoke test: booted the real app via `create_app()` and hammered `/overlay/<invalid-token>`, confirming it throttles after the configured number of misses and that the `/api/v1/` surface stays reachable through that lockout.

Frontend checks are untouched by this change but were run rather than assumed.

## Checklist

- [x] Added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] Regenerated screenshots if an operator-facing surface changed — **N/A**, no visual surface touched
- [x] Updated relevant docs — `AUTHENTICATION.md` §6.1
- [x] No secrets, credentials, or `.env` files committed

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqF9zcMx2iEhSWTju8RciN)_