### PR TITLE
docs: log merged dependency bumps in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -526,6 +526,15 @@ archive by hand.
   hardcodes uid/gid 1000. They invited operators to set a value that
   silently did nothing.
 
+### Dependencies
+
+- **Frontend:** `vite` `8.1.0` → `8.1.5` (patch-level bug fixes; pulls
+  `rolldown` `1.1.3` → `1.1.5`).
+  [#469](https://github.com/JacoboSanchez/volley-overlay-control/pull/469)
+- **CI (GitHub Actions):** `docker/login-action` `4.4.0` → `4.6.0`
+  (still pinned by commit SHA).
+  [#464](https://github.com/JacoboSanchez/volley-overlay-control/pull/464)
+
 ## [6.2.2] - 2026-07-20
 
 ### Changed


### PR DESCRIPTION
## Summary

Records two dependency bumps that were merged straight from Dependabot
(#464 and #469) and therefore landed without the `CHANGELOG.md` entry
that `AGENTS.md` requires for dependency changes.

## Changes

- Adds a `### Dependencies` subsection under `## [Unreleased]` covering
  `vite` `8.1.0` → `8.1.5` (#469) and `docker/login-action` `4.4.0` →
  `4.6.0` (#464).

## Implementation notes

This PR contains **no dependency changes** — both bumps are already on
`main`. The only diff is nine added lines in `CHANGELOG.md`.

Both source PRs were merged on fully green CI. `docker/login-action` is
pinned by commit SHA; `dbcb813823bdd20940b903addbd779551569679f` was
verified against `refs/tags/v4.6.0` upstream before merging.

Placement follows the precedent set by the 6.0.1 release, where
`### Dependencies` is the final subsection.

## Test plan

Not applicable — documentation-only change, no code paths touched. CI
runs the full suite regardless.

## Checklist

- [x] Added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] Regenerated screenshots if an operator-facing surface changed — n/a
- [x] Updated relevant docs when behaviour changed — n/a, no behaviour change
- [x] No secrets, credentials, or `.env` files committed