### PR TITLE
Harden the default Content Security Policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,7 +58,8 @@ APP_TITLE=Volley Scoreboard
 # URL is the app's own /overlay/<token> link, surfaced under "My overlays".
 
 # Public URL of this app for OBS-friendly overlay links when running behind a
-# reverse proxy.
+# reverse proxy. Its exact HTTP(S) origin is added to the default CSP frame-src
+# allow-list so split-host previews keep working.
 OVERLAY_PUBLIC_URL=
 
 # Fallback team logo URL used when a team has none configured.

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -618,12 +618,15 @@ Located in `app/api/middleware/security_headers.py`. Adds:
 * `X-Content-Type-Options: nosniff` and `Referrer-Policy:
   strict-origin-when-cross-origin` and a `Permissions-Policy` that
   denies geolocation/microphone/camera/payment/usb on every response.
-* `Content-Security-Policy` (locked to `'self'` plus
-  `'unsafe-inline'`/`'unsafe-eval'` to keep the existing inline
-  match-report and SPA scripts working) and `X-Frame-Options:
-  SAMEORIGIN` on HTML responses. The `/overlay/*` routes get
-  `frame-ancestors *` instead so OBS browser sources can still embed
-  them off-origin.
+* `Content-Security-Policy` locks scripts to `'self'` plus
+  `'unsafe-inline'` for the existing inline overlay and match-report
+  scripts; string evaluation is not allowed. Frames default to `'self'`,
+  with the exact HTTP(S) origin from `OVERLAY_PUBLIC_URL` added when
+  configured so a split-host overlay preview still works. `img-src`
+  retains `https:` because team customization accepts operator-selected
+  external logo URLs. HTML responses also get `X-Frame-Options:
+  SAMEORIGIN`; `/overlay/*` instead uses `frame-ancestors *` and omits
+  that legacy header so OBS browser sources can embed it off-origin.
 * `Cache-Control: no-store` on `/api/v1/` responses that don't
   already set a `Cache-Control` header — keeps authenticated JSON
   out of intermediary caches.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ archive by hand.
   evaluation or arbitrary HTTPS iframes.** `script-src` drops the unused
   `'unsafe-eval'`; `frame-src` now allows only `'self'` and, for split-host
   deployments, the exact HTTP(S) origin configured by
-  `OVERLAY_PUBLIC_URL`. The broad `img-src https:` source remains
-  intentional because operators can configure external team-logo URLs.
+  `OVERLAY_PUBLIC_URL`, using browser-compatible UTS #46 normalization
+  for internationalized hostnames. The broad `img-src https:` source
+  remains intentional because operators can configure external team-logo URLs.
   Fixes [#431](https://github.com/JacoboSanchez/volley-overlay-control/issues/431).
 
 - **The rate limiter now covers the capability-token routes, and counts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ archive by hand.
   `'unsafe-eval'`; `frame-src` now allows only `'self'` and, for split-host
   deployments, the exact HTTP(S) origin configured by
   `OVERLAY_PUBLIC_URL`, using browser-compatible UTS #46 normalization
-  for internationalized hostnames. The broad `img-src https:` source
-  remains intentional because operators can configure external team-logo URLs.
+  for internationalized hostnames and WHATWG parsing for legacy IPv4 forms.
+  The broad `img-src https:` source remains intentional because operators can
+  configure external team-logo URLs.
   Fixes [#431](https://github.com/JacoboSanchez/volley-overlay-control/issues/431).
 
 - **The rate limiter now covers the capability-token routes, and counts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ archive by hand.
 
 ### Security
 
+- **The default Content Security Policy no longer permits string
+  evaluation or arbitrary HTTPS iframes.** `script-src` drops the unused
+  `'unsafe-eval'`; `frame-src` now allows only `'self'` and, for split-host
+  deployments, the exact HTTP(S) origin configured by
+  `OVERLAY_PUBLIC_URL`. The broad `img-src https:` source remains
+  intentional because operators can configure external team-logo URLs.
+  Fixes [#431](https://github.com/JacoboSanchez/volley-overlay-control/issues/431).
+
 - **The rate limiter now covers the capability-token routes, and counts
   the status a token miss actually returns.** It watched only `/api/v1/`
   and counted only 401/403 — but an unknown `public_token` on

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Configure the application using the following environment variables:
 | :--- | :--- | :--- |
 | `APP_PORT` | The TCP port where the application will run. | `8080` |
 | `APP_TITLE` | Application title shown in the browser tab, the init screen heading and the PWA manifest. | `Volley Scoreboard` |
-| `OVERLAY_PUBLIC_URL` | *(Optional)* Public base URL for overlay output links served by the built-in engine. If unset, URLs are constructed from the request's host. When overlays are served from a separate origin via a reverse proxy, route `/media` (hosted icon images) to this backend on that origin too. | |
+| `OVERLAY_PUBLIC_URL` | *(Optional)* Public base URL for overlay output links served by the built-in engine. If unset, URLs are constructed from the request's host. Its exact HTTP(S) origin is added to the default CSP `frame-src` allow-list so split-host previews work without allowing every HTTPS origin. When overlays are served from a separate origin via a reverse proxy, route `/media` (hosted icon images) to this backend on that origin too. | |
 | `MATCH_GAME_POINTS` | Points needed to win a set. | `25` |
 | `MATCH_GAME_POINTS_LAST_SET` | Points needed to win the last set. | `15` |
 | `MATCH_SETS` | Total sets in the match (best of N). | `5` |

--- a/app/api/middleware/security_headers.py
+++ b/app/api/middleware/security_headers.py
@@ -18,9 +18,12 @@ Headers applied to every response:
 Headers applied only to HTML responses:
 
 * ``Content-Security-Policy`` — locks ``default-src``/``script-src`` to
-  ``'self'`` plus ``'unsafe-inline'`` so the existing inline match-report
-  styles keep rendering. ``img-src`` allows ``https:`` and ``data:`` so
-  team logos still load from arbitrary CDNs and embedded data URLs.
+  ``'self'`` plus ``'unsafe-inline'`` for the existing inline overlay and
+  match-report scripts. ``style-src`` separately permits inline styles.
+  ``img-src`` allows ``https:`` and ``data:`` so team logos still load
+  from operator-selected CDNs and embedded data URLs. ``frame-src`` allows
+  ``'self'`` plus the exact HTTP(S) origin configured by
+  ``OVERLAY_PUBLIC_URL`` for split-host preview deployments.
   Overlay routes (``/overlay/*``) get a relaxed ``frame-ancestors *``
   because OBS browser sources embed them off-origin.
 * ``X-Frame-Options: SAMEORIGIN`` for non-overlay routes (legacy
@@ -35,8 +38,13 @@ Headers applied to ``/api/v1/`` responses:
 
 from __future__ import annotations
 
+import ipaddress
 import os
+import re
 from collections.abc import Iterable
+from urllib.parse import urlsplit
+
+from app.env_vars_manager import EnvVarsManager
 
 
 def _env(name: str, default: str) -> str:
@@ -48,28 +56,29 @@ def _env(name: str, default: str) -> str:
 
 _DEFAULT_CSP = (
     "default-src 'self'; "
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
+    "script-src 'self' 'unsafe-inline'; "
     "style-src 'self' 'unsafe-inline'; "
     # ``http:`` deliberately omitted: HTTPS deployments would block
     # mixed-content images anyway, and ``'self'`` already covers
-    # plain-HTTP localhost dev servers. Operators that genuinely need
-    # third-party HTTP logos can override via ``SECURITY_CSP``.
+    # plain-HTTP localhost dev servers. Arbitrary HTTPS remains necessary
+    # because operators may use external team-logo URLs. Deployments that
+    # only use the hosted icon library can narrow this via ``SECURITY_CSP``.
     "img-src 'self' data: https:; "
     "font-src 'self' data:; "
     "connect-src 'self' ws: wss: https:; "
-    # ``frame-src`` covers iframes the control UI embeds: the OverlayPreview
-    # card loads UNO overlays from ``overlays.uno`` and custom overlays from
-    # whichever host ``OVERLAY_PUBLIC_URL`` points at (which can be a separate
-    # subdomain when the overlay is reverse-proxied independently of the
-    # control UI). Without an explicit ``frame-src``, browsers fall back to
-    # ``default-src 'self'`` and silently block both cases.
-    "frame-src 'self' https:; "
+    # The configured OVERLAY_PUBLIC_URL origin is added at response time.
+    # Without an explicit ``frame-src``, browsers fall back to
+    # ``default-src 'self'`` and block split-host overlay previews.
+    "frame-src 'self'; "
     "object-src 'none'; "
     "base-uri 'self'; "
     "form-action 'self'; "
     "frame-ancestors 'self'"
 )
 
+_CSP_DNS_HOST_RE = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?\.?",
+)
 _OVERLAY_CSP_FRAME_ANCESTORS = "frame-ancestors *"
 # Overlay templates pull webfonts from Google Fonts (Outfit, Inter,
 # Roboto, Oswald, Montserrat, Rajdhani, Barlow Condensed, Chakra Petch,
@@ -111,6 +120,63 @@ def _augment_directive(parts: list[str], name: str, *extras: str) -> None:
     parts.append(" ".join((name, "'self'", *extras)))
 
 
+def _overlay_public_origin() -> str | None:
+    """Return the configured overlay HTTP(S) origin as a safe CSP source.
+
+    ``OVERLAY_PUBLIC_URL`` is also used to build the iframe URL. CSP needs
+    only its origin, never its path/query/fragment. Reconstructing that origin
+    from parsed components prevents whitespace or directive delimiters in a
+    malformed operator value from becoming header syntax.
+    """
+    raw = EnvVarsManager.get_env_var("OVERLAY_PUBLIC_URL", "")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+
+    try:
+        parsed = urlsplit(raw.strip())
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return None
+
+    scheme = parsed.scheme.lower()
+    if (
+        scheme not in {"http", "https"}
+        or not hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or "%" in hostname
+    ):
+        return None
+
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        try:
+            ascii_host = hostname.encode("idna").decode("ascii")
+        except UnicodeError:
+            return None
+        if _CSP_DNS_HOST_RE.fullmatch(ascii_host) is None:
+            return None
+        host = ascii_host.lower()
+    else:
+        host = address.compressed
+        if address.version == 6:
+            host = f"[{host}]"
+
+    port_suffix = f":{port}" if port is not None else ""
+    return f"{scheme}://{host}{port_suffix}"
+
+
+def _build_default_csp() -> str:
+    """Return the baseline CSP with the configured preview origin allowed."""
+    parts = [part.strip() for part in _DEFAULT_CSP.split(";") if part.strip()]
+    overlay_origin = _overlay_public_origin()
+    if overlay_origin is not None:
+        _augment_directive(parts, "frame-src", overlay_origin)
+    return "; ".join(parts)
+
+
 def _build_html_csp(path: str) -> str:
     """Return the CSP string for an HTML response on *path*.
 
@@ -121,7 +187,7 @@ def _build_html_csp(path: str) -> str:
     only — every other ``script-src`` / ``img-src`` / ``connect-src``
     policy stays in force.
     """
-    csp = _env("SECURITY_CSP", _DEFAULT_CSP)
+    csp = _env("SECURITY_CSP", "") or _build_default_csp()
     if any(path.startswith(prefix) for prefix in _OVERLAY_PREFIXES):
         parts = [p.strip() for p in csp.split(";") if p.strip()]
         replaced = False

--- a/app/api/middleware/security_headers.py
+++ b/app/api/middleware/security_headers.py
@@ -40,9 +40,10 @@ from __future__ import annotations
 
 import ipaddress
 import os
-import re
 from collections.abc import Iterable
 from urllib.parse import urlsplit
+
+import idna
 
 from app.env_vars_manager import EnvVarsManager
 
@@ -76,9 +77,6 @@ _DEFAULT_CSP = (
     "frame-ancestors 'self'"
 )
 
-_CSP_DNS_HOST_RE = re.compile(
-    r"[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?\.?",
-)
 _OVERLAY_CSP_FRAME_ANCESTORS = "frame-ancestors *"
 # Overlay templates pull webfonts from Google Fonts (Outfit, Inter,
 # Roboto, Oswald, Montserrat, Rajdhani, Barlow Condensed, Chakra Petch,
@@ -153,12 +151,13 @@ def _overlay_public_origin() -> str | None:
         address = ipaddress.ip_address(hostname)
     except ValueError:
         try:
-            ascii_host = hostname.encode("idna").decode("ascii")
-        except UnicodeError:
+            host = idna.encode(
+                hostname,
+                uts46=True,
+                std3_rules=True,
+            ).decode("ascii").lower()
+        except (idna.IDNAError, UnicodeError):
             return None
-        if _CSP_DNS_HOST_RE.fullmatch(ascii_host) is None:
-            return None
-        host = ascii_host.lower()
     else:
         host = address.compressed
         if address.version == 6:

--- a/app/api/middleware/security_headers.py
+++ b/app/api/middleware/security_headers.py
@@ -97,6 +97,74 @@ _DEFAULT_REFERRER_POLICY = "strict-origin-when-cross-origin"
 # the overlay templates as HTML; explicit "html=True" responses elsewhere
 # still get the headers because we sniff the Content-Type at send time.
 _OVERLAY_PREFIXES: tuple[str, ...] = ("/overlay/",)
+_ASCII_DECIMAL_DIGITS = frozenset("0123456789")
+_ASCII_OCTAL_DIGITS = frozenset("01234567")
+_ASCII_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+
+def _parse_whatwg_ipv4_number(part: str) -> int | None:
+    """Parse one IPv4 number using the WHATWG URL Standard's radices."""
+    if not part:
+        return None
+
+    radix = 10
+    digits = part
+    allowed_digits = _ASCII_DECIMAL_DIGITS
+    if part[:2].lower() == "0x":
+        radix = 16
+        digits = part[2:]
+        allowed_digits = _ASCII_HEX_DIGITS
+    elif len(part) >= 2 and part.startswith("0"):
+        radix = 8
+        digits = part[1:]
+        allowed_digits = _ASCII_OCTAL_DIGITS
+
+    # WHATWG treats a stripped ``0x`` prefix as zero.
+    if not digits:
+        return 0
+    if any(character not in allowed_digits for character in digits):
+        return None
+    return int(digits, radix)
+
+
+def _ends_in_whatwg_ipv4_number(host: str) -> bool:
+    """Return whether WHATWG host parsing treats *host* as IPv4 syntax."""
+    parts = host.split(".")
+    if parts[-1] == "":
+        parts.pop()
+    if not parts:
+        return False
+
+    last = parts[-1]
+    if last and all(character in _ASCII_DECIMAL_DIGITS for character in last):
+        return True
+    return _parse_whatwg_ipv4_number(last) is not None
+
+
+def _parse_whatwg_ipv4(host: str) -> str | None:
+    """Return the browser-canonical IPv4 address for *host*, if valid."""
+    parts = host.split(".")
+    if parts[-1] == "" and len(parts) > 1:
+        parts.pop()
+    if not parts or len(parts) > 4:
+        return None
+
+    numbers: list[int] = []
+    for part in parts:
+        number = _parse_whatwg_ipv4_number(part)
+        if number is None:
+            return None
+        numbers.append(number)
+
+    if any(number > 255 for number in numbers[:-1]):
+        return None
+    if numbers[-1] >= 256 ** (5 - len(numbers)):
+        return None
+
+    ipv4 = numbers[-1]
+    for index, number in enumerate(numbers[:-1]):
+        ipv4 += number * 256 ** (3 - index)
+    return ipaddress.IPv4Address(ipv4).compressed
 
 
 def _augment_directive(parts: list[str], name: str, *extras: str) -> None:
@@ -158,6 +226,16 @@ def _overlay_public_origin() -> str | None:
             ).decode("ascii").lower()
         except (idna.IDNAError, UnicodeError):
             return None
+
+        # Special-scheme URLs apply WHATWG's legacy IPv4 parser after IDNA.
+        # Browsers therefore turn hosts such as ``127.1``, ``0x7f.1``, and
+        # ``2130706433`` into ``127.0.0.1``. CSP must use the same serialized
+        # origin as the iframe or the split-host preview is blocked.
+        if _ends_in_whatwg_ipv4_number(host):
+            ipv4_host = _parse_whatwg_ipv4(host)
+            if ipv4_host is None:
+                return None
+            host = ipv4_host
     else:
         host = address.compressed
         if address.version == 6:

--- a/requirements.lock
+++ b/requirements.lock
@@ -26,6 +26,7 @@ httptools==0.8.0
     # via uvicorn
 idna==3.15
     # via
+    #   -r requirements.txt
     #   anyio
     #   requests
 jinja2==3.1.6
@@ -69,13 +70,10 @@ starlette==1.3.1
 typing-extensions==4.15.0
     # via
     #   alembic
-    #   anyio
     #   fastapi
-    #   psycopg
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
-    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 fastapi>=0.139.2
 uvicorn[standard]>=0.51.0
 requests==2.34.2
+# Browser-compatible UTS #46 normalization for CSP frame origins.
+idna>=3.15
 python-dotenv==1.2.2
 websocket-client>=1.9.0
 jinja2>=3.1.6

--- a/tests/test_security_enhancements.py
+++ b/tests/test_security_enhancements.py
@@ -79,12 +79,26 @@ def test_api_v1_response_disables_caching(headers_client):
     assert res.headers.get("cache-control") == "no-store"
 
 
-def test_html_response_carries_csp_and_xframe(headers_client):
+def test_html_response_carries_csp_and_xframe(headers_client, monkeypatch):
+    monkeypatch.delenv("OVERLAY_PUBLIC_URL", raising=False)
     res = headers_client.get("/manage")
     assert res.status_code == 200
     csp = res.headers.get("content-security-policy", "")
     assert "default-src 'self'" in csp
     assert "frame-ancestors 'self'" in csp
+    script_directive = next(
+        (
+            p.strip()
+            for p in csp.split(";")
+            if p.strip().startswith("script-src")
+        ),
+        "",
+    )
+    script_tokens = script_directive.split()
+    # Inline overlay/report scripts still need ``unsafe-inline``, but no
+    # shipped runtime evaluates strings as code.
+    assert "'unsafe-inline'" in script_tokens
+    assert "'unsafe-eval'" not in script_tokens
     # Default img-src must not contain a bare ``http:`` token —
     # HTTPS deployments would block mixed-content images anyway.
     img_directive = next(
@@ -92,18 +106,59 @@ def test_html_response_carries_csp_and_xframe(headers_client):
         "",
     )
     assert " http:" not in f" {img_directive} "
+    # Arbitrary HTTPS is intentional: team customization supports
+    # operator-selected external logo URLs.
     assert "https:" in img_directive
-    # ``frame-src`` must allow cross-origin HTTPS sources so the
-    # OverlayPreview iframe can render UNO overlays and custom overlays
-    # served from a different host (``OVERLAY_PUBLIC_URL`` split-host
-    # deployments).
     frame_src_directive = next(
         (p.strip() for p in csp.split(";") if p.strip().startswith("frame-src")),
         "",
     )
-    assert "https:" in frame_src_directive
-    assert "'self'" in frame_src_directive
+    # No scheme wildcard: same-origin is the only default when
+    # OVERLAY_PUBLIC_URL is unset.
+    assert frame_src_directive.split() == ["frame-src", "'self'"]
     assert res.headers.get("x-frame-options") == "SAMEORIGIN"
+
+
+def test_html_csp_allows_exact_overlay_public_origin(monkeypatch):
+    monkeypatch.setenv(
+        "OVERLAY_PUBLIC_URL",
+        "https://overlays.example.test:8443/proxy/base?ignored=yes",
+    )
+    res = TestClient(_build_headers_app()).get("/manage")
+    csp = res.headers["content-security-policy"]
+    frame_src_directive = next(
+        (p.strip() for p in csp.split(";") if p.strip().startswith("frame-src")),
+        "",
+    )
+    assert frame_src_directive.split() == [
+        "frame-src",
+        "'self'",
+        "https://overlays.example.test:8443",
+    ]
+    assert "https:" not in frame_src_directive.split()
+
+
+@pytest.mark.parametrize(
+    "public_url",
+    [
+        "javascript:alert(1)",
+        "https://user:password@overlays.example.test",
+        "https://overlays.example.test:99999",
+        "https://overlays.example.test; frame-src https://evil.example",
+    ],
+)
+def test_html_csp_ignores_invalid_overlay_public_origin(
+    monkeypatch,
+    public_url,
+):
+    monkeypatch.setenv("OVERLAY_PUBLIC_URL", public_url)
+    res = TestClient(_build_headers_app()).get("/manage")
+    csp = res.headers["content-security-policy"]
+    frame_src_directive = next(
+        (p.strip() for p in csp.split(";") if p.strip().startswith("frame-src")),
+        "",
+    )
+    assert frame_src_directive.split() == ["frame-src", "'self'"]
 
 
 def test_overlay_html_relaxes_frame_ancestors(headers_client):

--- a/tests/test_security_enhancements.py
+++ b/tests/test_security_enhancements.py
@@ -154,12 +154,47 @@ def test_html_csp_normalizes_idn_like_a_browser(monkeypatch):
 
 
 @pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("127.1", "127.0.0.1"),
+        ("0x7f.1", "127.0.0.1"),
+        ("0177.1", "127.0.0.1"),
+        ("2130706433", "127.0.0.1"),
+        ("127.0.0.1.", "127.0.0.1"),
+        ("0x", "0.0.0.0"),
+        ("①.②.③.④", "1.2.3.4"),
+    ],
+)
+def test_html_csp_normalizes_whatwg_ipv4_like_a_browser(
+    monkeypatch,
+    host,
+    expected,
+):
+    monkeypatch.setenv("OVERLAY_PUBLIC_URL", f"https://{host}/overlay")
+    res = TestClient(_build_headers_app()).get("/manage")
+    csp = res.headers["content-security-policy"]
+    frame_src_directive = next(
+        (p.strip() for p in csp.split(";") if p.strip().startswith("frame-src")),
+        "",
+    )
+    assert frame_src_directive.split() == [
+        "frame-src",
+        "'self'",
+        f"https://{expected}",
+    ]
+
+
+@pytest.mark.parametrize(
     "public_url",
     [
         "javascript:alert(1)",
         "https://user:password@overlays.example.test",
         "https://overlays.example.test:99999",
         "https://overlays.example.test; frame-src https://evil.example",
+        "https://09/overlay",
+        "https://1.2.3.4.5/overlay",
+        "https://test.42/overlay",
+        "https://0x100000000/overlay",
     ],
 )
 def test_html_csp_ignores_invalid_overlay_public_origin(

--- a/tests/test_security_enhancements.py
+++ b/tests/test_security_enhancements.py
@@ -138,6 +138,21 @@ def test_html_csp_allows_exact_overlay_public_origin(monkeypatch):
     assert "https:" not in frame_src_directive.split()
 
 
+def test_html_csp_normalizes_idn_like_a_browser(monkeypatch):
+    monkeypatch.setenv("OVERLAY_PUBLIC_URL", "https://faß.de/overlay")
+    res = TestClient(_build_headers_app()).get("/manage")
+    csp = res.headers["content-security-policy"]
+    frame_src_directive = next(
+        (p.strip() for p in csp.split(";") if p.strip().startswith("frame-src")),
+        "",
+    )
+    assert frame_src_directive.split() == [
+        "frame-src",
+        "'self'",
+        "https://xn--fa-hia.de",
+    ]
+
+
 @pytest.mark.parametrize(
     "public_url",
     [


### PR DESCRIPTION
## Summary

- remove the unused `'unsafe-eval'` source from the default `script-src` policy
- replace the `frame-src https:` wildcard with `'self'` plus the exact validated `OVERLAY_PUBLIC_URL` origin for split-host previews
- retain and document `img-src https:` because external team-logo URLs remain supported
- add regression coverage for the default policy, exact origin extraction, and malformed/injectable configuration values
- update the owning security/operator docs and changelog

## Root cause and impact

The default CSP retained permissions justified by the removed overlays.uno integration. This allowed arbitrary HTTPS iframe origins and string evaluation even though neither is required by the current in-process overlay architecture. The new default narrows those capabilities while preserving same-origin previews and explicitly configured split-host deployments.

## Validation

- `.venv/bin/pytest tests/test_security_enhancements.py -q` — 72 passed
- `.venv/bin/pytest tests/ --cov=app --cov-report=term-missing -q` — 1,240 passed, 86.46% coverage
- `.venv/bin/ruff check .`
- `.venv/bin/mypy`
- `git diff --check`

Closes #431