### PR TITLE
Refactor board state into contexts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useLayoutEffect } from 'react';
+import { useState, useEffect, useCallback, useLayoutEffect, useMemo, useRef } from 'react';
 import { setControlToken, setPublicUser } from './api/client';
 import { useI18n } from './i18n';
 import { useAppConfig } from './hooks/useAppConfig';
@@ -22,6 +22,13 @@ import { useOverlayLocaleSync } from './hooks/useOverlayLocaleSync';
 import { useScoreActions } from './hooks/useScoreActions';
 import { useSetValueDialog } from './hooks/useSetValueDialog';
 import { useButtonTheme } from './hooks/useButtonTheme';
+import {
+  BoardContextProvider,
+  type BoardActionsValue,
+  type BoardLayoutValue,
+  type BoardStateValue,
+  type BoardThemeValue,
+} from './board/BoardContexts';
 import InitScreen from './components/InitScreen';
 import ScoreboardView from './components/ScoreboardView';
 import ScoreboardSkeleton from './components/ScoreboardSkeleton';
@@ -204,6 +211,12 @@ export default function App({
   const setsLimit = (state?.config?.sets_limit as number | undefined) ?? 5;
   const matchFinished = state?.match_finished ?? false;
   const simpleMode = state?.simple_mode ?? false;
+  const stateRef = useRef(state);
+  const settingsRef = useRef(settings);
+  const pulseRef = useRef(pulse);
+  stateRef.current = state;
+  settingsRef.current = settings;
+  pulseRef.current = pulse;
 
   const computeCurrentSet = useCallback((): number => {
     if (!state) return 1;
@@ -235,27 +248,28 @@ export default function App({
   } = useScoreActions({ actions, settings, simpleMode, matchFinished, pulse });
 
   const handleToggleVisibility = useCallback(() => {
-    if (state) actions.setVisibility(!state.visible);
-  }, [actions, state]);
+    const currentState = stateRef.current;
+    if (currentState) actions.setVisibility(!currentState.visible);
+  }, [actions]);
 
   const handleToggleSimpleMode = useCallback(() => {
-    actions.setSimpleMode(!simpleMode);
-  }, [actions, simpleMode]);
+    const currentState = stateRef.current;
+    if (currentState) actions.setSimpleMode(!currentState.simple_mode);
+  }, [actions]);
 
   const sidesSwapped = state?.sides_swapped ?? false;
   const handleSwapSides = useCallback(() => {
-    actions.setSwapSides(!sidesSwapped);
-  }, [actions, sidesSwapped]);
+    const currentState = stateRef.current;
+    if (currentState) actions.setSwapSides(!currentState.sides_swapped);
+  }, [actions]);
 
-  const setSummaryActive = state?.set_summary ?? false;
-  const setSummarySetNum = state?.set_summary_set_num ?? null;
   const setSummaryStyle = (state?.set_summary_style ??
     'brand_ledger') as import('./api/client').SetSummaryStyle;
 
   const handleToggleSetSummary = useCallback(() => {
-    if (!settings.setSummaryEnabled) return;
-    actions.setSetSummary(!setSummaryActive);
-  }, [actions, setSummaryActive, settings.setSummaryEnabled]);
+    if (!settingsRef.current.setSummaryEnabled) return;
+    actions.setSetSummary(!(stateRef.current?.set_summary ?? false));
+  }, [actions]);
 
   const handleChangeSetSummaryStyle = useCallback(
     (style: import('./api/client').SetSummaryStyle) => {
@@ -270,9 +284,9 @@ export default function App({
   // entry points (this and the per-team double-tap) share
   // the same stack on the server and cannot drift.
   const handleUndoLast = useCallback(() => {
-    pulse('confirm');
+    pulseRef.current('confirm');
     actions.undoLast();
-  }, [actions, pulse]);
+  }, [actions]);
 
   const handleToggleFullscreen = useCallback(() => {
     if (document.fullscreenElement) {
@@ -287,8 +301,8 @@ export default function App({
   }, []);
 
   const handleTogglePreview = useCallback(() => {
-    setSetting('showPreview', !settings.showPreview);
-  }, [setSetting, settings.showPreview]);
+    setSetting('showPreview', !settingsRef.current.showPreview);
+  }, [setSetting]);
 
   const handleReset = useCallback(() => {
     setResetConfirmOpen(true);
@@ -301,6 +315,13 @@ export default function App({
   const handleStartMatch = useCallback(() => {
     actions.startMatch();
   }, [actions]);
+
+  const handleOpenConfig = useCallback(() => setActiveTab('config'), []);
+  const handleOpenHistory = useCallback(() => setHistoryOpen(true), []);
+  const handleToggleControls = useCallback(
+    () => setShowControls((shown) => !shown),
+    [setShowControls],
+  );
 
   const { dialog, handleLongPressScore, handleLongPressSet, handleDialogSubmit, closeDialog } =
     useSetValueDialog({ state, currentSet, setsLimit, actions, t });
@@ -329,6 +350,114 @@ export default function App({
 
   const { btnColorA, btnTextA, btnColorB, btnTextB, iconLogoA, iconLogoB, fontStyle } =
     useButtonTheme({ settings, customization });
+  const boardState = useMemo<BoardStateValue | null>(() => {
+    if (!state) return null;
+    return {
+      state,
+      confirmedState,
+      customization,
+      currentSet,
+      setsLimit,
+      simpleMode,
+      matchFinished,
+      sidesSwapped,
+      previewData,
+      showPreview: settings.showPreview,
+      setSummaryEnabled: settings.setSummaryEnabled,
+      showOnAir: settings.showOnAir,
+      showReportLink: settings.showReportLink,
+      recentEvents,
+    };
+  }, [
+    confirmedState,
+    currentSet,
+    customization,
+    matchFinished,
+    previewData,
+    recentEvents,
+    settings.setSummaryEnabled,
+    settings.showOnAir,
+    settings.showPreview,
+    settings.showReportLink,
+    sidesSwapped,
+    simpleMode,
+    state,
+    setsLimit,
+  ]);
+  const boardActions = useMemo<BoardActionsValue>(
+    () => ({
+      onAddPoint: handleAddPoint,
+      onAddSet: handleAddSet,
+      onAddTimeout: handleAddTimeout,
+      onChangeServe: handleChangeServe,
+      onDoubleTapScore: handleDoubleTapScore,
+      onDoubleTapTimeout: handleDoubleTapTimeout,
+      onLongPressScore: handleLongPressScore,
+      onLongPressSet: handleLongPressSet,
+      onSwapSides: handleSwapSides,
+      onToggleVisibility: handleToggleVisibility,
+      onToggleSimpleMode: handleToggleSimpleMode,
+      onUndoLast: handleUndoLast,
+      onTogglePreview: handleTogglePreview,
+      onToggleSetSummary: handleToggleSetSummary,
+      onChangeSetSummaryStyle: handleChangeSetSummaryStyle,
+      onStartMatch: handleStartMatch,
+      onReset: handleReset,
+      onOpenConfig: handleOpenConfig,
+      onOpenShare: handleOpenShare,
+      onOpenHistory: handleOpenHistory,
+      onToggleControls: handleToggleControls,
+    }),
+    [
+      handleAddPoint,
+      handleAddSet,
+      handleAddTimeout,
+      handleChangeServe,
+      handleChangeSetSummaryStyle,
+      handleDoubleTapScore,
+      handleDoubleTapTimeout,
+      handleLongPressScore,
+      handleLongPressSet,
+      handleOpenConfig,
+      handleOpenHistory,
+      handleOpenShare,
+      handleReset,
+      handleStartMatch,
+      handleSwapSides,
+      handleToggleControls,
+      handleTogglePreview,
+      handleToggleSetSummary,
+      handleToggleSimpleMode,
+      handleToggleVisibility,
+      handleUndoLast,
+    ],
+  );
+  const boardTheme = useMemo<BoardThemeValue>(
+    () => ({
+      btnColorA,
+      btnTextA,
+      btnColorB,
+      btnTextB,
+      iconLogoA,
+      iconLogoB,
+      iconOpacity: settings.iconOpacity,
+      fontStyle,
+    }),
+    [
+      btnColorA,
+      btnColorB,
+      btnTextA,
+      btnTextB,
+      fontStyle,
+      iconLogoA,
+      iconLogoB,
+      settings.iconOpacity,
+    ],
+  );
+  const boardLayout = useMemo<BoardLayoutValue>(
+    () => ({ isPortrait, buttonSize, compactLandscape, showControls }),
+    [buttonSize, compactLandscape, isPortrait, showControls],
+  );
 
   if (!oid || (error && !state)) {
     // A failed capability link (revoked ?c= token, disabled ?u= bookmark)
@@ -367,7 +496,7 @@ export default function App({
   // OID is set, no error, but the first authoritative state hasn't
   // arrived yet — show a structurally-matched skeleton instead of the
   // InitScreen so the next render swap doesn't flash unrelated UI.
-  if (!state) {
+  if (!state || !boardState) {
     return (
       <div className="app-container">
         <ConnectionStatus connected={connected} />
@@ -381,62 +510,14 @@ export default function App({
       <ConnectionStatus connected={connected} />
       {activeTab === 'scoreboard' && (
         <ErrorBoundary>
-          <ScoreboardView
-            state={state}
-            customization={customization}
-            sidesSwapped={sidesSwapped}
-            onSwapSides={handleSwapSides}
-            currentSet={currentSet}
-            setsLimit={setsLimit}
-            isPortrait={isPortrait}
-            buttonSize={buttonSize}
-            previewData={previewData}
-            showPreview={settings.showPreview}
-            recentEvents={recentEvents}
-            // Landscape phones (no room for persistent controls) need the
-            // preview shrunk so the alert pills below it don't get pushed
-            // off the bottom of the viewport.
-            compactLandscape={compactLandscape}
-            showControls={showControls}
-            setShowControls={setShowControls}
-            canUndo={state?.can_undo ?? false}
-            simpleMode={simpleMode}
-            btnColorA={btnColorA}
-            btnTextA={btnTextA}
-            btnColorB={btnColorB}
-            btnTextB={btnTextB}
-            iconLogoA={iconLogoA}
-            iconLogoB={iconLogoB}
-            iconOpacity={settings.iconOpacity}
-            fontStyle={fontStyle}
-            onAddPoint={handleAddPoint}
-            onAddSet={handleAddSet}
-            onAddTimeout={handleAddTimeout}
-            onChangeServe={handleChangeServe}
-            onDoubleTapScore={handleDoubleTapScore}
-            onDoubleTapTimeout={handleDoubleTapTimeout}
-            onLongPressScore={handleLongPressScore}
-            onLongPressSet={handleLongPressSet}
-            onToggleVisibility={handleToggleVisibility}
-            onToggleSimpleMode={handleToggleSimpleMode}
-            onUndoLast={handleUndoLast}
-            onTogglePreview={handleTogglePreview}
-            onStartMatch={handleStartMatch}
-            onReset={handleReset}
-            onOpenConfig={() => setActiveTab('config')}
-            onOpenShare={handleOpenShare}
-            onOpenHistory={() => setHistoryOpen(true)}
-            setSummaryEnabled={settings.setSummaryEnabled}
-            setSummaryActive={setSummaryActive}
-            setSummarySetNum={setSummarySetNum}
-            setSummaryStyle={setSummaryStyle}
-            onToggleSetSummary={handleToggleSetSummary}
-            onChangeSetSummaryStyle={handleChangeSetSummaryStyle}
-            obsClients={state?.obs_clients ?? 0}
-            showOnAir={settings.showOnAir}
-            lastMatchId={state?.last_match_id ?? null}
-            showReportLink={settings.showReportLink}
-          />
+          <BoardContextProvider
+            state={boardState}
+            actions={boardActions}
+            theme={boardTheme}
+            layout={boardLayout}
+          >
+            <ScoreboardView />
+          </BoardContextProvider>
         </ErrorBoundary>
       )}
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -235,7 +235,7 @@ async function getPage<B>(path: string, offset: number): Promise<{ body: B; tota
  */
 async function getAllPages<B, R>(path: string, extract: (body: B) => R[]): Promise<R[]> {
   const rows: R[] = [];
-  for (let offset = 0; ; ) {
+  for (let offset = 0; ;) {
     const { body, total } = await getPage<B>(path, offset);
     const page = extract(body);
     // A body that isn't the expected array (an error envelope, a shape change)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -235,7 +235,7 @@ async function getPage<B>(path: string, offset: number): Promise<{ body: B; tota
  */
 async function getAllPages<B, R>(path: string, extract: (body: B) => R[]): Promise<R[]> {
   const rows: R[] = [];
-  for (let offset = 0; ;) {
+  for (let offset = 0; ; ) {
     const { body, total } = await getPage<B>(path, offset);
     const page = extract(body);
     // A body that isn't the expected array (an error envelope, a shape change)

--- a/frontend/src/board/BoardContexts.tsx
+++ b/frontend/src/board/BoardContexts.tsx
@@ -1,0 +1,127 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import type { SetSummaryStyle, GameState } from '../api/client';
+import type { ConfigModel } from '../components/TeamCard';
+import type { PreviewData } from '../components/CenterPanel';
+import type { ScoreButtonFontStyle } from '../components/ScoreButton';
+import type { RecentEvent } from '../hooks/useRecentEvents';
+
+type Team = 1 | 2;
+
+/** Live and derived board data shared by the score-facing components. */
+export interface BoardStateValue {
+  state: GameState;
+  confirmedState: GameState | null;
+  customization: ConfigModel | null | undefined;
+  currentSet: number;
+  setsLimit: number;
+  simpleMode: boolean;
+  matchFinished: boolean;
+  sidesSwapped: boolean;
+  previewData: PreviewData | null | undefined;
+  showPreview: boolean;
+  setSummaryEnabled: boolean;
+  showOnAir: boolean;
+  showReportLink: boolean;
+  recentEvents: RecentEvent[];
+}
+
+/** Operator callbacks. Their provider value is memoized by App. */
+export interface BoardActionsValue {
+  onAddPoint: (team: Team) => void;
+  onAddSet: (team: Team) => void;
+  onAddTimeout: (team: Team) => void;
+  onChangeServe: (team: Team) => void;
+  onDoubleTapScore: (team: Team) => void;
+  onDoubleTapTimeout: (team: Team) => void;
+  onLongPressScore: (team: Team) => void;
+  onLongPressSet: (team: Team) => void;
+  onSwapSides: () => void;
+  onToggleVisibility: () => void;
+  onToggleSimpleMode: () => void;
+  onUndoLast: () => void;
+  onTogglePreview: () => void;
+  onToggleSetSummary: () => void;
+  onChangeSetSummaryStyle: (style: SetSummaryStyle) => void;
+  onStartMatch: () => void;
+  onReset: () => void;
+  onOpenConfig: () => void;
+  onOpenShare: () => void;
+  onOpenHistory: () => void;
+  onToggleControls: () => void;
+}
+
+/** Score-button colors, logos and typography resolved from user settings. */
+export interface BoardThemeValue {
+  btnColorA: string;
+  btnTextA: string;
+  btnColorB: string;
+  btnTextB: string;
+  iconLogoA: string | null;
+  iconLogoB: string | null;
+  iconOpacity?: number;
+  fontStyle: ScoreButtonFontStyle;
+}
+
+/** Viewport-derived board layout values. */
+export interface BoardLayoutValue {
+  isPortrait: boolean;
+  buttonSize?: number;
+  compactLandscape: boolean;
+  showControls: boolean;
+}
+
+const BoardStateContext = createContext<BoardStateValue | null>(null);
+const BoardActionsContext = createContext<BoardActionsValue | null>(null);
+const BoardThemeContext = createContext<BoardThemeValue | null>(null);
+const BoardLayoutContext = createContext<BoardLayoutValue | null>(null);
+
+export interface BoardContextProviderProps {
+  state: BoardStateValue;
+  actions: BoardActionsValue;
+  theme: BoardThemeValue;
+  layout: BoardLayoutValue;
+  children: ReactNode;
+}
+
+/**
+ * Groups the deliberately split board contexts at the App boundary. Keeping
+ * live match data separate from stable handlers, theme, and layout means a
+ * state push only notifies consumers of the data they actually read.
+ */
+export function BoardContextProvider({
+  state,
+  actions,
+  theme,
+  layout,
+  children,
+}: BoardContextProviderProps) {
+  return (
+    <BoardStateContext.Provider value={state}>
+      <BoardActionsContext.Provider value={actions}>
+        <BoardThemeContext.Provider value={theme}>
+          <BoardLayoutContext.Provider value={layout}>{children}</BoardLayoutContext.Provider>
+        </BoardThemeContext.Provider>
+      </BoardActionsContext.Provider>
+    </BoardStateContext.Provider>
+  );
+}
+
+function missingProvider(name: string): never {
+  throw new Error(`${name} must be used within a BoardContextProvider`);
+}
+
+export function useBoardState(): BoardStateValue {
+  return useContext(BoardStateContext) ?? missingProvider('useBoardState');
+}
+
+export function useBoardActions(): BoardActionsValue {
+  return useContext(BoardActionsContext) ?? missingProvider('useBoardActions');
+}
+
+export function useBoardTheme(): BoardThemeValue {
+  return useContext(BoardThemeContext) ?? missingProvider('useBoardTheme');
+}
+
+export function useBoardLayout(): BoardLayoutValue {
+  return useContext(BoardLayoutContext) ?? missingProvider('useBoardLayout');
+}

--- a/frontend/src/components/CenterPanel.tsx
+++ b/frontend/src/components/CenterPanel.tsx
@@ -1,20 +1,21 @@
 import { memo } from 'react';
 import { useI18n } from '../i18n';
 import ScoreButton from './ScoreButton';
-import type { ScoreButtonFontStyle } from './ScoreButton';
 import ScoreTable from './ScoreTable';
 import OverlayPreview from './OverlayPreview';
 import PointsHistoryStrip from './PointsHistoryStrip';
 import SetSummaryActiveNotice from './SetSummaryActiveNotice';
-import type { SetSummaryStyle } from '../api/client';
 import SideSwitchIndicator from './SideSwitchIndicator';
 import ServeSwitchIndicator from './ServeSwitchIndicator';
 import MatchAlertIndicator from './MatchAlertIndicator';
-import type { GameState } from '../api/client';
-import type { ConfigModel } from './TeamCard';
-import type { RecentEvent } from '../hooks/useRecentEvents';
 import { useIndoorMidpointAlert } from '../hooks/useIndoorMidpointAlert';
 import { asString } from '../utils/coerce';
+import {
+  useBoardActions,
+  useBoardLayout,
+  useBoardState,
+  useBoardTheme,
+} from '../board/BoardContexts';
 
 export interface PreviewData {
   overlayUrl: string;
@@ -25,94 +26,28 @@ export interface PreviewData {
   layoutId?: string;
 }
 
-export interface CenterPanelProps {
-  state: GameState | null | undefined;
-  /** Display-side swap: true mirrors the centre columns too. */
-  sidesSwapped?: boolean;
-  onSwapSides?: () => void;
-  customization: ConfigModel | null | undefined;
-  currentSet: number;
-  setsLimit: number;
-  isPortrait: boolean;
-  /**
-   * Landscape phones can't fit a 300px-wide preview AND the alert pills
-   * (set/match point, side switch) without spilling off the viewport.
-   * When true the centre column tightens its spacing and the preview
-   * renders at a reduced width so its derived height shrinks too.
-   */
-  compactLandscape?: boolean;
-  previewData: PreviewData | null | undefined;
-  /**
-   * Recent audit events in chronological order (oldest first).
-   * Rendered as a two-row table (one per team) in the slot the
-   * preview would occupy whenever the preview is hidden.
-   */
-  recentEvents: RecentEvent[];
-  /** Score-button colours, reused for the points-history chips so the
-   * strip honours followTeamColors / custom team colour overrides. */
-  btnColorA: string;
-  btnTextA: string;
-  btnColorB: string;
-  btnTextB: string;
-  /**
-   * Team logos, already resolved against the operator's "show logos"
-   * (``showIcon``) setting — ``null`` when logos are turned off. Passing
-   * the resolved value (rather than re-reading the customization here)
-   * keeps the set-score columns and points-history strip in lockstep
-   * with the score buttons, which hide their logos from the same toggle.
-   */
-  team1Logo: string | null;
-  team2Logo: string | null;
-  fontStyle?: ScoreButtonFontStyle;
-  /**
-   * Set summary overlay: when the operator has the recap active, the
-   * centre column swaps the preview / history strip for a notice so
-   * they can't lose track of it being on air. Defaults to off.
-   */
-  setSummaryActive?: boolean;
-  setSummarySetNum?: number | null;
-  setSummaryStyle?: SetSummaryStyle;
-  onDeactivateSetSummary?: () => void;
-  onChangeSetSummaryStyle?: (style: SetSummaryStyle) => void;
-  onAddSet: (teamId: 1 | 2) => void;
-  onLongPressSet: (teamId: 1 | 2) => void;
-}
-
 const PREVIEW_CARD_WIDTH = 300;
 const PREVIEW_CARD_WIDTH_COMPACT = 200;
 
-function CenterPanel({
-  state,
-  sidesSwapped = false,
-  onSwapSides,
-  customization,
-  currentSet,
-  setsLimit,
-  isPortrait,
-  compactLandscape = false,
-  previewData,
-  recentEvents,
-  btnColorA,
-  btnTextA,
-  btnColorB,
-  btnTextB,
-  team1Logo,
-  team2Logo,
-  fontStyle,
-  setSummaryActive,
-  setSummarySetNum,
-  setSummaryStyle,
-  onDeactivateSetSummary,
-  onChangeSetSummaryStyle,
-  onAddSet,
-  onLongPressSet,
-}: CenterPanelProps) {
+/** Centre score, alerts, and preview column. */
+function CenterPanel() {
   const { t } = useI18n();
-  // Hooks must run before any early return — the hook itself handles
-  // a null/undefined state by returning ``false``.
+  const {
+    state,
+    customization,
+    currentSet,
+    setsLimit,
+    sidesSwapped,
+    previewData,
+    showPreview,
+    recentEvents,
+  } = useBoardState();
+  const { isPortrait, compactLandscape } = useBoardLayout();
+  const { btnColorA, btnTextA, btnColorB, btnTextB, iconLogoA, iconLogoB, fontStyle } =
+    useBoardTheme();
+  const { onAddSet, onLongPressSet, onSwapSides, onToggleSetSummary, onChangeSetSummaryStyle } =
+    useBoardActions();
   const indoorMidpointPending = useIndoorMidpointAlert(state, currentSet, setsLimit);
-
-  if (!state) return null;
 
   // Display-side swap: presentation only — the buttons stay bound to
   // their real team ids, the columns just trade places.
@@ -120,7 +55,7 @@ function CenterPanel({
   const rightId: 1 | 2 = sidesSwapped ? 1 : 2;
   const setsById = { 1: state.team_1.sets, 2: state.team_2.sets } as const;
   // Already gated by the "show logos" toggle upstream — null when off.
-  const logosById = { 1: team1Logo, 2: team2Logo } as const;
+  const logosById = { 1: iconLogoA, 2: iconLogoB } as const;
   const teamNamesById = {
     1:
       asString(customization?.['Team 1 Name']) ||
@@ -131,6 +66,10 @@ function CenterPanel({
       asString(customization?.['Team 2 Text Name']) ||
       t('scoreboard.team', { team: 2 }),
   } as const;
+  const setSummaryActive = state.set_summary ?? false;
+  const setSummarySetNum = state.set_summary_set_num ?? null;
+  const setSummaryStyle = (state.set_summary_style ??
+    'brand_ledger') as import('../api/client').SetSummaryStyle;
 
   return (
     <div className={`center-panel${compactLandscape ? ' center-panel-compact' : ''}`}>
@@ -209,21 +148,19 @@ function CenterPanel({
       </div>
 
       <div className="match-alerts-row" data-testid="match-alerts-row">
-        {onSwapSides && (
-          <button
-            type="button"
-            className="swap-sides-button"
-            onClick={onSwapSides}
-            title={t('scoreboard.swapSides')}
-            aria-label={t('scoreboard.swapSides')}
-            aria-pressed={sidesSwapped}
-            data-testid="swap-sides-button"
-          >
-            <span className="material-icons" aria-hidden="true">
-              swap_horiz
-            </span>
-          </button>
-        )}
+        <button
+          type="button"
+          className="swap-sides-button"
+          onClick={onSwapSides}
+          title={t('scoreboard.swapSides')}
+          aria-label={t('scoreboard.swapSides')}
+          aria-pressed={sidesSwapped}
+          data-testid="swap-sides-button"
+        >
+          <span className="material-icons" aria-hidden="true">
+            swap_horiz
+          </span>
+        </button>
         <MatchAlertIndicator state={state} isPortrait={isPortrait} sidesSwapped={sidesSwapped} />
         {!state.match_finished && (
           <SideSwitchIndicator
@@ -234,14 +171,14 @@ function CenterPanel({
         {!state.match_finished && <ServeSwitchIndicator info={state.serve_switch} />}
       </div>
 
-      {setSummaryActive && onDeactivateSetSummary && onChangeSetSummaryStyle ? (
+      {setSummaryActive ? (
         <SetSummaryActiveNotice
-          setNum={setSummarySetNum ?? null}
-          style={setSummaryStyle ?? 'brand_ledger'}
-          onDeactivate={onDeactivateSetSummary}
+          setNum={setSummarySetNum}
+          style={setSummaryStyle}
+          onDeactivate={onToggleSetSummary}
           onChangeStyle={onChangeSetSummaryStyle}
         />
-      ) : previewData ? (
+      ) : showPreview && previewData ? (
         <OverlayPreview
           overlayUrl={previewData.overlayUrl}
           x={previewData.x}

--- a/frontend/src/components/ControlButtons.tsx
+++ b/frontend/src/components/ControlButtons.tsx
@@ -1,4 +1,6 @@
+import type { CSSProperties } from 'react';
 import { useI18n } from '../i18n';
+import { useBoardActions, useBoardState } from '../board/BoardContexts';
 import MatchTimer from './MatchTimer';
 import {
   VISIBLE_ON_COLOR,
@@ -10,102 +12,77 @@ import {
   PREVIEW_OFF_COLOR,
 } from '../theme';
 
-export interface ControlButtonsProps {
-  visible: boolean;
-  simpleMode: boolean;
-  canUndo: boolean;
-  showPreview: boolean;
-  /**
-   * Match start timestamp (Unix seconds), or ``null`` when the match
-   * is unarmed. Drives the live timer in the spacer and one half of
-   * the Start-match / Reset toggle.
-   */
-  matchStartedAt: number | null | undefined;
-  /**
-   * Match end timestamp (Unix seconds), or ``null`` while the match
-   * is still in progress. Forwarded to ``MatchTimer`` so the live
-   * counter freezes at the actual end-of-match value once the
-   * match transitions to finished.
-   */
-  matchFinishedAt?: number | null | undefined;
-  /**
-   * ``true`` once the match transitions to finished. Drives one half
-   * of the Start-match / Reset toggle so the operator's next step is
-   * Reset, not Start. ``matchStartedAt`` stays in place after match
-   * end (so the timer can render the final duration); Reset is the
-   * only path that clears it back to ``null``.
-   */
-  matchFinished: boolean;
-  /**
-   * Set summary overlay — operator toggle that swaps the scoreboard
-   * for a recap panel. The button slot only renders when the
-   * feature is enabled in settings (``setSummaryEnabled``); the live
-   * state of the toggle is in ``setSummaryActive``.
-   */
-  setSummaryEnabled?: boolean;
-  setSummaryActive?: boolean;
-  /**
-   * Live output clients (OBS browser sources + spectators) connected to
-   * this overlay. With ``showOnAir`` on, a >0 count lights an "on-air"
-   * badge so the operator can confirm the scoreboard is reaching OBS.
-   */
-  obsClients?: number;
-  showOnAir?: boolean;
-  /**
-   * ``match_id`` of the just-finished match. With ``showReportLink`` on,
-   * a "Match report" button appears next to Reset at match end.
-   */
-  lastMatchId?: string | null;
-  showReportLink?: boolean;
-  onToggleVisibility: () => void;
-  onToggleSimpleMode: () => void;
-  onUndoLast: () => void;
-  onTogglePreview: () => void;
-  onStartMatch: () => void;
-  onReset: () => void;
-  onToggleSetSummary?: () => void;
-}
+const UNDO_STYLE_ENABLED: CSSProperties = {
+  borderColor: UNDO_COLOR,
+  color: UNDO_COLOR,
+  opacity: 1,
+};
+const UNDO_STYLE_DISABLED: CSSProperties = {
+  borderColor: UNDO_COLOR,
+  color: UNDO_COLOR,
+  opacity: 0.4,
+};
+const SIMPLE_MODE_STYLE: CSSProperties = {
+  borderColor: SIMPLE_SCOREBOARD_COLOR,
+  color: SIMPLE_SCOREBOARD_COLOR,
+};
+const FULL_MODE_STYLE: CSSProperties = {
+  borderColor: FULL_SCOREBOARD_COLOR,
+  color: FULL_SCOREBOARD_COLOR,
+};
+const PREVIEW_ON_STYLE: CSSProperties = {
+  borderColor: PREVIEW_ON_COLOR,
+  color: PREVIEW_ON_COLOR,
+};
+const PREVIEW_OFF_STYLE: CSSProperties = {
+  borderColor: PREVIEW_OFF_COLOR,
+  color: PREVIEW_OFF_COLOR,
+};
+const SET_SUMMARY_ACTIVE_STYLE: CSSProperties = {
+  borderColor: FULL_SCOREBOARD_COLOR,
+  color: FULL_SCOREBOARD_COLOR,
+};
+const SET_SUMMARY_INACTIVE_STYLE: CSSProperties = PREVIEW_OFF_STYLE;
+const VISIBLE_STYLE: CSSProperties = {
+  borderColor: VISIBLE_ON_COLOR,
+  color: VISIBLE_ON_COLOR,
+};
+const HIDDEN_STYLE: CSSProperties = {
+  borderColor: VISIBLE_OFF_COLOR,
+  color: VISIBLE_OFF_COLOR,
+};
 
 /**
- * Bottom HUD control bar. Layout, left → right:
- *   * Start-match / Reset toggle (with text label) — primary
- *     operator action, parked on the dominant side.
- *   * Live match timer (when armed).
- *   * Undo, simple-mode, preview, visibility — secondary toggles
- *     pushed to the right edge so they don't crowd the primary
- *     action. Undo sits closest to the timer because it's the
- *     most reached-for during play.
- *
- * Theme + fullscreen toggles live in the config panel; they're
- * once-per-session decisions and don't earn a permanent slot here.
+ * Bottom HUD control bar. Its live display fields and operator actions are
+ * context slices, so it stays independent of ScoreboardView's composition.
  */
-export default function ControlButtons({
-  visible,
-  simpleMode,
-  canUndo,
-  showPreview,
-  matchStartedAt,
-  matchFinishedAt,
-  matchFinished,
-  setSummaryEnabled,
-  setSummaryActive,
-  obsClients = 0,
-  showOnAir = true,
-  lastMatchId,
-  showReportLink = true,
-  onToggleVisibility,
-  onToggleSimpleMode,
-  onUndoLast,
-  onTogglePreview,
-  onStartMatch,
-  onReset,
-  onToggleSetSummary,
-}: ControlButtonsProps) {
+export default function ControlButtons() {
   const { t } = useI18n();
-  // The Reset face stays up while the match is in progress, and
-  // while a finished match is still being shown — only an explicit
-  // Reset returns the operator to the pre-match idle state where
-  // Start match is armable again.
+  const { state, simpleMode, showPreview, setSummaryEnabled, showOnAir, showReportLink } =
+    useBoardState();
+  const {
+    onToggleVisibility,
+    onToggleSimpleMode,
+    onUndoLast,
+    onTogglePreview,
+    onStartMatch,
+    onReset,
+    onToggleSetSummary,
+  } = useBoardActions();
+  const {
+    visible,
+    can_undo: canUndo,
+    match_started_at: matchStartedAt,
+    match_finished_at: matchFinishedAt,
+    match_finished: matchFinished,
+    set_summary: setSummaryActive,
+    obs_clients: obsClients = 0,
+    last_match_id: lastMatchId,
+  } = state;
+
+  // The Reset face stays up while the match is in progress, and while a
+  // finished match is still being shown — only an explicit Reset returns the
+  // operator to the pre-match idle state where Start match is armable again.
   const showReset = matchStartedAt != null || matchFinished;
 
   return (
@@ -173,11 +150,7 @@ export default function ControlButtons({
 
       <button
         className="control-btn"
-        style={{
-          borderColor: UNDO_COLOR,
-          color: UNDO_COLOR,
-          opacity: canUndo ? 1 : 0.4,
-        }}
+        style={canUndo ? UNDO_STYLE_ENABLED : UNDO_STYLE_DISABLED}
         onClick={onUndoLast}
         disabled={!canUndo}
         title={t('ctrl.undoLast')}
@@ -191,10 +164,7 @@ export default function ControlButtons({
 
       <button
         className="control-btn"
-        style={{
-          borderColor: simpleMode ? SIMPLE_SCOREBOARD_COLOR : FULL_SCOREBOARD_COLOR,
-          color: simpleMode ? SIMPLE_SCOREBOARD_COLOR : FULL_SCOREBOARD_COLOR,
-        }}
+        style={simpleMode ? SIMPLE_MODE_STYLE : FULL_MODE_STYLE}
         onClick={onToggleSimpleMode}
         title={simpleMode ? t('ctrl.fullScoreboard') : t('ctrl.simpleScoreboard')}
         aria-label={t('ctrl.simpleScoreboard')}
@@ -208,10 +178,7 @@ export default function ControlButtons({
 
       <button
         className="control-btn"
-        style={{
-          borderColor: showPreview ? PREVIEW_ON_COLOR : PREVIEW_OFF_COLOR,
-          color: showPreview ? PREVIEW_ON_COLOR : PREVIEW_OFF_COLOR,
-        }}
+        style={showPreview ? PREVIEW_ON_STYLE : PREVIEW_OFF_STYLE}
         onClick={onTogglePreview}
         title={showPreview ? t('ctrl.hidePreview') : t('ctrl.showPreview')}
         aria-label={t('links.preview')}
@@ -223,17 +190,10 @@ export default function ControlButtons({
         </span>
       </button>
 
-      {setSummaryEnabled && onToggleSetSummary && (
+      {setSummaryEnabled && (
         <button
           className="control-btn"
-          style={{
-            // Gated by the feature flag — when enabled and active,
-            // tint the icon orange to match the SIMPLE / FULL scoreboard
-            // family so it visually groups with the other display
-            // toggles.
-            borderColor: setSummaryActive ? FULL_SCOREBOARD_COLOR : PREVIEW_OFF_COLOR,
-            color: setSummaryActive ? FULL_SCOREBOARD_COLOR : PREVIEW_OFF_COLOR,
-          }}
+          style={setSummaryActive ? SET_SUMMARY_ACTIVE_STYLE : SET_SUMMARY_INACTIVE_STYLE}
           onClick={onToggleSetSummary}
           title={t('setSummary.toggle')}
           aria-label={t('setSummary.toggle')}
@@ -248,10 +208,7 @@ export default function ControlButtons({
 
       <button
         className="control-btn"
-        style={{
-          borderColor: visible ? VISIBLE_ON_COLOR : VISIBLE_OFF_COLOR,
-          color: visible ? VISIBLE_ON_COLOR : VISIBLE_OFF_COLOR,
-        }}
+        style={visible ? VISIBLE_STYLE : HIDDEN_STYLE}
         onClick={onToggleVisibility}
         title={visible ? t('ctrl.hideOverlay') : t('ctrl.showOverlay')}
         aria-label={t('ctrl.overlayVisibility')}

--- a/frontend/src/components/ScoreboardView.tsx
+++ b/frontend/src/components/ScoreboardView.tsx
@@ -1,240 +1,33 @@
-import { Dispatch, SetStateAction } from 'react';
+import { memo } from 'react';
 import { useI18n } from '../i18n';
+import { useBoardActions, useBoardLayout } from '../board/BoardContexts';
 import TeamPanel from './TeamPanel';
 import CenterPanel from './CenterPanel';
 import ControlButtons from './ControlButtons';
-import type { GameState } from '../api/client';
-import type { ConfigModel } from './TeamCard';
-import type { PreviewData } from './CenterPanel';
-import type { ScoreButtonFontStyle } from './ScoreButton';
-import type { RecentEvent } from '../hooks/useRecentEvents';
-import { TEAM_A_SERVE_ACTIVE, TEAM_B_SERVE_ACTIVE, TEAM_A_LIGHT, TEAM_B_LIGHT } from '../theme';
 
-export interface ScoreboardViewProps {
-  state: GameState;
-  customization: ConfigModel | null | undefined;
-  currentSet: number;
-  setsLimit: number;
-  isPortrait: boolean;
-  buttonSize?: number;
-  previewData: PreviewData | null | undefined;
-  showPreview: boolean;
-  recentEvents: RecentEvent[];
-  /**
-   * True on landscape phones (no room for persistent controls). The
-   * centre column then uses a tighter layout and a smaller preview so
-   * the alert pills don't get pushed off the bottom of the viewport.
-   */
-  compactLandscape?: boolean;
-  showControls: boolean;
-  setShowControls: Dispatch<SetStateAction<boolean>>;
-  /** Display-side swap: true renders team 2 on the left. */
-  sidesSwapped: boolean;
-  onSwapSides: () => void;
-  canUndo: boolean;
-  simpleMode: boolean;
-  btnColorA: string;
-  btnTextA: string;
-  btnColorB: string;
-  btnTextB: string;
-  iconLogoA: string | null;
-  iconLogoB: string | null;
-  iconOpacity?: number;
-  fontStyle?: ScoreButtonFontStyle;
-  onAddPoint: (teamId: 1 | 2) => void;
-  onAddSet: (teamId: 1 | 2) => void;
-  onAddTimeout: (teamId: 1 | 2) => void;
-  onChangeServe: (teamId: 1 | 2) => void;
-  onDoubleTapScore: (teamId: 1 | 2) => void;
-  onDoubleTapTimeout: (teamId: 1 | 2) => void;
-  onLongPressScore: (teamId: 1 | 2) => void;
-  onLongPressSet: (teamId: 1 | 2) => void;
-  onToggleVisibility: () => void;
-  onToggleSimpleMode: () => void;
-  onUndoLast: () => void;
-  onTogglePreview: () => void;
-  onStartMatch: () => void;
-  onReset: () => void;
-  onOpenConfig: () => void;
-  onOpenShare: () => void;
-  onOpenHistory: () => void;
-  /** Set summary overlay — feature flag + live state + handlers. */
-  setSummaryEnabled?: boolean;
-  setSummaryActive?: boolean;
-  setSummarySetNum?: number | null;
-  setSummaryStyle?: import('../api/client').SetSummaryStyle;
-  onToggleSetSummary?: () => void;
-  onChangeSetSummaryStyle?: (style: import('../api/client').SetSummaryStyle) => void;
-  /** On-air indicator + match-report link (control-bar affordances). */
-  obsClients?: number;
-  showOnAir?: boolean;
-  lastMatchId?: string | null;
-  showReportLink?: boolean;
-}
-
-export default function ScoreboardView({
-  state,
-  customization,
-  currentSet,
-  setsLimit,
-  isPortrait,
-  buttonSize,
-  previewData,
-  showPreview,
-  recentEvents,
-  compactLandscape = false,
-  showControls,
-  setShowControls,
-  sidesSwapped,
-  onSwapSides,
-  canUndo,
-  simpleMode,
-  btnColorA,
-  btnTextA,
-  btnColorB,
-  btnTextB,
-  iconLogoA,
-  iconLogoB,
-  iconOpacity,
-  fontStyle,
-  onAddPoint,
-  onAddSet,
-  onAddTimeout,
-  onChangeServe,
-  onDoubleTapScore,
-  onDoubleTapTimeout,
-  onLongPressScore,
-  onLongPressSet,
-  onToggleVisibility,
-  onToggleSimpleMode,
-  onUndoLast,
-  onTogglePreview,
-  onStartMatch,
-  onReset,
-  onOpenConfig,
-  onOpenShare,
-  onOpenHistory,
-  setSummaryEnabled,
-  setSummaryActive,
-  setSummarySetNum,
-  setSummaryStyle,
-  onToggleSetSummary,
-  onChangeSetSummaryStyle,
-  obsClients,
-  showOnAir,
-  lastMatchId,
-  showReportLink,
-}: ScoreboardViewProps) {
+/**
+ * Board composition. The team, centre, and HUD components consume the state
+ * slices they need directly, so this layer never has to mirror App's board
+ * state through a pass-through prop interface.
+ */
+function ScoreboardView() {
   const { t } = useI18n();
+  const { isPortrait, showControls } = useBoardLayout();
+  const { onOpenConfig, onOpenShare, onOpenHistory, onToggleControls } = useBoardActions();
 
   return (
     <>
       <div
         className={`main-layout ${isPortrait ? 'main-layout-portrait' : 'main-layout-landscape'}`}
       >
-        {(() => {
-          const panel1 = (
-            <TeamPanel
-              key={1}
-              teamId={1}
-              order={sidesSwapped ? 1 : -1}
-              teamState={state.team_1}
-              currentSet={currentSet}
-              buttonColor={btnColorA}
-              buttonTextColor={btnTextA}
-              serveColor={TEAM_A_SERVE_ACTIVE}
-              timeoutColor={TEAM_A_LIGHT}
-              buttonSize={buttonSize}
-              isPortrait={isPortrait}
-              iconLogo={iconLogoA}
-              iconOpacity={iconOpacity}
-              fontStyle={fontStyle}
-              state={state}
-              setsLimit={setsLimit}
-              customization={customization}
-              onAddPoint={onAddPoint}
-              onAddTimeout={onAddTimeout}
-              onChangeServe={onChangeServe}
-              onDoubleTapScore={onDoubleTapScore}
-              onDoubleTapTimeout={onDoubleTapTimeout}
-              onLongPressScore={onLongPressScore}
-            />
-          );
-          const panel2 = (
-            <TeamPanel
-              key={2}
-              teamId={2}
-              order={sidesSwapped ? -1 : 1}
-              teamState={state.team_2}
-              currentSet={currentSet}
-              buttonColor={btnColorB}
-              buttonTextColor={btnTextB}
-              serveColor={TEAM_B_SERVE_ACTIVE}
-              timeoutColor={TEAM_B_LIGHT}
-              buttonSize={buttonSize}
-              isPortrait={isPortrait}
-              iconLogo={iconLogoB}
-              iconOpacity={iconOpacity}
-              fontStyle={fontStyle}
-              state={state}
-              setsLimit={setsLimit}
-              customization={customization}
-              onAddPoint={onAddPoint}
-              onAddTimeout={onAddTimeout}
-              onChangeServe={onChangeServe}
-              onDoubleTapScore={onDoubleTapScore}
-              onDoubleTapTimeout={onDoubleTapTimeout}
-              onLongPressScore={onLongPressScore}
-            />
-          );
-          const centre = (
-            // The three children render in a FIXED DOM order
-            // (panel1 · centre · panel2) regardless of the swap; the team
-            // panels only trade *visual* places via flex ``order`` (see
-            // their ``order`` prop). This keeps the centre panel's DOM node
-            // stationary across swaps — moving it would tear down and reload
-            // its embedded OverlayPreview iframe (a visible flash). The
-            // stable key just documents that intent.
-            <CenterPanel
-              key="centre"
-              state={state}
-              sidesSwapped={sidesSwapped}
-              onSwapSides={onSwapSides}
-              customization={customization}
-              currentSet={currentSet}
-              setsLimit={setsLimit}
-              isPortrait={isPortrait}
-              compactLandscape={compactLandscape}
-              previewData={showPreview ? previewData : null}
-              recentEvents={recentEvents}
-              btnColorA={btnColorA}
-              btnTextA={btnTextA}
-              btnColorB={btnColorB}
-              btnTextB={btnTextB}
-              team1Logo={iconLogoA}
-              team2Logo={iconLogoB}
-              fontStyle={fontStyle}
-              setSummaryActive={setSummaryActive}
-              setSummarySetNum={setSummarySetNum}
-              setSummaryStyle={setSummaryStyle}
-              onDeactivateSetSummary={onToggleSetSummary}
-              onChangeSetSummaryStyle={onChangeSetSummaryStyle}
-              onAddSet={onAddSet}
-              onLongPressSet={onLongPressSet}
-            />
-          );
-          // Display-side swap: presentation only — every handler stays
-          // bound to its real team id, and the DOM order never changes.
-          // The visual left/right flip is done with flex ``order`` so the
-          // centre panel (and its preview iframe) is never moved/remounted.
-          return (
-            <>
-              {panel1}
-              {centre}
-              {panel2}
-            </>
-          );
-        })()}
+        {/**
+         * The three children stay in this fixed DOM order across display-side
+         * swaps. TeamPanel changes its flex order from board state, keeping
+         * CentrePanel's preview iframe mounted and free from visible reloads.
+         */}
+        <TeamPanel teamId={1} />
+        <CenterPanel />
+        <TeamPanel teamId={2} />
       </div>
 
       <div className={`hud-controls ${!showControls ? 'ui-hidden' : ''}`}>
@@ -280,41 +73,22 @@ export default function ScoreboardView({
             role="button"
             tabIndex={0}
             aria-label={showControls ? t('ctrl.hideControls') : t('ctrl.showControls')}
-            onClick={() => setShowControls(!showControls)}
+            onClick={onToggleControls}
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
-                setShowControls(!showControls);
+                onToggleControls();
               }
             }}
             title={showControls ? t('ctrl.hideControls') : t('ctrl.showControls')}
           >
             <span className="material-icons">{showControls ? 'expand_more' : 'expand_less'}</span>
           </div>
-          <ControlButtons
-            visible={state.visible}
-            simpleMode={simpleMode}
-            canUndo={canUndo}
-            showPreview={showPreview}
-            matchStartedAt={state.match_started_at}
-            matchFinishedAt={state.match_finished_at}
-            matchFinished={state.match_finished}
-            setSummaryEnabled={setSummaryEnabled}
-            setSummaryActive={setSummaryActive}
-            obsClients={obsClients}
-            showOnAir={showOnAir}
-            lastMatchId={lastMatchId}
-            showReportLink={showReportLink}
-            onToggleVisibility={onToggleVisibility}
-            onToggleSimpleMode={onToggleSimpleMode}
-            onUndoLast={onUndoLast}
-            onTogglePreview={onTogglePreview}
-            onStartMatch={onStartMatch}
-            onReset={onReset}
-            onToggleSetSummary={onToggleSetSummary}
-          />
+          <ControlButtons />
         </div>
       </div>
     </>
   );
 }
+
+export default memo(ScoreboardView);

--- a/frontend/src/components/TeamPanel.tsx
+++ b/frontend/src/components/TeamPanel.tsx
@@ -1,44 +1,30 @@
-import { CSSProperties, ReactElement, memo, useCallback } from 'react';
-import ScoreButton, { ScoreButtonFontStyle } from './ScoreButton';
+import { CSSProperties, ReactElement, memo, useCallback, useMemo } from 'react';
+import ScoreButton from './ScoreButton';
 import ScoreTable from './ScoreTable';
-import type { GameState, TeamState } from '../api/client';
-import type { ConfigModel } from './TeamCard';
 import { toNumber, asString } from '../utils/coerce';
 import { getReadableOnSurface } from '../utils/contrast';
 import { useDoubleTap } from '../hooks/useDoubleTap';
 import { useSurfaceColor } from '../hooks/useSurfaceColor';
 import { useI18n } from '../i18n';
+import {
+  useBoardActions,
+  useBoardLayout,
+  useBoardState,
+  useBoardTheme,
+} from '../board/BoardContexts';
+import { TEAM_A_LIGHT, TEAM_A_SERVE_ACTIVE, TEAM_B_LIGHT, TEAM_B_SERVE_ACTIVE } from '../theme';
 
 export interface TeamPanelProps {
   teamId: 1 | 2;
-  teamState: TeamState | null | undefined;
-  currentSet: number;
-  /**
-   * Flex ``order`` for the display-side swap. The two team panels keep a
-   * fixed DOM position (so sibling reordering never moves the centre
-   * panel's preview iframe — which would reload it) and trade visual
-   * places purely via this CSS order.
-   */
-  order?: number;
-  buttonColor: string;
-  buttonTextColor?: string;
-  serveColor: string;
-  timeoutColor: string;
-  buttonSize?: number;
-  isPortrait: boolean;
-  iconLogo?: string | null;
-  iconOpacity?: number;
-  fontStyle?: ScoreButtonFontStyle;
-  state: GameState | null | undefined;
-  setsLimit: number;
-  customization?: ConfigModel | null;
-  onAddPoint: (teamId: 1 | 2) => void;
-  onAddTimeout: (teamId: 1 | 2) => void;
-  onChangeServe: (teamId: 1 | 2) => void;
-  onDoubleTapScore: (teamId: 1 | 2) => void;
-  onDoubleTapTimeout: (teamId: 1 | 2) => void;
-  onLongPressScore: (teamId: 1 | 2) => void;
 }
+
+const SERVE_ICON_BASE_STYLE: CSSProperties = {
+  cursor: 'pointer',
+  border: 'none',
+  background: 'transparent',
+  padding: 0,
+};
+const SERVE_ICON_SIZE_STYLE: CSSProperties = { fontSize: '2rem' };
 
 function isSafeUrl(url: string | null | undefined): url is string {
   if (!url) return false;
@@ -52,32 +38,31 @@ function isSafeUrl(url: string | null | undefined): url is string {
 
 /**
  * Team panel with score button, timeout button + indicators, and serve icon.
+ * Its board data and handlers are intentionally read from narrow contexts so
+ * ScoreboardView does not need to relay them through another component level.
  */
-function TeamPanel({
-  teamId,
-  order,
-  teamState,
-  currentSet,
-  buttonColor,
-  buttonTextColor = '#fff',
-  serveColor,
-  timeoutColor,
-  buttonSize,
-  isPortrait,
-  iconLogo,
-  iconOpacity = 50,
-  fontStyle,
-  state,
-  setsLimit,
-  customization,
-  onAddPoint,
-  onAddTimeout,
-  onChangeServe,
-  onDoubleTapScore,
-  onDoubleTapTimeout,
-  onLongPressScore,
-}: TeamPanelProps) {
+function TeamPanel({ teamId }: TeamPanelProps) {
   const { t } = useI18n();
+  const { state, customization, currentSet, setsLimit, sidesSwapped } = useBoardState();
+  const { btnColorA, btnTextA, btnColorB, btnTextB, iconLogoA, iconLogoB, iconOpacity, fontStyle } =
+    useBoardTheme();
+  const { buttonSize, isPortrait } = useBoardLayout();
+  const {
+    onAddPoint,
+    onAddTimeout,
+    onChangeServe,
+    onDoubleTapScore,
+    onDoubleTapTimeout,
+    onLongPressScore,
+  } = useBoardActions();
+
+  const teamState = teamId === 1 ? state.team_1 : state.team_2;
+  const buttonColor = teamId === 1 ? btnColorA : btnColorB;
+  const buttonTextColor = teamId === 1 ? btnTextA : btnTextB;
+  const iconLogo = teamId === 1 ? iconLogoA : iconLogoB;
+  const serveColor = teamId === 1 ? TEAM_A_SERVE_ACTIVE : TEAM_B_SERVE_ACTIVE;
+  const timeoutColor = teamId === 1 ? TEAM_A_LIGHT : TEAM_B_LIGHT;
+  const order = teamId === 1 ? (sidesSwapped ? 1 : -1) : sidesSwapped ? -1 : 1;
   const score = toNumber(teamState?.scores?.[`set_${currentSet}`]);
   const timeouts = teamState?.timeouts ?? 0;
   const isServing = teamState?.serving ?? false;
@@ -97,6 +82,7 @@ function TeamPanel({
     [onDoubleTapTimeout, teamId],
   );
   const handleLongPress = useCallback(() => onLongPressScore(teamId), [onLongPressScore, teamId]);
+  const handleChangeServe = useCallback(() => onChangeServe(teamId), [onChangeServe, teamId]);
 
   const timeoutHandlers = useDoubleTap({
     onClick: handleAddTimeout,
@@ -115,6 +101,10 @@ function TeamPanel({
     t('scoreboard.team', { team: teamId });
   const scoreAriaLabel = t('scoreboard.score', { team: teamNameLabel, score });
   const scoreDescId = `team-${teamId}-score-help`;
+  const timeoutDotStyle = useMemo<CSSProperties>(
+    () => ({ color: readableTimeoutColor, fontSize: '12px' }),
+    [readableTimeoutColor],
+  );
 
   const timeoutDots: ReactElement[] = [];
   for (let i = 0; i < timeouts; i++) {
@@ -122,7 +112,7 @@ function TeamPanel({
       <span
         key={i}
         className="material-icons timeout-dot"
-        style={{ color: readableTimeoutColor, fontSize: '12px' }}
+        style={timeoutDotStyle}
         data-testid={`timeout-${teamId}-number-${i}`}
       >
         radio_button_unchecked
@@ -130,32 +120,43 @@ function TeamPanel({
     );
   }
 
-  const iconStyle: CSSProperties = {};
   const safeIconLogo = isSafeUrl(iconLogo) ? iconLogo : null;
-  if (safeIconLogo) {
-    const alpha = 1.0 - iconOpacity / 100;
-    let r = 0,
-      g = 0,
-      b = 0;
+  const iconStyle = useMemo<CSSProperties>(() => {
+    if (!safeIconLogo) return {};
+    const alpha = 1.0 - (iconOpacity ?? 50) / 100;
+    let r = 0;
+    let g = 0;
+    let b = 0;
     const hex = buttonColor.replace('#', '');
     if (hex.length === 6) {
       r = parseInt(hex.substring(0, 2), 16);
       g = parseInt(hex.substring(2, 4), 16);
       b = parseInt(hex.substring(4, 6), 16);
     }
-    iconStyle.backgroundImage = `linear-gradient(rgba(${r},${g},${b},${alpha}), rgba(${r},${g},${b},${alpha})), url(${safeIconLogo})`;
-    iconStyle.backgroundSize = 'contain';
-    iconStyle.backgroundRepeat = 'no-repeat';
-    iconStyle.backgroundPosition = 'center';
-  }
+    return {
+      backgroundImage: `linear-gradient(rgba(${r},${g},${b},${alpha}), rgba(${r},${g},${b},${alpha})), url(${safeIconLogo})`,
+      backgroundSize: 'contain',
+      backgroundRepeat: 'no-repeat',
+      backgroundPosition: 'center',
+    };
+  }, [buttonColor, iconOpacity, safeIconLogo]);
+  const panelStyle = useMemo<CSSProperties>(() => ({ order }), [order]);
+  const timeoutButtonStyle = useMemo<CSSProperties>(
+    () => ({ borderColor: readableTimeoutColor, color: readableTimeoutColor }),
+    [readableTimeoutColor],
+  );
+  const serveIconStyle = useMemo<CSSProperties>(
+    () => ({ ...SERVE_ICON_BASE_STYLE, color: readableServeColor, opacity: isServing ? 1 : 0.4 }),
+    [isServing, readableServeColor],
+  );
 
   return (
     <div
       className={`team-panel ${isPortrait ? 'team-panel-portrait' : 'team-panel-landscape'}`}
-      style={{ order }}
+      style={panelStyle}
     >
       <div className={isPortrait ? 'team-panel-row' : 'team-panel-col'}>
-        {isPortrait && state && (
+        {isPortrait && (
           <div className="team-history-col">
             {safeIconLogo && (
               <img
@@ -194,7 +195,7 @@ function TeamPanel({
           <div className={isPortrait ? 'team-side-group-col' : 'team-side-group-row'}>
             <button
               className="timeout-button"
-              style={{ borderColor: readableTimeoutColor, color: readableTimeoutColor }}
+              style={timeoutButtonStyle}
               {...timeoutHandlers}
               aria-label={t('scoreboard.timeout', { team: teamNameLabel })}
               aria-describedby={`team-${teamId}-timeout-help`}
@@ -220,18 +221,11 @@ function TeamPanel({
             className="serve-icon"
             aria-label={t('scoreboard.serve', { team: teamNameLabel })}
             aria-pressed={isServing}
-            style={{
-              color: readableServeColor,
-              opacity: isServing ? 1 : 0.4,
-              cursor: 'pointer',
-              border: 'none',
-              background: 'transparent',
-              padding: 0,
-            }}
-            onClick={() => onChangeServe(teamId)}
+            style={serveIconStyle}
+            onClick={handleChangeServe}
             data-testid={`team-${teamId}-serve`}
           >
-            <span className="material-icons" aria-hidden="true" style={{ fontSize: '2rem' }}>
+            <span className="material-icons" aria-hidden="true" style={SERVE_ICON_SIZE_STYLE}>
               sports_volleyball
             </span>
           </button>

--- a/frontend/src/hooks/useScoreActions.ts
+++ b/frontend/src/hooks/useScoreActions.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import * as api from '../api/client';
 import type { GameActions } from './useGameState';
 import type { Settings } from './useSettings';
@@ -17,6 +17,14 @@ export interface UseScoreActionsResult {
   handleDoubleTapTimeout: (team: Team) => void;
   pointPickerTeam: Team | null;
   setPointPickerTeam: (team: Team | null) => void;
+}
+
+interface ScoreActionInputs {
+  actions: GameActions;
+  settings: Settings;
+  simpleMode: boolean;
+  matchFinished: boolean;
+  pulse: Pulse;
 }
 
 /**
@@ -42,80 +50,91 @@ export function useScoreActions({
   // awaiting a point-type choice, or ``null`` when closed. Only used
   // when ``settings.trackPointTypes`` is on.
   const [pointPickerTeam, setPointPickerTeam] = useState<Team | null>(null);
+  // Keep gesture callbacks stable across live state pushes. The scoreboard
+  // exposes them through BoardActionsContext, whose memoized value must not
+  // change simply because a WebSocket message updated a score.
+  const inputsRef = useRef<ScoreActionInputs>({
+    actions,
+    settings,
+    simpleMode,
+    matchFinished,
+    pulse,
+  });
+  inputsRef.current = { actions, settings, simpleMode, matchFinished, pulse };
 
   // Score a point (optionally tagged). Shared by the direct tap path
   // and the point-type picker so the auto-simple side-effect stays in
   // one place.
   const commitPoint = useCallback(
     (team: Team, pointType?: api.PointType, errorType?: api.ErrorType) => {
-      actions.addPoint(team, false, pointType, errorType);
-      if (settings.autoSimple && !simpleMode) {
-        actions.setSimpleMode(true);
+      const {
+        actions: currentActions,
+        settings: currentSettings,
+        simpleMode: currentSimpleMode,
+      } = inputsRef.current;
+      currentActions.addPoint(team, false, pointType, errorType);
+      if (currentSettings.autoSimple && !currentSimpleMode) {
+        currentActions.setSimpleMode(true);
       }
     },
-    [actions, settings.autoSimple, simpleMode],
+    [],
   );
 
   const handleAddPoint = useCallback(
     (team: Team) => {
-      if (matchFinished) return;
+      const { matchFinished: currentMatchFinished, settings: currentSettings } = inputsRef.current;
+      if (currentMatchFinished) return;
       // Opt-in classification: defer scoring to the picker so the
       // operator can tag how the point was won. Off by default — the
       // tap scores immediately, unchanged.
-      if (settings.trackPointTypes) {
+      if (currentSettings.trackPointTypes) {
         setPointPickerTeam(team);
         return;
       }
       commitPoint(team);
     },
-    [matchFinished, settings.trackPointTypes, commitPoint],
+    [commitPoint],
   );
 
-  const handleAddSet = useCallback(
-    (team: Team) => {
-      if (matchFinished) return;
-      actions.addSet(team, false);
-    },
-    [actions, matchFinished],
-  );
+  const handleAddSet = useCallback((team: Team) => {
+    const { actions: currentActions, matchFinished: currentMatchFinished } = inputsRef.current;
+    if (currentMatchFinished) return;
+    currentActions.addSet(team, false);
+  }, []);
 
-  const handleAddTimeout = useCallback(
-    (team: Team) => {
-      if (matchFinished) return;
-      actions.addTimeout(team, false);
-      if (settings.autoSimple && settings.autoSimpleOnTimeout && simpleMode) {
-        actions.setSimpleMode(false);
-      }
-    },
-    [actions, matchFinished, settings.autoSimple, settings.autoSimpleOnTimeout, simpleMode],
-  );
+  const handleAddTimeout = useCallback((team: Team) => {
+    const {
+      actions: currentActions,
+      settings: currentSettings,
+      simpleMode: currentSimpleMode,
+      matchFinished: currentMatchFinished,
+    } = inputsRef.current;
+    if (currentMatchFinished) return;
+    currentActions.addTimeout(team, false);
+    if (currentSettings.autoSimple && currentSettings.autoSimpleOnTimeout && currentSimpleMode) {
+      currentActions.setSimpleMode(false);
+    }
+  }, []);
 
-  const handleChangeServe = useCallback(
-    (team: Team) => {
-      actions.changeServe(team);
-    },
-    [actions],
-  );
+  const handleChangeServe = useCallback((team: Team) => {
+    inputsRef.current.actions.changeServe(team);
+  }, []);
 
   // Per-team double-tap undoes the most recent forward of the
   // same (action, team). The server-side per-type undo path
   // pops the matching forward from the audit log on its own, so
   // no client-side bookkeeping is required.
-  const handleDoubleTapScore = useCallback(
-    (team: Team) => {
-      pulse('confirm');
-      actions.addPoint(team, true);
-    },
-    [actions, pulse],
-  );
+  const handleDoubleTapScore = useCallback((team: Team) => {
+    const { actions: currentActions, pulse: currentPulse } = inputsRef.current;
+    currentPulse('confirm');
+    currentActions.addPoint(team, true);
+  }, []);
 
-  const handleDoubleTapTimeout = useCallback(
-    (team: Team) => {
-      pulse('confirm');
-      actions.addTimeout(team, true);
-    },
-    [actions, pulse],
-  );
+  const handleDoubleTapTimeout = useCallback((team: Team) => {
+    const { actions: currentActions, pulse: currentPulse } = inputsRef.current;
+    currentPulse('confirm');
+    currentActions.addTimeout(team, true);
+  }, []);
 
   return {
     commitPoint,

--- a/frontend/src/hooks/useSetValueDialog.ts
+++ b/frontend/src/hooks/useSetValueDialog.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import type { GameState } from '../api/client';
 import type { Translate } from '../i18n';
 import type { GameActions } from './useGameState';
@@ -41,52 +41,55 @@ export function useSetValueDialog({
     isSet: false,
   });
 
-  const handleLongPressScore = useCallback(
-    (team: Team) => {
-      if (!state) return;
-      const teamState = team === 1 ? state.team_1 : state.team_2;
-      const rawScore = teamState.scores?.[`set_${currentSet}`];
-      const currentScore = typeof rawScore === 'number' ? rawScore : 0;
-      setDialog({
-        open: true,
-        title: t('dialog.setScore', { team }),
-        initialValue: currentScore,
-        maxValue: 99,
-        team,
-        isSet: false,
-      });
-    },
-    [state, currentSet, t],
-  );
+  // Scoreboard handlers live in the stable BoardActionsContext. Read the
+  // latest live score / set values from refs instead of recreating the
+  // long-press callbacks after every WebSocket state update.
+  const inputsRef = useRef({ state, currentSet, setsLimit, actions, t });
+  const dialogRef = useRef(dialog);
+  inputsRef.current = { state, currentSet, setsLimit, actions, t };
+  dialogRef.current = dialog;
 
-  const handleLongPressSet = useCallback(
-    (team: Team) => {
-      if (!state) return;
-      const teamState = team === 1 ? state.team_1 : state.team_2;
-      setDialog({
-        open: true,
-        title: t('dialog.setSets', { team }),
-        initialValue: teamState.sets,
-        maxValue: Math.ceil(setsLimit / 2),
-        team,
-        isSet: true,
-      });
-    },
-    [state, setsLimit, t],
-  );
+  const handleLongPressScore = useCallback((team: Team) => {
+    const current = inputsRef.current;
+    if (!current.state) return;
+    const teamState = team === 1 ? current.state.team_1 : current.state.team_2;
+    const rawScore = teamState.scores?.[`set_${current.currentSet}`];
+    const currentScore = typeof rawScore === 'number' ? rawScore : 0;
+    setDialog({
+      open: true,
+      title: current.t('dialog.setScore', { team }),
+      initialValue: currentScore,
+      maxValue: 99,
+      team,
+      isSet: false,
+    });
+  }, []);
 
-  const handleDialogSubmit = useCallback(
-    (value: number) => {
-      if (dialog.team === null) return;
-      if (dialog.isSet) {
-        actions.setSets(dialog.team, value);
-      } else {
-        actions.setScore(dialog.team, currentSet, value);
-      }
-      setDialog((d) => ({ ...d, open: false }));
-    },
-    [dialog, actions, currentSet],
-  );
+  const handleLongPressSet = useCallback((team: Team) => {
+    const current = inputsRef.current;
+    if (!current.state) return;
+    const teamState = team === 1 ? current.state.team_1 : current.state.team_2;
+    setDialog({
+      open: true,
+      title: current.t('dialog.setSets', { team }),
+      initialValue: teamState.sets,
+      maxValue: Math.ceil(current.setsLimit / 2),
+      team,
+      isSet: true,
+    });
+  }, []);
+
+  const handleDialogSubmit = useCallback((value: number) => {
+    const currentDialog = dialogRef.current;
+    const current = inputsRef.current;
+    if (currentDialog.team === null) return;
+    if (currentDialog.isSet) {
+      current.actions.setSets(currentDialog.team, value);
+    } else {
+      current.actions.setScore(currentDialog.team, current.currentSet, value);
+    }
+    setDialog((d) => ({ ...d, open: false }));
+  }, []);
 
   const closeDialog = useCallback(() => {
     setDialog((d) => ({ ...d, open: false }));

--- a/frontend/src/test/CenterPanel.test.tsx
+++ b/frontend/src/test/CenterPanel.test.tsx
@@ -1,25 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent } from '@testing-library/react';
 import CenterPanel from '../components/CenterPanel';
-import { renderWithI18n, mockGameState, mockCustomization } from './helpers';
-
-const defaultProps = {
-  state: mockGameState,
-  customization: mockCustomization,
-  currentSet: 2,
-  setsLimit: 5,
-  isPortrait: false,
-  previewData: null,
-  recentEvents: [],
-  btnColorA: '#2196f3',
-  btnTextA: '#ffffff',
-  btnColorB: '#f44336',
-  btnTextB: '#ffffff',
-  team1Logo: null as string | null,
-  team2Logo: null as string | null,
-  onAddSet: vi.fn(),
-  onLongPressSet: vi.fn(),
-};
+import { mockCustomization, renderWithBoard } from './helpers';
 
 describe('CenterPanel', () => {
   beforeEach(() => {
@@ -27,117 +9,114 @@ describe('CenterPanel', () => {
     localStorage.clear();
   });
 
-  it('returns null when state is null', () => {
-    const { container } = renderWithI18n(<CenterPanel {...defaultProps} state={null} />);
-    expect(container.innerHTML).toBe('');
-  });
-
   it('renders team 1 and team 2 set buttons', () => {
-    renderWithI18n(<CenterPanel {...defaultProps} />);
+    renderWithBoard(<CenterPanel />, { state: { currentSet: 2 } });
     expect(screen.getByTestId('team-1-sets')).toHaveTextContent('1');
     expect(screen.getByTestId('team-2-sets')).toHaveTextContent('0');
   });
 
   it('calls onAddSet when set buttons are pressed', () => {
-    renderWithI18n(<CenterPanel {...defaultProps} />);
-    // ScoreButton uses mouseDown/mouseUp instead of click
+    const onAddSet = vi.fn();
+    renderWithBoard(<CenterPanel />, { actions: { onAddSet } });
+    // ScoreButton uses mouseDown/mouseUp instead of click.
     const btn1 = screen.getByTestId('team-1-sets');
     fireEvent.mouseDown(btn1);
     fireEvent.mouseUp(btn1);
-    expect(defaultProps.onAddSet).toHaveBeenCalledWith(1);
+    expect(onAddSet).toHaveBeenCalledWith(1);
 
     const btn2 = screen.getByTestId('team-2-sets');
     fireEvent.mouseDown(btn2);
     fireEvent.mouseUp(btn2);
-    expect(defaultProps.onAddSet).toHaveBeenCalledWith(2);
+    expect(onAddSet).toHaveBeenCalledWith(2);
   });
 
   it('does not render the legacy set selector', () => {
-    renderWithI18n(<CenterPanel {...defaultProps} />);
+    renderWithBoard(<CenterPanel />);
     expect(screen.queryByTestId('set-selector')).not.toBeInTheDocument();
   });
 
   it('renders the current set indicator with the active set number in landscape', () => {
-    renderWithI18n(<CenterPanel {...defaultProps} currentSet={3} isPortrait={false} />);
+    renderWithBoard(<CenterPanel />, {
+      state: { currentSet: 3 },
+      layout: { isPortrait: false },
+    });
     const indicators = screen.getAllByTestId('current-set-indicator');
     expect(indicators).toHaveLength(1);
     expect(indicators[0]).toHaveTextContent('3');
   });
 
   it('renders the current set indicator with the active set number in portrait', () => {
-    renderWithI18n(<CenterPanel {...defaultProps} currentSet={4} isPortrait={true} />);
+    renderWithBoard(<CenterPanel />, {
+      state: { currentSet: 4 },
+      layout: { isPortrait: true },
+    });
     const indicators = screen.getAllByTestId('current-set-indicator');
     expect(indicators).toHaveLength(1);
     expect(indicators[0]).toHaveTextContent('4');
   });
 
   it('shows logos in landscape mode when logos are provided', () => {
-    renderWithI18n(
-      <CenterPanel
-        {...defaultProps}
-        team1Logo="logo1.png"
-        team2Logo="logo2.png"
-        isPortrait={false}
-      />,
-    );
+    renderWithBoard(<CenterPanel />, {
+      theme: { iconLogoA: 'logo1.png', iconLogoB: 'logo2.png' },
+      layout: { isPortrait: false },
+    });
     expect(screen.getByTestId('team-1-logo')).toHaveAttribute('src', 'logo1.png');
     expect(screen.getByTestId('team-2-logo')).toHaveAttribute('src', 'logo2.png');
   });
 
   it('uses localized fallback team names for logo alt text', () => {
     localStorage.setItem('volley_lang', 'es');
-    renderWithI18n(
-      <CenterPanel
-        {...defaultProps}
-        customization={null}
-        team1Logo="logo1.png"
-        team2Logo="logo2.png"
-        isPortrait={false}
-      />,
-    );
+    renderWithBoard(<CenterPanel />, {
+      state: { customization: null },
+      theme: { iconLogoA: 'logo1.png', iconLogoB: 'logo2.png' },
+      layout: { isPortrait: false },
+    });
     expect(screen.getByTestId('team-1-logo')).toHaveAttribute('alt', 'Equipo 1');
     expect(screen.getByTestId('team-2-logo')).toHaveAttribute('alt', 'Equipo 2');
   });
 
   it('hides logos when they are turned off, regardless of the customization', () => {
-    // ``team1Logo``/``team2Logo`` arrive already null when the operator's
-    // "show logos" toggle is off; the centre column must not fall back to
-    // the customization's logo URLs (the bug this guards against).
-    const cust = { ...mockCustomization, 'Team 1 Logo': 'logo1.png', 'Team 2 Logo': 'logo2.png' };
-    renderWithI18n(
-      <CenterPanel {...defaultProps} customization={cust} team1Logo={null} team2Logo={null} />,
-    );
+    // The resolved theme values are null when the operator turns logos off;
+    // CentrePanel must not fall back to the raw customization URLs.
+    const customization = {
+      ...mockCustomization,
+      'Team 1 Logo': 'logo1.png',
+      'Team 2 Logo': 'logo2.png',
+    };
+    renderWithBoard(<CenterPanel />, { state: { customization } });
     expect(screen.queryByTestId('team-1-logo')).not.toBeInTheDocument();
     expect(screen.queryByTestId('team-2-logo')).not.toBeInTheDocument();
   });
 
   it('hides score section in portrait mode', () => {
-    renderWithI18n(<CenterPanel {...defaultProps} isPortrait={true} />);
+    renderWithBoard(<CenterPanel />, { layout: { isPortrait: true } });
     expect(screen.queryByTestId('team-1-logo')).not.toBeInTheDocument();
   });
 
-  it('does not render logos when customization has empty logo URLs', () => {
-    renderWithI18n(<CenterPanel {...defaultProps} />);
+  it('does not render logos when the resolved logo URLs are empty', () => {
+    renderWithBoard(<CenterPanel />);
     expect(screen.queryByTestId('team-1-logo')).not.toBeInTheDocument();
     expect(screen.queryByTestId('team-2-logo')).not.toBeInTheDocument();
   });
 
   it('applies the compact modifier when compactLandscape is true', () => {
-    const { container } = renderWithI18n(<CenterPanel {...defaultProps} compactLandscape={true} />);
+    const { container } = renderWithBoard(<CenterPanel />, {
+      layout: { compactLandscape: true },
+    });
     expect(container.querySelector('.center-panel-compact')).not.toBeNull();
   });
 
   it('omits the compact modifier by default', () => {
-    const { container } = renderWithI18n(<CenterPanel {...defaultProps} />);
+    const { container } = renderWithBoard(<CenterPanel />);
     expect(container.querySelector('.center-panel-compact')).toBeNull();
   });
 
   it('renders the points history strip when no preview is provided', () => {
-    const events = [
+    const recentEvents = [
       { ts: 1, team: 1 as const, kind: 'point_add' as const },
       { ts: 2, team: 2 as const, kind: 'point_add' as const },
     ];
-    renderWithI18n(<CenterPanel {...defaultProps} previewData={null} recentEvents={events} />);
+    renderWithBoard(<CenterPanel />, { state: { recentEvents } });
     expect(screen.getByTestId('points-history-strip')).toBeInTheDocument();
     expect(screen.getByTestId('phs-chip-1-0')).toHaveTextContent('+1');
     expect(screen.getByTestId('phs-chip-2-1')).toHaveTextContent('+1');
@@ -151,10 +130,7 @@ describe('CenterPanel', () => {
       width: 100,
       height: 50,
     };
-    const events = [{ ts: 1, team: 1 as const, kind: 'point_add' as const }];
-    renderWithI18n(
-      <CenterPanel {...defaultProps} previewData={previewData} recentEvents={events} />,
-    );
+    renderWithBoard(<CenterPanel />, { state: { previewData, showPreview: true } });
     expect(screen.queryByTestId('points-history-strip')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/test/ControlButtons.test.tsx
+++ b/frontend/src/test/ControlButtons.test.tsx
@@ -1,24 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, fireEvent } from '@testing-library/react';
-import { I18nProvider } from '../i18n';
-import { SettingsProvider } from '../hooks/useSettings';
 import ControlButtons from '../components/ControlButtons';
-import { renderWithI18n } from './helpers';
+import { mockGameState, renderWithBoard } from './helpers';
+import type { GameState } from '../api/client';
 
-const defaultProps = {
-  visible: true,
-  simpleMode: false,
-  canUndo: true,
-  showPreview: false,
-  matchStartedAt: null as number | null,
-  matchFinished: false,
-  onToggleVisibility: vi.fn(),
-  onToggleSimpleMode: vi.fn(),
-  onUndoLast: vi.fn(),
-  onTogglePreview: vi.fn(),
-  onStartMatch: vi.fn(),
-  onReset: vi.fn(),
-};
+function liveState(overrides: Partial<GameState> = {}): GameState {
+  return { ...mockGameState, ...overrides };
+}
 
 describe('ControlButtons', () => {
   beforeEach(() => {
@@ -26,214 +14,166 @@ describe('ControlButtons', () => {
   });
 
   it('renders the in-game control buttons', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} />);
+    renderWithBoard(<ControlButtons />);
     expect(screen.getByTestId('visibility-button')).toBeInTheDocument();
     expect(screen.getByTestId('simple-mode-button')).toBeInTheDocument();
     expect(screen.getByTestId('undo-button')).toBeInTheDocument();
     expect(screen.getByTestId('preview-button')).toBeInTheDocument();
   });
 
-  it('calls onToggleVisibility when visibility button clicked', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} />);
-    fireEvent.click(screen.getByTestId('visibility-button'));
-    expect(defaultProps.onToggleVisibility).toHaveBeenCalledOnce();
-  });
-
-  it('calls onToggleSimpleMode when simple mode button clicked', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} />);
-    fireEvent.click(screen.getByTestId('simple-mode-button'));
-    expect(defaultProps.onToggleSimpleMode).toHaveBeenCalledOnce();
-  });
-
-  it('calls onUndoLast when undo button clicked and canUndo', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} />);
-    fireEvent.click(screen.getByTestId('undo-button'));
-    expect(defaultProps.onUndoLast).toHaveBeenCalledOnce();
-  });
-
-  it('disables undo button when canUndo is false', () => {
+  it('calls the matching action for each primary toggle', () => {
+    const onToggleVisibility = vi.fn();
+    const onToggleSimpleMode = vi.fn();
     const onUndoLast = vi.fn();
-    renderWithI18n(<ControlButtons {...defaultProps} canUndo={false} onUndoLast={onUndoLast} />);
-    const btn = screen.getByTestId('undo-button') as HTMLButtonElement;
-    expect(btn.disabled).toBe(true);
-    fireEvent.click(btn);
+    const onTogglePreview = vi.fn();
+    renderWithBoard(<ControlButtons />, {
+      state: { state: liveState({ can_undo: true }) },
+      actions: { onToggleVisibility, onToggleSimpleMode, onUndoLast, onTogglePreview },
+    });
+    fireEvent.click(screen.getByTestId('visibility-button'));
+    fireEvent.click(screen.getByTestId('simple-mode-button'));
+    fireEvent.click(screen.getByTestId('undo-button'));
+    fireEvent.click(screen.getByTestId('preview-button'));
+    expect(onToggleVisibility).toHaveBeenCalledOnce();
+    expect(onToggleSimpleMode).toHaveBeenCalledOnce();
+    expect(onUndoLast).toHaveBeenCalledOnce();
+    expect(onTogglePreview).toHaveBeenCalledOnce();
+  });
+
+  it('disables undo when no server-side action can be reversed', () => {
+    const onUndoLast = vi.fn();
+    renderWithBoard(<ControlButtons />, {
+      state: { state: liveState({ can_undo: false }) },
+      actions: { onUndoLast },
+    });
+    const button = screen.getByTestId('undo-button') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    fireEvent.click(button);
     expect(onUndoLast).not.toHaveBeenCalled();
   });
 
   it('always renders the undo icon (no redo toggle)', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} canUndo={true} />);
+    renderWithBoard(<ControlButtons />, { state: { state: liveState({ can_undo: true }) } });
     expect(screen.getByTestId('undo-button')).toHaveTextContent('undo');
   });
 
-  it('calls onTogglePreview when preview button clicked', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} />);
-    fireEvent.click(screen.getByTestId('preview-button'));
-    expect(defaultProps.onTogglePreview).toHaveBeenCalledOnce();
-  });
-
-  it('does not render share / history buttons — both moved to the top-right corner stack', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} />);
+  it('does not render share / history buttons — both live in the top-right corner stack', () => {
+    renderWithBoard(<ControlButtons />);
     expect(screen.queryByTestId('share-button')).toBeNull();
     expect(screen.queryByTestId('history-button')).toBeNull();
   });
 
-  it('shows visibility icon based on visible prop', () => {
-    const { rerender } = renderWithI18n(<ControlButtons {...defaultProps} visible={true} />);
+  it('uses state and preferences for the visibility and preview button icons', () => {
+    const { unmount } = renderWithBoard(<ControlButtons />, {
+      state: { state: liveState({ visible: true }), showPreview: true },
+    });
     expect(screen.getByTestId('visibility-button')).toHaveTextContent('visibility');
-
-    rerender(
-      <I18nProvider>
-        <SettingsProvider>
-          <ControlButtons {...defaultProps} visible={false} />
-        </SettingsProvider>
-      </I18nProvider>,
-    );
-    expect(screen.getByTestId('visibility-button')).toHaveTextContent('visibility_off');
-  });
-
-  it('preview button uses tv icon when showPreview is true', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} showPreview={true} />);
     expect(screen.getByTestId('preview-button')).toHaveTextContent('tv');
-  });
+    unmount();
 
-  it('preview button uses tv_off icon when showPreview is false', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} showPreview={false} />);
+    renderWithBoard(<ControlButtons />, {
+      state: { state: liveState({ visible: false }), showPreview: false },
+    });
+    expect(screen.getByTestId('visibility-button')).toHaveTextContent('visibility_off');
     expect(screen.getByTestId('preview-button')).toHaveTextContent('tv_off');
   });
 
-  // ── Theme + fullscreen relocated to the config panel ──────────────
-
   it('does not render theme/fullscreen buttons in the HUD', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} />);
+    renderWithBoard(<ControlButtons />);
     expect(screen.queryByTestId('dark-mode-button')).toBeNull();
     expect(screen.queryByTestId('fullscreen-button')).toBeNull();
   });
 
-  // ── Start-match / Reset toggle ─────────────────────────────────────
-
-  it('shows the Start-match button when match is unarmed', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} matchStartedAt={null} />);
-    expect(screen.getByTestId('start-match-button')).toBeInTheDocument();
-    expect(screen.queryByTestId('reset-button')).toBeNull();
-  });
-
-  it('shows the Reset button once the match is armed', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} matchStartedAt={1700000000} />);
-    expect(screen.getByTestId('reset-button')).toBeInTheDocument();
-    expect(screen.queryByTestId('start-match-button')).toBeNull();
-  });
-
-  it('calls onStartMatch when Start-match button clicked', () => {
+  it('shows Start-match before the match is armed and calls its action', () => {
     const onStartMatch = vi.fn();
-    renderWithI18n(
-      <ControlButtons {...defaultProps} matchStartedAt={null} onStartMatch={onStartMatch} />,
-    );
-    fireEvent.click(screen.getByTestId('start-match-button'));
+    renderWithBoard(<ControlButtons />, {
+      state: { state: liveState({ match_started_at: null }) },
+      actions: { onStartMatch },
+    });
+    const start = screen.getByTestId('start-match-button');
+    expect(start).toHaveTextContent(/Start match/i);
+    expect(screen.queryByTestId('reset-button')).toBeNull();
+    fireEvent.click(start);
     expect(onStartMatch).toHaveBeenCalledOnce();
   });
 
-  it('calls onReset when Reset button clicked', () => {
+  it('shows Reset once the match is armed and calls its action', () => {
     const onReset = vi.fn();
-    renderWithI18n(
-      <ControlButtons {...defaultProps} matchStartedAt={1700000000} onReset={onReset} />,
-    );
+    renderWithBoard(<ControlButtons />, {
+      state: { state: liveState({ match_started_at: 1700000000 }) },
+      actions: { onReset },
+    });
+    expect(screen.getByTestId('reset-button')).toBeInTheDocument();
+    expect(screen.queryByTestId('start-match-button')).toBeNull();
     fireEvent.click(screen.getByTestId('reset-button'));
     expect(onReset).toHaveBeenCalledOnce();
   });
 
-  it('shows Reset (not Start) once the match is finished, even if matchStartedAt is null', () => {
-    // ``match_started_at`` would normally still be set after match
-    // end (so the timer can render the final duration), but a meta
-    // file from a pre-fix deployment can land in this state on
-    // restart. The Reset face must still win over Start so the
-    // operator does not accidentally arm a new timer over the
-    // visible just-finished scoreboard.
-    renderWithI18n(<ControlButtons {...defaultProps} matchStartedAt={null} matchFinished={true} />);
+  it('shows Reset after a finished match even with no start timestamp', () => {
+    renderWithBoard(<ControlButtons />, {
+      state: { state: liveState({ match_started_at: null, match_finished: true }) },
+    });
     expect(screen.getByTestId('reset-button')).toBeInTheDocument();
     expect(screen.queryByTestId('start-match-button')).toBeNull();
   });
 
-  it('renders the start/reset button with a visible text label', () => {
-    // The primary action sits on the left edge of the HUD with an
-    // icon *and* text — ``ctrl.startMatch`` / ``ctrl.reset`` from
-    // the i18n catalogue. Bare-icon mode is reserved for the
-    // secondary toggles on the right.
-    renderWithI18n(<ControlButtons {...defaultProps} matchStartedAt={null} />);
-    const start = screen.getByTestId('start-match-button');
-    expect(start.textContent).toMatch(/Start match/i);
-  });
-
-  // ── Match timer ────────────────────────────────────────────────────
-
-  it('omits the match timer until the match is armed', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} matchStartedAt={null} />);
+  it('renders the match timer only once the match is armed', () => {
+    const { unmount } = renderWithBoard(<ControlButtons />, {
+      state: { state: liveState({ match_started_at: null }) },
+    });
     expect(screen.queryByTestId('match-timer')).toBeNull();
-  });
+    unmount();
 
-  it('renders the match timer once the match is armed', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} matchStartedAt={Date.now() / 1000} />);
+    renderWithBoard(<ControlButtons />, {
+      state: { state: liveState({ match_started_at: Date.now() / 1000 }) },
+    });
     expect(screen.getByTestId('match-timer')).toBeInTheDocument();
   });
 
-  // ── On-air indicator ───────────────────────────────────────────────
-
-  it('shows the on-air badge with the connected-client count', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} obsClients={3} showOnAir />);
+  it('shows the on-air badge only when enabled and clients are connected', () => {
+    const { unmount } = renderWithBoard(<ControlButtons />, {
+      state: { state: liveState({ obs_clients: 3 }), showOnAir: true },
+    });
     expect(screen.getByTestId('onair-indicator')).toHaveTextContent('3');
-  });
+    unmount();
 
-  it('hides the on-air badge when no clients are connected', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} obsClients={0} showOnAir />);
+    renderWithBoard(<ControlButtons />, {
+      state: { state: liveState({ obs_clients: 5 }), showOnAir: false },
+    });
     expect(screen.queryByTestId('onair-indicator')).toBeNull();
   });
 
-  it('hides the on-air badge when the setting is off', () => {
-    renderWithI18n(<ControlButtons {...defaultProps} obsClients={5} showOnAir={false} />);
-    expect(screen.queryByTestId('onair-indicator')).toBeNull();
-  });
-
-  // ── Match-report link ──────────────────────────────────────────────
-
-  it('shows the report link to the finished match when enabled', () => {
-    renderWithI18n(
-      <ControlButtons {...defaultProps} matchFinished lastMatchId="match_abc_123" showReportLink />,
-    );
+  it('shows the report link only for a finished match when enabled', () => {
+    const { unmount } = renderWithBoard(<ControlButtons />, {
+      state: {
+        state: liveState({ match_finished: true, last_match_id: 'match_abc_123' }),
+        showReportLink: true,
+      },
+    });
     const link = screen.getByTestId('view-report-button') as HTMLAnchorElement;
     expect(link.getAttribute('href')).toContain('/match/match_abc_123/report');
     expect(link.getAttribute('target')).toBe('_blank');
-  });
+    unmount();
 
-  it('hides the report link until the match is finished', () => {
-    renderWithI18n(
-      <ControlButtons {...defaultProps} matchFinished={false} lastMatchId="m1" showReportLink />,
-    );
-    expect(screen.queryByTestId('view-report-button')).toBeNull();
-  });
-
-  it('hides the report link with no archived match or when the setting is off', () => {
-    renderWithI18n(
-      <ControlButtons {...defaultProps} matchFinished lastMatchId={null} showReportLink />,
-    );
-    expect(screen.queryByTestId('view-report-button')).toBeNull();
-    renderWithI18n(
-      <ControlButtons {...defaultProps} matchFinished lastMatchId="m1" showReportLink={false} />,
-    );
+    renderWithBoard(<ControlButtons />, {
+      state: {
+        state: liveState({ match_finished: true, last_match_id: 'match_abc_123' }),
+        showReportLink: false,
+      },
+    });
     expect(screen.queryByTestId('view-report-button')).toBeNull();
   });
 
   it('localizes icon-only controls and exposes toggle state', () => {
     localStorage.setItem('volley_lang', 'es');
-    const { container } = renderWithI18n(
-      <ControlButtons
-        {...defaultProps}
-        visible
-        simpleMode
-        showPreview={false}
-        setSummaryEnabled
-        setSummaryActive={false}
-        onToggleSetSummary={vi.fn()}
-      />,
-    );
+    const { container } = renderWithBoard(<ControlButtons />, {
+      state: {
+        state: liveState({ visible: true, set_summary: false }),
+        simpleMode: true,
+        showPreview: false,
+        setSummaryEnabled: true,
+      },
+    });
 
     expect(screen.getByTestId('undo-button')).toHaveAccessibleName('Deshacer última acción');
     expect(screen.getByTestId('simple-mode-button')).toHaveAccessibleName('Marcador simple');

--- a/frontend/src/test/ScoreboardView.test.tsx
+++ b/frontend/src/test/ScoreboardView.test.tsx
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi } from 'vitest';
 import { screen, fireEvent } from '@testing-library/react';
 import ScoreboardView from '../components/ScoreboardView';
-import { renderWithI18n, mockGameState, mockCustomization } from './helpers';
+import { BoardContextProvider } from '../board/BoardContexts';
+import { boardContextValues, renderWithBoard, renderWithI18n } from './helpers';
+
+const mocks = vi.hoisted(() => ({
+  teamPanel: vi.fn(({ teamId }: { teamId: number }) => (
+    <div data-testid={`team-panel-${teamId}`} />
+  )),
+}));
 
 vi.mock('../components/TeamPanel', () => ({
-  default: ({ teamId, order }: { teamId: number; order?: number }) => (
-    <div data-testid={`team-panel-${teamId}`} style={{ order }} />
-  ),
+  default: mocks.teamPanel,
 }));
 
 vi.mock('../components/CenterPanel', () => ({
@@ -17,49 +22,40 @@ vi.mock('../components/ControlButtons', () => ({
   default: () => <div data-testid="control-buttons" />,
 }));
 
-const baseProps = {
-  state: mockGameState,
-  customization: mockCustomization,
-  currentSet: 1,
-  setsLimit: 5,
-  isPortrait: false,
-  previewData: null,
-  showPreview: false,
-  recentEvents: [],
-  showControls: true,
-  setShowControls: vi.fn(),
-  canUndo: false,
-  simpleMode: false,
-  btnColorA: '#2196f3',
-  btnTextA: '#ffffff',
-  btnColorB: '#f44336',
-  btnTextB: '#ffffff',
-  iconLogoA: null,
-  iconLogoB: null,
-  onAddPoint: vi.fn(),
-  onAddSet: vi.fn(),
-  onAddTimeout: vi.fn(),
-  onChangeServe: vi.fn(),
-  onDoubleTapScore: vi.fn(),
-  onDoubleTapTimeout: vi.fn(),
-  onLongPressScore: vi.fn(),
-  onLongPressSet: vi.fn(),
-  onToggleVisibility: vi.fn(),
-  onToggleSimpleMode: vi.fn(),
-  onUndoLast: vi.fn(),
-  onTogglePreview: vi.fn(),
-  onStartMatch: vi.fn(),
-  onReset: vi.fn(),
-  onOpenConfig: vi.fn(),
-  onOpenShare: vi.fn(),
-  onOpenHistory: vi.fn(),
-  sidesSwapped: false,
-  onSwapSides: vi.fn(),
-};
-
 describe('ScoreboardView top-right corner stack', () => {
+  it('does not recompose its subtree for a board-state-only update', () => {
+    mocks.teamPanel.mockClear();
+    const initial = boardContextValues();
+    const { rerender } = renderWithI18n(
+      <BoardContextProvider {...initial}>
+        <ScoreboardView />
+      </BoardContextProvider>,
+    );
+    expect(mocks.teamPanel).toHaveBeenCalledTimes(2);
+
+    const next = {
+      ...initial,
+      state: {
+        ...initial.state,
+        state: {
+          ...initial.state.state,
+          team_1: {
+            ...initial.state.state.team_1,
+            scores: { ...initial.state.state.team_1.scores, set_1: 26 },
+          },
+        },
+      },
+    };
+    rerender(
+      <BoardContextProvider {...next}>
+        <ScoreboardView />
+      </BoardContextProvider>,
+    );
+    expect(mocks.teamPanel).toHaveBeenCalledTimes(2);
+  });
+
   it('renders config, share and history buttons in the top-right stack', () => {
-    renderWithI18n(<ScoreboardView {...baseProps} />);
+    renderWithBoard(<ScoreboardView />);
     const stack = document.querySelector('.top-corner-stack.top-right-stack');
     expect(stack).not.toBeNull();
     expect(screen.getByTestId('config-tab-button')).toBeInTheDocument();
@@ -73,44 +69,30 @@ describe('ScoreboardView top-right corner stack', () => {
     expect(buttons).toEqual(['config-tab-button', 'share-button', 'history-button']);
   });
 
-  it('keeps a fixed DOM order across a side swap, flipping only flex order', () => {
-    // Regression guard: the side swap must reorder the panels *visually*
-    // (via CSS flex ``order``) without changing their DOM positions. If
-    // the swap reordered the DOM, React would move the centre panel's
-    // node — tearing down and reloading its embedded preview iframe (a
-    // visible flash on every swap).
+  it('keeps a fixed DOM order across a side swap', () => {
+    // Regression guard: the side swap must reorder team panels visually in
+    // their own context-aware implementation without moving CentrePanel's
+    // position, which would reload its preview iframe.
     const domOrder = () =>
       Array.from(document.querySelector('.main-layout')!.children).map(
         (c) => (c as HTMLElement).dataset.testid,
       );
-    const orderOf = (testid: string) =>
-      Number((screen.getByTestId(testid) as HTMLElement).style.order);
 
-    const { rerender } = renderWithI18n(<ScoreboardView {...baseProps} sidesSwapped={false} />);
-    // DOM order is always panel1 · centre · panel2.
+    const { unmount } = renderWithBoard(<ScoreboardView />);
     expect(domOrder()).toEqual(['team-panel-1', 'center-panel', 'team-panel-2']);
-    // Not swapped: team 1 sits visually to the left of team 2.
-    expect(orderOf('team-panel-1')).toBeLessThan(orderOf('team-panel-2'));
+    unmount();
 
-    rerender(<ScoreboardView {...baseProps} sidesSwapped={true} />);
-    // DOM order is unchanged — only the flex order flips.
+    renderWithBoard(<ScoreboardView />, { state: { sidesSwapped: true } });
     expect(domOrder()).toEqual(['team-panel-1', 'center-panel', 'team-panel-2']);
-    // Swapped: team 2 now sits visually to the left of team 1.
-    expect(orderOf('team-panel-2')).toBeLessThan(orderOf('team-panel-1'));
   });
 
   it('invokes the matching callback when each top-right button is clicked', () => {
     const onOpenConfig = vi.fn();
     const onOpenShare = vi.fn();
     const onOpenHistory = vi.fn();
-    renderWithI18n(
-      <ScoreboardView
-        {...baseProps}
-        onOpenConfig={onOpenConfig}
-        onOpenShare={onOpenShare}
-        onOpenHistory={onOpenHistory}
-      />,
-    );
+    renderWithBoard(<ScoreboardView />, {
+      actions: { onOpenConfig, onOpenShare, onOpenHistory },
+    });
     fireEvent.click(screen.getByTestId('config-tab-button'));
     fireEvent.click(screen.getByTestId('share-button'));
     fireEvent.click(screen.getByTestId('history-button'));

--- a/frontend/src/test/TeamPanel.test.tsx
+++ b/frontend/src/test/TeamPanel.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
-import TeamPanel, { TeamPanelProps } from '../components/TeamPanel';
-import type { TeamState } from '../api/client';
-import { mockGameState, renderWithI18n } from './helpers';
+import { screen, fireEvent, act } from '@testing-library/react';
+import TeamPanel from '../components/TeamPanel';
+import type { GameState, TeamState } from '../api/client';
+import { mockGameState, mockCustomization, renderWithBoard } from './helpers';
 
 const baseTeamState: TeamState = {
   sets: 1,
@@ -12,21 +12,40 @@ const baseTeamState: TeamState = {
   scores: { set_1: 25, set_2: 15 },
 };
 
-const defaultProps: TeamPanelProps = {
+interface TeamPanelTestValues {
+  teamId: 1 | 2;
+  teamState: TeamState;
+  currentSet: number;
+  buttonColor: string;
+  buttonTextColor: string;
+  buttonSize: number;
+  isPortrait: boolean;
+  iconLogo: string | null;
+  iconOpacity: number;
+  state: GameState;
+  setsLimit: number;
+  customization: Record<string, unknown> | null;
+  onAddPoint: (teamId: 1 | 2) => void;
+  onAddTimeout: (teamId: 1 | 2) => void;
+  onChangeServe: (teamId: 1 | 2) => void;
+  onDoubleTapScore: (teamId: 1 | 2) => void;
+  onDoubleTapTimeout: (teamId: 1 | 2) => void;
+  onLongPressScore: (teamId: 1 | 2) => void;
+}
+
+const defaults: TeamPanelTestValues = {
   teamId: 1,
   teamState: baseTeamState,
   currentSet: 2,
   buttonColor: '#2196f3',
   buttonTextColor: '#ffffff',
-  serveColor: '#5c6bc0',
-  timeoutColor: '#5c6bc0',
   buttonSize: 150,
   isPortrait: false,
   iconLogo: null,
   iconOpacity: 50,
-  fontStyle: { fontFamily: undefined, fontScale: 1.0, fontOffsetY: 0.0 },
   state: mockGameState,
   setsLimit: 5,
+  customization: mockCustomization,
   onAddPoint: vi.fn(),
   onAddTimeout: vi.fn(),
   onChangeServe: vi.fn(),
@@ -34,6 +53,45 @@ const defaultProps: TeamPanelProps = {
   onDoubleTapTimeout: vi.fn(),
   onLongPressScore: vi.fn(),
 };
+
+function renderTeamPanel(overrides: Partial<TeamPanelTestValues> = {}) {
+  const values = { ...defaults, ...overrides };
+  const state = {
+    ...values.state,
+    [values.teamId === 1 ? 'team_1' : 'team_2']: values.teamState,
+  } as GameState;
+  return renderWithBoard(<TeamPanel teamId={values.teamId} />, {
+    state: {
+      state,
+      customization: values.customization,
+      currentSet: values.currentSet,
+      setsLimit: values.setsLimit,
+    },
+    theme:
+      values.teamId === 1
+        ? {
+            btnColorA: values.buttonColor,
+            btnTextA: values.buttonTextColor,
+            iconLogoA: values.iconLogo,
+            iconOpacity: values.iconOpacity,
+          }
+        : {
+            btnColorB: values.buttonColor,
+            btnTextB: values.buttonTextColor,
+            iconLogoB: values.iconLogo,
+            iconOpacity: values.iconOpacity,
+          },
+    layout: { buttonSize: values.buttonSize, isPortrait: values.isPortrait },
+    actions: {
+      onAddPoint: values.onAddPoint,
+      onAddTimeout: values.onAddTimeout,
+      onChangeServe: values.onChangeServe,
+      onDoubleTapScore: values.onDoubleTapScore,
+      onDoubleTapTimeout: values.onDoubleTapTimeout,
+      onLongPressScore: values.onLongPressScore,
+    },
+  });
+}
 
 describe('TeamPanel', () => {
   beforeEach(() => {
@@ -45,181 +103,124 @@ describe('TeamPanel', () => {
   });
 
   it('renders score for current set', () => {
-    render(<TeamPanel {...defaultProps} />);
-    // currentSet=2, scores.set_2=15, displayed as "15"
+    renderTeamPanel();
     expect(screen.getByTestId('team-1-score')).toHaveTextContent('15');
   });
 
   it('renders timeout dots matching timeout count', () => {
-    render(<TeamPanel {...defaultProps} />);
+    renderTeamPanel();
     expect(screen.getByTestId('timeout-1-number-0')).toBeInTheDocument();
     expect(screen.getByTestId('timeout-1-number-1')).toBeInTheDocument();
   });
 
-  it('renders serve icon', () => {
-    render(<TeamPanel {...defaultProps} />);
+  it('renders serve icon and dims it when the team is not serving', () => {
+    const { unmount } = renderTeamPanel();
     const serve = screen.getByTestId('team-1-serve');
-    expect(serve).toBeInTheDocument();
     expect(serve.style.opacity).toBe('1');
     expect(serve.querySelector<HTMLElement>('.material-icons')?.style.fontSize).toBe('2rem');
-  });
+    unmount();
 
-  it('renders serve icon dimmed when not serving', () => {
-    render(<TeamPanel {...defaultProps} teamState={{ ...baseTeamState, serving: false }} />);
+    renderTeamPanel({ teamState: { ...baseTeamState, serving: false } });
     expect(screen.getByTestId('team-1-serve').style.opacity).toBe('0.4');
   });
 
   it('calls onAddPoint when score button tapped once', () => {
     const onAddPoint = vi.fn();
-    render(<TeamPanel {...defaultProps} onAddPoint={onAddPoint} />);
+    renderTeamPanel({ onAddPoint });
     fireEvent.mouseDown(screen.getByTestId('team-1-score'));
     fireEvent.mouseUp(screen.getByTestId('team-1-score'));
-    act(() => {
-      vi.advanceTimersByTime(400);
-    });
+    act(() => vi.advanceTimersByTime(400));
     expect(onAddPoint).toHaveBeenCalledWith(1);
   });
 
   it('calls onDoubleTapScore on rapid double-tap', () => {
     const onDoubleTapScore = vi.fn();
     const onAddPoint = vi.fn();
-    render(
-      <TeamPanel {...defaultProps} onAddPoint={onAddPoint} onDoubleTapScore={onDoubleTapScore} />,
-    );
-    const btn = screen.getByTestId('team-1-score');
-    fireEvent.mouseDown(btn);
-    fireEvent.mouseUp(btn);
-    act(() => {
-      vi.advanceTimersByTime(100);
-    });
-    fireEvent.mouseDown(btn);
-    fireEvent.mouseUp(btn);
+    renderTeamPanel({ onAddPoint, onDoubleTapScore });
+    const button = screen.getByTestId('team-1-score');
+    fireEvent.mouseDown(button);
+    fireEvent.mouseUp(button);
+    act(() => vi.advanceTimersByTime(100));
+    fireEvent.mouseDown(button);
+    fireEvent.mouseUp(button);
     expect(onDoubleTapScore).toHaveBeenCalledWith(1);
     expect(onAddPoint).not.toHaveBeenCalled();
   });
 
-  it('calls onAddTimeout when timeout button tapped once', () => {
+  it('handles single and double taps on timeout controls', () => {
     const onAddTimeout = vi.fn();
-    render(<TeamPanel {...defaultProps} onAddTimeout={onAddTimeout} />);
-    const btn = screen.getByTestId('team-1-timeout');
-    fireEvent.mouseDown(btn);
-    fireEvent.mouseUp(btn);
-    act(() => {
-      vi.advanceTimersByTime(400);
-    });
+    const { unmount } = renderTeamPanel({ onAddTimeout });
+    const button = screen.getByTestId('team-1-timeout');
+    fireEvent.mouseDown(button);
+    fireEvent.mouseUp(button);
+    act(() => vi.advanceTimersByTime(400));
     expect(onAddTimeout).toHaveBeenCalledWith(1);
-  });
+    unmount();
 
-  it('calls onDoubleTapTimeout on rapid double-tap of timeout button', () => {
     const onDoubleTapTimeout = vi.fn();
-    const onAddTimeout = vi.fn();
-    render(
-      <TeamPanel
-        {...defaultProps}
-        onAddTimeout={onAddTimeout}
-        onDoubleTapTimeout={onDoubleTapTimeout}
-      />,
-    );
-    const btn = screen.getByTestId('team-1-timeout');
-    fireEvent.mouseDown(btn);
-    fireEvent.mouseUp(btn);
-    act(() => {
-      vi.advanceTimersByTime(100);
-    });
-    fireEvent.mouseDown(btn);
-    fireEvent.mouseUp(btn);
+    renderTeamPanel({ onAddTimeout, onDoubleTapTimeout });
+    const doubleTapButton = screen.getByTestId('team-1-timeout');
+    fireEvent.mouseDown(doubleTapButton);
+    fireEvent.mouseUp(doubleTapButton);
+    act(() => vi.advanceTimersByTime(100));
+    fireEvent.mouseDown(doubleTapButton);
+    fireEvent.mouseUp(doubleTapButton);
     expect(onDoubleTapTimeout).toHaveBeenCalledWith(1);
-    expect(onAddTimeout).not.toHaveBeenCalled();
   });
 
-  it('keyboard: Enter on timeout button activates onAddTimeout', () => {
+  it('supports keyboard activation of timeout controls', () => {
     const onAddTimeout = vi.fn();
-    render(<TeamPanel {...defaultProps} onAddTimeout={onAddTimeout} />);
-    const btn = screen.getByTestId('team-1-timeout');
-    fireEvent.keyDown(btn, { key: 'Enter' });
-    fireEvent.keyUp(btn, { key: 'Enter' });
-    act(() => {
-      vi.advanceTimersByTime(400);
-    });
+    renderTeamPanel({ onAddTimeout });
+    const button = screen.getByTestId('team-1-timeout');
+    fireEvent.keyDown(button, { key: 'Enter' });
+    fireEvent.keyUp(button, { key: 'Enter' });
+    act(() => vi.advanceTimersByTime(400));
     expect(onAddTimeout).toHaveBeenCalledWith(1);
-  });
-
-  it('keyboard: rapid double-Enter on timeout button triggers onDoubleTapTimeout', () => {
-    const onAddTimeout = vi.fn();
-    const onDoubleTapTimeout = vi.fn();
-    render(
-      <TeamPanel
-        {...defaultProps}
-        onAddTimeout={onAddTimeout}
-        onDoubleTapTimeout={onDoubleTapTimeout}
-      />,
-    );
-    const btn = screen.getByTestId('team-1-timeout');
-    fireEvent.keyDown(btn, { key: 'Enter' });
-    fireEvent.keyUp(btn, { key: 'Enter' });
-    act(() => {
-      vi.advanceTimersByTime(100);
-    });
-    fireEvent.keyDown(btn, { key: 'Enter' });
-    fireEvent.keyUp(btn, { key: 'Enter' });
-    expect(onDoubleTapTimeout).toHaveBeenCalledWith(1);
-    expect(onAddTimeout).not.toHaveBeenCalled();
   });
 
   it('calls onChangeServe when serve icon clicked', () => {
-    render(<TeamPanel {...defaultProps} />);
+    const onChangeServe = vi.fn();
+    renderTeamPanel({ onChangeServe });
     fireEvent.click(screen.getByTestId('team-1-serve'));
-    expect(defaultProps.onChangeServe).toHaveBeenCalledWith(1);
+    expect(onChangeServe).toHaveBeenCalledWith(1);
   });
 
-  it('uses portrait layout classes when isPortrait', () => {
-    const { container } = render(<TeamPanel {...defaultProps} isPortrait={true} />);
+  it('uses portrait and landscape layout classes', () => {
+    const { container, unmount } = renderTeamPanel({ isPortrait: true });
     expect(container.querySelector('.team-panel-portrait')).toBeInTheDocument();
+    unmount();
+    const { container: landscape } = renderTeamPanel({ isPortrait: false });
+    expect(landscape.querySelector('.team-panel-landscape')).toBeInTheDocument();
   });
 
-  it('uses landscape layout classes when not portrait', () => {
-    const { container } = render(<TeamPanel {...defaultProps} isPortrait={false} />);
-    expect(container.querySelector('.team-panel-landscape')).toBeInTheDocument();
-  });
-
-  it('pads score to two digits', () => {
-    render(<TeamPanel {...defaultProps} teamState={{ ...baseTeamState, scores: { set_2: 3 } }} />);
+  it('pads scores to two digits', () => {
+    renderTeamPanel({ teamState: { ...baseTeamState, scores: { set_2: 3 } } });
     expect(screen.getByTestId('team-1-score')).toHaveTextContent('03');
   });
 
-  it('portrait: hides the team logo when icons are disabled (iconLogo null)', () => {
-    // Even if customization carries a logo, the portrait history column
-    // must honour the "show icons" setting (which nulls iconLogo) — the
-    // bug was that it read the logo straight from customization.
-    render(
-      <TeamPanel
-        {...defaultProps}
-        isPortrait={true}
-        iconLogo={null}
-        customization={{ 'Team 1 Logo': 'https://example.com/logo.png' }}
-      />,
-    );
+  it('uses only the resolved icon theme value in portrait mode', () => {
+    const { unmount } = renderTeamPanel({
+      isPortrait: true,
+      iconLogo: null,
+      customization: { 'Team 1 Logo': 'https://example.com/logo.png' },
+    });
     expect(screen.queryByTestId('team-1-logo')).toBeNull();
-  });
+    unmount();
 
-  it('portrait: shows the team logo from iconLogo when icons are enabled', () => {
-    render(
-      <TeamPanel {...defaultProps} isPortrait={true} iconLogo="https://example.com/logo.png" />,
+    renderTeamPanel({ isPortrait: true, iconLogo: 'https://example.com/logo.png' });
+    expect(screen.getByTestId('team-1-logo')).toHaveAttribute(
+      'src',
+      'https://example.com/logo.png',
     );
-    const img = screen.getByTestId('team-1-logo') as HTMLImageElement;
-    expect(img.src).toContain('https://example.com/logo.png');
   });
 
   it('localizes scoring-control names and gesture descriptions', () => {
     localStorage.setItem('volley_lang', 'es');
-    renderWithI18n(
-      <TeamPanel
-        {...defaultProps}
-        isPortrait={true}
-        iconLogo="https://example.com/logo.png"
-        customization={{ 'Team 1 Name': 'Lobos' }}
-      />,
-    );
+    renderTeamPanel({
+      isPortrait: true,
+      iconLogo: 'https://example.com/logo.png',
+      customization: { 'Team 1 Name': 'Lobos' },
+    });
 
     expect(screen.getByTestId('team-1-score')).toHaveAccessibleName('Lobos, puntuación 15');
     expect(screen.getByTestId('team-1-score')).toHaveAccessibleDescription(

--- a/frontend/src/test/helpers.tsx
+++ b/frontend/src/test/helpers.tsx
@@ -3,6 +3,13 @@ import { render, RenderOptions } from '@testing-library/react';
 import { I18nProvider } from '../i18n';
 import { SettingsProvider } from '../hooks/useSettings';
 import type { GameState } from '../api/client';
+import {
+  BoardContextProvider,
+  type BoardActionsValue,
+  type BoardLayoutValue,
+  type BoardStateValue,
+  type BoardThemeValue,
+} from '../board/BoardContexts';
 
 // Use the ``wrapper`` option (rather than wrapping ``ui`` inline) so the
 // providers are re-applied by ``rerender`` too — otherwise a rerender drops
@@ -67,3 +74,85 @@ export const mockCustomization = {
   'Left-Right': -33,
   'Up-Down': -41.1,
 };
+
+const noop = () => {};
+
+export interface BoardContextOverrides {
+  state?: Omit<Partial<BoardStateValue>, 'state'> & { state?: GameState };
+  actions?: Partial<BoardActionsValue>;
+  theme?: Partial<BoardThemeValue>;
+  layout?: Partial<BoardLayoutValue>;
+}
+
+/** Default board contexts for focused component tests. */
+export function boardContextValues(overrides: BoardContextOverrides = {}) {
+  const state: BoardStateValue = {
+    state: mockGameState,
+    confirmedState: mockGameState,
+    customization: mockCustomization,
+    currentSet: 1,
+    setsLimit: 5,
+    simpleMode: false,
+    matchFinished: false,
+    sidesSwapped: false,
+    previewData: null,
+    showPreview: false,
+    setSummaryEnabled: false,
+    showOnAir: true,
+    showReportLink: true,
+    recentEvents: [],
+    ...overrides.state,
+  };
+  const actions: BoardActionsValue = {
+    onAddPoint: noop,
+    onAddSet: noop,
+    onAddTimeout: noop,
+    onChangeServe: noop,
+    onDoubleTapScore: noop,
+    onDoubleTapTimeout: noop,
+    onLongPressScore: noop,
+    onLongPressSet: noop,
+    onSwapSides: noop,
+    onToggleVisibility: noop,
+    onToggleSimpleMode: noop,
+    onUndoLast: noop,
+    onTogglePreview: noop,
+    onToggleSetSummary: noop,
+    onChangeSetSummaryStyle: noop,
+    onStartMatch: noop,
+    onReset: noop,
+    onOpenConfig: noop,
+    onOpenShare: noop,
+    onOpenHistory: noop,
+    onToggleControls: noop,
+    ...overrides.actions,
+  };
+  const theme: BoardThemeValue = {
+    btnColorA: '#2196f3',
+    btnTextA: '#ffffff',
+    btnColorB: '#f44336',
+    btnTextB: '#ffffff',
+    iconLogoA: null,
+    iconLogoB: null,
+    iconOpacity: 50,
+    fontStyle: { fontFamily: undefined, fontScale: 1, fontOffsetY: 0, fontOffsetX: 0 },
+    ...overrides.theme,
+  };
+  const layout: BoardLayoutValue = {
+    isPortrait: false,
+    buttonSize: 150,
+    compactLandscape: false,
+    showControls: true,
+    ...overrides.layout,
+  };
+  return { state, actions, theme, layout };
+}
+
+export function renderWithBoard(
+  ui: ReactElement,
+  overrides: BoardContextOverrides = {},
+  options: Omit<RenderOptions, 'wrapper'> = {},
+) {
+  const values = boardContextValues(overrides);
+  return renderWithI18n(<BoardContextProvider {...values}>{ui}</BoardContextProvider>, options);
+}


### PR DESCRIPTION
## Summary

Closes #437.

- Split scoreboard data into focused board state, actions, theme, and layout contexts.
- Made `ScoreboardView` a memoized composition layer and removed its 51-prop forwarding surface.
- Stabilized score and long-press action callbacks across live state updates; hoisted static HUD styles.
- Added context-based component coverage, including a regression test that state-only updates do not recompose the scoreboard subtree.

## Why

The old App → ScoreboardView → panel chain forwarded state, theme, and handlers through multiple levels. Fresh callback props meant memo boundaries were reevaluated on each WebSocket update.

## Validation

- `frontend: npm test -- --run` (823 passed)
- `frontend: npm run typecheck`
- `frontend: npm run build`
- `frontend: npm run format:check`
- `frontend: npm run lint`
- `frontend: npm run stylelint`
- `.venv/bin/pytest tests/ -q`
- `.venv/bin/ruff check .`
- `.venv/bin/mypy`
