### PR TITLE
Harden Docker CI with caching, scanning, and smoke testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,12 +281,74 @@ jobs:
         npm audit --omit=dev --audit-level=high
 
   docker-build:
-    name: Docker image build
+    name: Docker image build, scan, and smoke test
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v7
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
     - name: Build production image
-      run: docker build -t volley-overlay-control:ci .
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      with:
+        context: .
+        file: ./Dockerfile
+        load: true
+        tags: volley-overlay-control:ci
+        cache-from: type=gha,scope=docker-ci
+        cache-to: type=gha,mode=max,scope=docker-ci
+
+    - name: Smoke test production image
+      run: |
+        container_id="$(
+          docker run --detach \
+            --name volley-overlay-control-ci \
+            --publish 127.0.0.1:8080:8080 \
+            volley-overlay-control:ci
+        )"
+
+        cleanup() {
+          status=$?
+          if [ "$status" -ne 0 ]; then
+            echo "::group::Container logs"
+            docker logs "$container_id" || true
+            echo "::endgroup::"
+          fi
+          docker rm --force "$container_id" >/dev/null 2>&1 || true
+          trap - EXIT
+          exit "$status"
+        }
+        trap cleanup EXIT
+
+        for attempt in $(seq 1 30); do
+          if curl --fail --silent --output /dev/null \
+              http://127.0.0.1:8080/health; then
+            echo "Container passed its /health smoke test."
+            exit 0
+          fi
+
+          if [ "$(docker inspect --format '{{.State.Running}}' "$container_id")" != "true" ]; then
+            echo "::error::Container exited before /health became ready."
+            exit 1
+          fi
+
+          echo "Waiting for /health (attempt $attempt/30)..."
+          sleep 2
+        done
+
+        echo "::error::Timed out waiting for /health."
+        exit 1
+
+    - name: Scan production image for vulnerabilities
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      with:
+        image-ref: volley-overlay-control:ci
+        scanners: vuln
+        format: table
+        ignore-unfixed: true
+        vuln-type: os,library
+        severity: HIGH,CRITICAL
+        exit-code: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,7 +317,7 @@ so satisfying only a subset still produces a red PR:
 | Backend | `pytest` (coverage floor 70%) · `ruff` · `mypy` · `bandit` · `pip-audit` (both lockfiles) · lockfile-satisfies-`requirements.txt` |
 | Frontend / overlay assets | `vitest` (coverage floors in `vite.config.js`) · `tsc` · `eslint` (`--max-warnings 0`) · `prettier --check` · `stylelint` · `npm audit` |
 | Contract | committed OpenAPI schema + generated types must not drift |
-| Image | `docker build` must succeed |
+| Image | `docker build` via Buildx must succeed · Trivy image scan (fixed HIGH/CRITICAL findings fail) · `/health` smoke test |
 
 ```bash
 # Backend

--- a/tests/test_docs_consistency.py
+++ b/tests/test_docs_consistency.py
@@ -156,9 +156,9 @@ def test_readme_style_list_matches_reality(selectable_styles):
 # CI gates
 # --------------------------------------------------------------------------
 
-# Each documented gate → a command fragment that must appear in a ci.yml
-# `run:` block. Keyed by the token AGENTS.md's gate table uses, so the two
-# directions below can name the offender precisely.
+# Each documented gate → an invocation fragment that must appear in a ci.yml
+# `run:` block or gating action. Keyed by the token AGENTS.md's gate table uses,
+# so the two directions below can name the offender precisely.
 #
 # The value is a tuple because one documented gate can promise more than one
 # CI step: the table says pip-audit covers "both lockfiles", so a lone
@@ -186,12 +186,14 @@ CI_GATES = {
         "git diff --exit-code -- frontend/schema/openapi.json",
         "frontend/src/api/schema.d.ts",
     ),
-    "docker build": ("docker build",),
+    "docker build": ("docker/build-push-action@",),
+    "Trivy": ("aquasecurity/trivy-action@",),
+    "/health": ("http://127.0.0.1:8080/health",),
 }
 
 # ci.yml steps that cannot fail on a code problem: environment setup and
-# artifact upload. Anything else that runs a command is a gate and must be
-# documented.
+# artifact upload. Anything else that runs a command or invokes an action is a
+# gate and must be documented.
 NON_GATE_STEPS = {
     "Install dependencies",
     "Install Python dependencies",
@@ -200,9 +202,17 @@ NON_GATE_STEPS = {
     "Regenerate OpenAPI schema and TypeScript types",
 }
 
+NON_GATE_ACTIONS = (
+    "actions/checkout@",
+    "actions/setup-node@",
+    "actions/setup-python@",
+    "actions/upload-artifact@",
+    "docker/setup-buildx-action@",
+)
+
 
 def _ci_gate_steps() -> list[tuple[str, str]]:
-    """Every ``(step name, run command)`` pair that can fail the build.
+    """Every ``(step name, invocation)`` pair that can fail the build.
 
     Setup steps are excluded, and that exclusion is load-bearing rather than
     cosmetic: the dependency-install step pins ``ruff==…`` and ``mypy==…``, so
@@ -215,6 +225,9 @@ def _ci_gate_steps() -> list[tuple[str, str]]:
         for step in job.get("steps", []):
             if "run" in step and step.get("name") not in NON_GATE_STEPS:
                 steps.append((step.get("name", "<unnamed>"), step["run"]))
+            elif "uses" in step and not step["uses"].startswith(NON_GATE_ACTIONS):
+                invocation = f"{step['uses']}\n{yaml.safe_dump(step.get('with', {}))}"
+                steps.append((step.get("name", "<unnamed>"), invocation))
     return steps
 
 


### PR DESCRIPTION
## Summary

Hardens the Docker CI job so production images are cached, vulnerability-scanned, and exercised at runtime before merge.

Closes #444.

## Changes

- build the CI image through Buildx with a scoped GitHub Actions layer cache
- boot the built image and poll `/health`, preserving container logs when startup fails
- scan the exact built image with Trivy and fail on fixed HIGH/CRITICAL OS or library vulnerabilities
- pin the newly introduced third-party actions to immutable commit SHAs
- keep the contributor gate table and its drift guard aligned with action-backed CI gates

## Implementation notes

The Buildx step uses `load: true`, allowing the smoke test and Trivy scan to reuse the same image without rebuilding or pushing it. Unfixed findings are reported but do not block the PR, keeping the gate actionable when no upstream fix exists.

The related Dockerfile and publishing-workflow observations in #444 are intentionally outside this focused PR; this resolves the three gaps named in the issue title.

## Test plan

- [x] `ruff check .` (GitHub Actions, Python 3.11 and 3.14)
- [x] `mypy` (GitHub Actions, Python 3.11 and 3.14)
- [x] `pytest tests/ --cov=app --cov-fail-under=70` (GitHub Actions, Python 3.11 and 3.14)
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run test:coverage`
- [x] `pytest -q tests/test_docs_consistency.py` locally (16 passed)
- [x] `ruff check tests/test_docs_consistency.py` locally
- [x] `actionlint .github/workflows/ci.yml` locally
- [x] `docker buildx build --load --tag volley-overlay-control:ci .` locally
- [x] Started the production image locally and confirmed `GET /health` returns success
- [x] Trivy 0.70.0 local image scan with the PR's HIGH/CRITICAL policy (zero findings)
- [x] GitHub Actions Docker build, smoke test, and Trivy scan
- [x] GitHub Actions security scanners and CodeQL

## Checklist

- [x] `CHANGELOG.md` omitted because this is an internal-only CI change
- [x] Screenshots are not applicable
- [x] Updated `AGENTS.md` for the expanded image quality gates
- [x] No secrets, credentials, or `.env` files committed