### PR TITLE
chore: complete backend type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ archive by hand.
 
 ### Added
 
+- **The backend typing gate now rejects every unannotated function.**
+  All remaining application signatures are typed, including the
+  `GameSession`/`Backend` game-service path and ASGI middleware boundaries;
+  mypy now enables `disallow_untyped_defs` and disables implicit optionals,
+  with Ruff `RUF013` enforcing the same optional-parameter syntax.
+  Fixes [#443](https://github.com/JacoboSanchez/volley-overlay-control/issues/443).
+
 - **The JavaScript and CSS that render the on-air overlays now pass the same
   automated quality gates as the React SPA.** ESLint checks every first-party
   script in `overlay_static/js/` with browser globals plus blocking

--- a/app/api/game_actions.py
+++ b/app/api/game_actions.py
@@ -1,7 +1,10 @@
 """Score, rules, lifecycle, audit, and webhook game actions."""
 
+from __future__ import annotations
+
 import logging
 import time
+from typing import TYPE_CHECKING, Any, cast
 
 from app.api import action_log
 from app.api import game_audit_hooks as _audit_hooks
@@ -17,6 +20,10 @@ from app.api.schemas import (
     GameStateResponse,
 )
 from app.customization_cache_ttl import customization_cache_ttl_seconds
+
+if TYPE_CHECKING:
+    from app.api.game_service import GameService
+    from app.api.session_manager import GameSession
 
 logger = logging.getLogger(__name__)
 
@@ -41,16 +48,16 @@ RAPID_PAIR_WINDOW_S = _rapid_pair.RAPID_PAIR_WINDOW_S
 CUSTOMIZATION_CACHE_TTL_SECONDS = customization_cache_ttl_seconds()
 
 
-def _service(cls: type):
+def _service(cls: type) -> type[GameService]:
     """Return the composed facade class for cross-mixin calls."""
-    return cls
+    return cast("type[GameService]", cls)
 
 
 class GameActions:
     """Mutate match state through GameManager and fan out side effects."""
 
     @classmethod
-    def _match_finished_response(cls, session) -> ActionResponse | None:
+    def _match_finished_response(cls, session: GameSession) -> ActionResponse | None:
         """Return the early-exit ``ActionResponse`` when the match is already over.
 
         ``add_point`` / ``add_set`` / ``add_timeout`` all share the same
@@ -66,7 +73,7 @@ class GameActions:
         return None
 
     @classmethod
-    def _ended_set_index(cls, session) -> int:
+    def _ended_set_index(cls, session: GameSession) -> int:
         """Set number that just ended (1-indexed).
 
         ``current_set`` is advanced on a set win unless the match
@@ -80,7 +87,12 @@ class GameActions:
         return session.current_set - 1
 
     @classmethod
-    def _fire_serve_change_if_changed(cls, session, serve_before, state_response: GameStateResponse) -> None:
+    def _fire_serve_change_if_changed(
+        cls,
+        session: GameSession,
+        serve_before: object,
+        state_response: GameStateResponse,
+    ) -> None:
         """Fire a ``serve_change`` webhook when the current serve flipped."""
         serve_after = session.game_manager.get_current_state().get_current_serve()
         if serve_before != serve_after:
@@ -92,7 +104,7 @@ class GameActions:
             )
 
     @classmethod
-    def _sync_match_finished_at(cls, session, was_finished_before: bool) -> None:
+    def _sync_match_finished_at(cls, session: GameSession, was_finished_before: bool) -> None:
         """Stamp / clear ``session.match_finished_at`` to match the
         current match-finished state.
 
@@ -124,7 +136,7 @@ class GameActions:
     @classmethod
     def _consume_rapid_pair(
         cls,
-        session,
+        session: GameSession,
         team: int,
         undo: bool,
         point_type: str | None = None,
@@ -141,22 +153,22 @@ class GameActions:
     @classmethod
     def _record_rapid_pair_seed(
         cls,
-        session,
+        session: GameSession,
         team: int,
         undo: bool,
-        audit_record: dict | None,
-        popped: dict | None,
+        audit_record: dict[str, Any] | None,
+        popped: dict[str, Any] | None,
     ) -> None:
         _rapid_pair.record_rapid_pair_seed(session, team, undo, audit_record, popped)
 
     @classmethod
-    def _invalidate_rapid_pair_cache(cls, session) -> None:
+    def _invalidate_rapid_pair_cache(cls, session: GameSession) -> None:
         _rapid_pair.invalidate_rapid_pair_cache(session)
 
     @classmethod
     def add_point(
         cls,
-        session,
+        session: GameSession,
         team: int,
         undo: bool = False,
         point_type: str | None = None,
@@ -310,7 +322,7 @@ class GameActions:
         return ActionResponse(success=True, state=state_response)
 
     @classmethod
-    def add_set(cls, session, team: int, undo: bool = False) -> ActionResponse:
+    def add_set(cls, session: GameSession, team: int, undo: bool = False) -> ActionResponse:
         if not undo:
             blocked = _service(cls)._match_finished_response(session)
             if blocked is not None:
@@ -382,7 +394,7 @@ class GameActions:
         return ActionResponse(success=True, state=state_response)
 
     @classmethod
-    def add_timeout(cls, session, team: int, undo: bool = False) -> ActionResponse:
+    def add_timeout(cls, session: GameSession, team: int, undo: bool = False) -> ActionResponse:
         if not undo:
             blocked = _service(cls)._match_finished_response(session)
             if blocked is not None:
@@ -438,7 +450,7 @@ class GameActions:
         return ActionResponse(success=True, state=state_response)
 
     @classmethod
-    def change_serve(cls, session, team: int) -> ActionResponse:
+    def change_serve(cls, session: GameSession, team: int) -> ActionResponse:
         _service(cls)._invalidate_rapid_pair_cache(session)
         serve_before = session.game_manager.get_current_state().get_current_serve()
         if session.mode == "table_tennis":
@@ -470,7 +482,7 @@ class GameActions:
         return ActionResponse(success=True, state=state_response)
 
     @classmethod
-    def set_score(cls, session, team: int, set_number: int, value: int) -> ActionResponse:
+    def set_score(cls, session: GameSession, team: int, set_number: int, value: int) -> ActionResponse:
         if not (1 <= set_number <= session.sets_limit):
             return ActionResponse(
                 success=False,
@@ -512,7 +524,7 @@ class GameActions:
         return ActionResponse(success=True, state=state_response)
 
     @classmethod
-    def set_sets_value(cls, session, team: int, value: int) -> ActionResponse:
+    def set_sets_value(cls, session: GameSession, team: int, value: int) -> ActionResponse:
         _service(cls)._invalidate_rapid_pair_cache(session)
         was_finished_before = session.game_manager.match_finished(session.sets_limit)
         session.game_manager.set_sets_value(team, value)
@@ -527,7 +539,7 @@ class GameActions:
         return ActionResponse(success=True, state=state_response)
 
     @classmethod
-    def undo_last(cls, session) -> ActionResponse:
+    def undo_last(cls, session: GameSession) -> ActionResponse:
         """Reverse the most-recent undoable forward action.
 
         The audit log is the single source of truth for the undo
@@ -578,7 +590,7 @@ class GameActions:
     @classmethod
     def set_rules(
         cls,
-        session,
+        session: GameSession,
         mode: str | None = None,
         points_limit: int | None = None,
         points_limit_last_set: int | None = None,
@@ -656,7 +668,7 @@ class GameActions:
         return ActionResponse(success=True, state=state_response)
 
     @classmethod
-    def start_match(cls, session) -> ActionResponse:
+    def start_match(cls, session: GameSession) -> ActionResponse:
         """Arm the match-start clock without scoring a point.
 
         Idempotent: a second call after the match has already started
@@ -678,7 +690,7 @@ class GameActions:
         return ActionResponse(success=True, state=_service(cls).get_state(session))
 
     @classmethod
-    def reset(cls, session) -> ActionResponse:
+    def reset(cls, session: GameSession) -> ActionResponse:
         # Reset wipes the audit log; the rapid-pair cache that
         # references audit timestamps must vanish with it.
         _service(cls)._invalidate_rapid_pair_cache(session)
@@ -704,17 +716,17 @@ class GameActions:
         return ActionResponse(success=True, state=state_response)
 
     @classmethod
-    def _save_and_broadcast(cls, session, state_response: GameStateResponse | None = None):
+    def _save_and_broadcast(cls, session: GameSession, state_response: GameStateResponse | None = None) -> None:
         _broadcast.save_and_broadcast(session, state_response)
 
     @classmethod
-    def _broadcast(cls, session, state_response: GameStateResponse | None = None):
+    def _broadcast(cls, session: GameSession, state_response: GameStateResponse | None = None) -> None:
         _broadcast.broadcast(session, state_response)
 
     @classmethod
     def _archive_if_finished(
         cls,
-        session,
+        session: GameSession,
         was_finished_before: bool,
         winning_team: int,
         state_response: GameStateResponse | None = None,
@@ -729,12 +741,12 @@ class GameActions:
     @classmethod
     def _audit(
         cls,
-        session,
+        session: GameSession,
         action: str,
-        params: dict,
-        popped_forward: dict | None = None,
+        params: dict[str, Any],
+        popped_forward: dict[str, Any] | None = None,
         target_set: int | None = None,
-    ) -> dict | None:
+    ) -> dict[str, Any] | None:
         return _audit_hooks.audit(
             session,
             action,
@@ -744,5 +756,11 @@ class GameActions:
         )
 
     @classmethod
-    def _fire(cls, session, event: str, state_response, details: dict) -> None:
+    def _fire(
+        cls,
+        session: GameSession,
+        event: str,
+        state_response: GameStateResponse,
+        details: dict[str, Any],
+    ) -> None:
         _audit_hooks.fire_webhook(session, event, state_response, details)

--- a/app/api/game_customization_service.py
+++ b/app/api/game_customization_service.py
@@ -1,7 +1,10 @@
 """Customization reads, validation, and persistence."""
 
+from __future__ import annotations
+
 import logging
 import time
+from typing import TYPE_CHECKING, Any, cast
 
 from app.api import game_rapid_pair as _rapid_pair
 from app.api.schemas import (
@@ -15,6 +18,10 @@ from app.api.schemas import (
 )
 from app.customization_cache_ttl import customization_cache_ttl_seconds
 from app.match_report.i18n import SUPPORTED_LOCALES as _SUPPORTED_LOCALES
+
+if TYPE_CHECKING:
+    from app.api.game_service import GameService
+    from app.api.session_manager import GameSession
 
 logger = logging.getLogger(__name__)
 
@@ -46,20 +53,26 @@ def _cache_ttl_seconds() -> float:
     return float(game_service.CUSTOMIZATION_CACHE_TTL_SECONDS)
 
 
-def _service(cls: type):
+def _service(cls: type) -> type[GameService]:
     """Return the composed facade class for cross-mixin calls."""
-    return cls
+    return cast("type[GameService]", cls)
 
 
 class GameCustomizationService:
     """Manage customization state without owning gameplay actions."""
 
     @classmethod
-    def get_customization(cls, session) -> dict:
+    def get_customization(
+        cls,
+        session: GameSession,
+    ) -> dict[str, Any]:
         return session.customization.get_model()
 
     @classmethod
-    def refresh_customization(cls, session) -> dict:
+    def refresh_customization(
+        cls,
+        session: GameSession,
+    ) -> dict[str, Any]:
         """Re-fetch customization from the overlay server and update the session cache.
 
         For custom overlays this performs an HTTP round-trip to the overlay server
@@ -104,7 +117,7 @@ class GameCustomizationService:
     # ------------------------------------------------------------------
 
     @classmethod
-    def set_selected_team_group(cls, session, group_id: int | None) -> None:
+    def set_selected_team_group(cls, session: GameSession, group_id: int | None) -> None:
         """Remember the board's selected team group (``None`` = the "All"
         group). Persist-only — the selection changes which teams the control
         selectors offer, not the rendered overlay, so no broadcast is needed."""
@@ -112,7 +125,11 @@ class GameCustomizationService:
         session.persist_meta()
 
     @classmethod
-    def update_customization(cls, session, data: dict) -> ActionResponse:
+    def update_customization(
+        cls,
+        session: GameSession,
+        data: dict[str, Any],
+    ) -> ActionResponse:
         # Reject obviously malformed payloads before doing any work. The
         # cap on top-level keys keeps a malicious client from streaming
         # tens of thousands of unknown keys (the filter below drops them,

--- a/app/api/game_display_service.py
+++ b/app/api/game_display_service.py
@@ -1,12 +1,20 @@
 """Display-only toggles and side-swap behavior."""
 
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING, cast
 
 from app.api import game_rapid_pair as _rapid_pair
 from app.api.schemas import (
     ActionResponse,
 )
 from app.customization_cache_ttl import customization_cache_ttl_seconds
+from app.state import State
+
+if TYPE_CHECKING:
+    from app.api.game_service import GameService
+    from app.api.session_manager import GameSession
 
 logger = logging.getLogger(__name__)
 
@@ -31,16 +39,16 @@ RAPID_PAIR_WINDOW_S = _rapid_pair.RAPID_PAIR_WINDOW_S
 CUSTOMIZATION_CACHE_TTL_SECONDS = customization_cache_ttl_seconds()
 
 
-def _service(cls: type):
+def _service(cls: type) -> type[GameService]:
     """Return the composed facade class for cross-mixin calls."""
-    return cls
+    return cast("type[GameService]", cls)
 
 
 class GameDisplayService:
     """Manage overlay presentation flags without scoring mutations."""
 
     @classmethod
-    def set_visibility(cls, session, visible: bool) -> ActionResponse:
+    def set_visibility(cls, session: GameSession, visible: bool) -> ActionResponse:
         session.visible = visible
         session.backend.change_overlay_visibility(visible)
         state_response = _service(cls).get_state(session)
@@ -48,7 +56,7 @@ class GameDisplayService:
         return ActionResponse(success=True, state=state_response)
 
     @classmethod
-    def set_simple_mode(cls, session, enabled: bool) -> ActionResponse:
+    def set_simple_mode(cls, session: GameSession, enabled: bool) -> ActionResponse:
         session.simple = enabled
         if enabled:
             session.backend.reduce_games_to_one()
@@ -57,7 +65,11 @@ class GameDisplayService:
         return ActionResponse(success=True, state=state_response)
 
     @classmethod
-    def _auto_swap_component(cls, session, state) -> bool:
+    def _auto_swap_component(
+        cls,
+        session: GameSession,
+        state: State,
+    ) -> bool:
         """Auto-derived side-swap parity for the session's live state."""
         from app.api.match_rules import compute_sides_swapped_auto
 
@@ -74,7 +86,11 @@ class GameDisplayService:
         )
 
     @classmethod
-    def effective_sides_swapped(cls, session, state) -> bool:
+    def effective_sides_swapped(
+        cls,
+        session: GameSession,
+        state: State,
+    ) -> bool:
         """The orientation every live view should render right now.
 
         Manual base XOR the auto component (when auto-swap is on), so
@@ -86,7 +102,7 @@ class GameDisplayService:
         return swapped
 
     @classmethod
-    def set_sides_swapped(cls, session, swapped: bool) -> ActionResponse:
+    def set_sides_swapped(cls, session: GameSession, swapped: bool) -> ActionResponse:
         """Set the *effective* display orientation to ``swapped``.
 
         The stored manual base absorbs the auto component so the
@@ -104,7 +120,7 @@ class GameDisplayService:
         return ActionResponse(success=True, state=state_response)
 
     @classmethod
-    def set_auto_swap_sides(cls, session, enabled: bool) -> ActionResponse:
+    def set_auto_swap_sides(cls, session: GameSession, enabled: bool) -> ActionResponse:
         """Toggle automatic side swapping.
 
         The manual base is re-anchored so the orientation visible at
@@ -126,7 +142,7 @@ class GameDisplayService:
         return ActionResponse(success=True, state=state_response)
 
     @classmethod
-    def set_set_summary_mode(cls, session, enabled: bool) -> ActionResponse:
+    def set_set_summary_mode(cls, session: GameSession, enabled: bool) -> ActionResponse:
         """Toggle the set-summary overlay panel.
 
         The summary picks the "last played" set: if the current set has
@@ -141,7 +157,7 @@ class GameDisplayService:
         return ActionResponse(success=True, state=state_response)
 
     @classmethod
-    def set_set_summary_style(cls, session, style: str) -> ActionResponse:
+    def set_set_summary_style(cls, session: GameSession, style: str) -> ActionResponse:
         """Pick the visual variant for the set-summary overlay.
 
         ``style`` is validated against

--- a/app/api/game_state_presenter.py
+++ b/app/api/game_state_presenter.py
@@ -1,7 +1,10 @@
 """Presentation of live game state as API response models."""
 
+from __future__ import annotations
+
 import logging
 import time
+from typing import TYPE_CHECKING, Any, cast
 
 from app.api import game_rapid_pair as _rapid_pair
 from app.api.match_rules import (
@@ -20,6 +23,10 @@ from app.api.schemas import (
 from app.customization_cache_ttl import customization_cache_ttl_seconds
 from app.env_vars_manager import EnvVarsManager
 from app.state import State
+
+if TYPE_CHECKING:
+    from app.api.game_service import GameService
+    from app.api.session_manager import GameSession
 
 logger = logging.getLogger(__name__)
 
@@ -44,16 +51,16 @@ RAPID_PAIR_WINDOW_S = _rapid_pair.RAPID_PAIR_WINDOW_S
 CUSTOMIZATION_CACHE_TTL_SECONDS = customization_cache_ttl_seconds()
 
 
-def _service(cls: type):
+def _service(cls: type) -> type[GameService]:
     """Return the composed facade class for cross-mixin calls."""
-    return cls
+    return cast("type[GameService]", cls)
 
 
 class GameStatePresenter:
     """Build response models and presentation-only derived values."""
 
     @classmethod
-    def _obs_client_count(cls, session) -> int:
+    def _obs_client_count(cls, session: GameSession) -> int:
         """Live output clients (OBS + spectator) on this overlay, 0 on error.
 
         Defensive: not every backend tracks this (e.g. bare/test backends),
@@ -70,7 +77,7 @@ class GameStatePresenter:
             return 0
 
     @classmethod
-    def _resolve_last_match_id(cls, session) -> str | None:
+    def _resolve_last_match_id(cls, session: GameSession) -> str | None:
         """``match_id`` of the just-finished match for the report link.
 
         Prefers the id stashed on the session when the match was archived
@@ -94,7 +101,7 @@ class GameStatePresenter:
             return None
 
     @classmethod
-    def _sync_table_tennis_serve(cls, session) -> None:
+    def _sync_table_tennis_serve(cls, session: GameSession) -> None:
         """Recompute the live serve for a table-tennis session.
 
         Volleyball serve follows the rally winner (handled in
@@ -126,16 +133,16 @@ class GameStatePresenter:
             state.set_current_serve(desired)
 
     @classmethod
-    def get_state(cls, session) -> GameStateResponse:
+    def get_state(cls, session: GameSession) -> GameStateResponse:
         """Build a ``GameStateResponse`` from the current session state."""
         t0 = time.perf_counter()
         _service(cls)._sync_table_tennis_serve(session)
         state = session.game_manager.get_current_state()
         serve = state.get_current_serve()
 
-        def team_state(team):
-            scores = {}
-            timeouts_by_set = {}
+        def team_state(team: int) -> TeamState:
+            scores: dict[str, int] = {}
+            timeouts_by_set: dict[str, int] = {}
             for i in range(1, session.sets_limit + 1):
                 scores[f"set_{i}"] = state.get_game(team, i)
                 timeouts_by_set[f"set_{i}"] = state.get_timeout(team, set_num=i)
@@ -198,7 +205,7 @@ class GameStatePresenter:
         # audit mutation is shared with the overlay push, which needs the
         # full stats payload anyway. ``None`` here is safe — the helpers
         # treat it as "no stats available" and fall back to defaults.
-        points_by_set_cache: dict | None
+        points_by_set_cache: dict[Any, Any] | None
         try:
             from app.api.live_stats import compute_live_stats
 
@@ -277,8 +284,8 @@ class GameStatePresenter:
     @classmethod
     def _current_set_started_at(
         cls,
-        session,
-        points_by_set: dict | None = None,
+        session: GameSession,
+        points_by_set: dict[Any, Any] | None = None,
     ) -> float | None:
         """Wall-clock timestamp of the first scoring event in the
         operator's current set.
@@ -325,8 +332,8 @@ class GameStatePresenter:
     @classmethod
     def _resolve_summary_set(
         cls,
-        session,
-        points_by_set: dict | None = None,
+        session: GameSession,
+        points_by_set: dict[Any, Any] | None = None,
     ) -> int:
         """Return the set number the summary panel should show.
 

--- a/app/api/match_archive.py
+++ b/app/api/match_archive.py
@@ -25,9 +25,11 @@ from __future__ import annotations
 import datetime
 import logging
 import re
+from typing import Any
 
 from sqlalchemy import delete as sa_delete
 from sqlalchemy import func, select
+from sqlalchemy.sql import Select
 
 from app.api import action_log
 from app.api._persistence_paths import DEFAULT_HASH_LEN, hashed_filename
@@ -164,7 +166,11 @@ def archive_match(
     return match_id
 
 
-def _scope_predicates(stmt, oid: str | None, user_id: int | None):
+def _scope_predicates(
+    stmt: Select[Any],
+    oid: str | None,
+    user_id: int | None,
+) -> Select[Any] | None:
     """Apply the skey / user_id scoping shared by list and count.
 
     Returns the scoped statement, or ``None`` when a provided-but-invalid

--- a/app/api/match_rules.py
+++ b/app/api/match_rules.py
@@ -40,9 +40,17 @@ Table tennis:
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, TypedDict
 
 MatchMode = Literal["indoor", "beach", "table_tennis"]
+
+
+class BeachSideSwitchData(TypedDict):
+    interval: int
+    points_in_set: int
+    next_switch_at: int
+    points_until_switch: int
+    is_switch_pending: bool
 
 VALID_MODES: tuple[str, ...] = ("indoor", "beach", "table_tennis")
 
@@ -52,12 +60,12 @@ class RulesPreset:
 
     def __init__(
         self, points_limit: int, points_limit_last_set: int, sets_limit: int,
-    ):
+    ) -> None:
         self.points_limit = points_limit
         self.points_limit_last_set = points_limit_last_set
         self.sets_limit = sets_limit
 
-    def as_dict(self) -> dict:
+    def as_dict(self) -> dict[str, int]:
         return {
             "points_limit": self.points_limit,
             "points_limit_last_set": self.points_limit_last_set,
@@ -124,7 +132,7 @@ def compute_side_switch(
     *, mode: str, current_set: int, sets_limit: int,
     team1_score: int, team2_score: int,
     points_limit: int, points_limit_last_set: int,
-) -> dict | None:
+) -> BeachSideSwitchData | None:
     """Return the beach side-switch indicator for the current set.
 
     Returns ``None`` for non-beach modes — callers attach the field

--- a/app/api/middleware/auth_rate_limit.py
+++ b/app/api/middleware/auth_rate_limit.py
@@ -67,6 +67,8 @@ import time
 from collections import OrderedDict, deque
 from collections.abc import Iterable
 
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
 _MAX_CLIENTS = 4096
 
 # Surface name -> (watched path prefixes, statuses that count as a failure).
@@ -131,7 +133,7 @@ _buckets: OrderedDict[tuple[str, str], _Bucket] = OrderedDict()
 _lock = asyncio.Lock()
 
 
-def _client_ip(scope) -> str:
+def _client_ip(scope: Scope) -> str:
     """Best-effort peer identifier from the ASGI scope.
 
     Reads ``scope["client"]`` only — uvicorn populates this from the
@@ -221,10 +223,15 @@ def _reset_for_tests() -> None:
 class AuthRateLimitMiddleware:
     """Pure-ASGI middleware enforcing the per-(surface, IP) failure limit."""
 
-    def __init__(self, app) -> None:
+    def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
         # WebSocket handshakes arrive as scope type "websocket" and are not
         # observable here — see the module docstring.
         if scope["type"] != "http":
@@ -246,7 +253,7 @@ class AuthRateLimitMiddleware:
 
         status_holder = {"code": 0}
 
-        async def send_wrapper(message):
+        async def send_wrapper(message: Message) -> None:
             if message.get("type") == "http.response.start":
                 status_holder["code"] = int(message.get("status") or 0)
             await send(message)
@@ -266,7 +273,7 @@ def _record_block(surface: str) -> None:
         pass
 
 
-async def _send_429(send) -> None:
+async def _send_429(send: Send) -> None:
     body = (
         b'{"detail":"Too many authentication failures. '
         b'Please retry later."}'

--- a/app/api/middleware/body_limit.py
+++ b/app/api/middleware/body_limit.py
@@ -19,6 +19,8 @@ errors earlier) stay where they are.
 import json
 import logging
 
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
 from app.constants import REQUEST_MAX_BODY_BYTES
 
 logger = logging.getLogger(__name__)
@@ -27,11 +29,20 @@ logger = logging.getLogger(__name__)
 class BodySizeLimitMiddleware:
     """Reject request bodies larger than *max_bytes* with a 413."""
 
-    def __init__(self, app, max_bytes: int = REQUEST_MAX_BODY_BYTES):
+    def __init__(
+        self,
+        app: ASGIApp,
+        max_bytes: int = REQUEST_MAX_BODY_BYTES,
+    ) -> None:
         self.app = app
         self.max_bytes = max_bytes
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
@@ -46,14 +57,16 @@ class BodySizeLimitMiddleware:
             except ValueError:
                 pass  # malformed header — let the framework reject it
 
-        state = {"received": 0, "response_started": False, "tripped": False}
+        received = 0
+        tripped = False
 
-        async def limited_receive():
+        async def limited_receive() -> Message:
+            nonlocal received, tripped
             message = await receive()
             if message["type"] == "http.request":
-                state["received"] += len(message.get("body", b""))
-                if state["received"] > self.max_bytes:
-                    state["tripped"] = True
+                received += len(message.get("body", b""))
+                if received > self.max_bytes:
+                    tripped = True
                     logger.warning(
                         "Request body exceeded REQUEST_MAX_BODY_BYTES (%d) for %s %s",
                         self.max_bytes, scope.get("method"), scope.get("path"),
@@ -63,14 +76,13 @@ class BodySizeLimitMiddleware:
                     return {"type": "http.request", "body": b"", "more_body": False}
             return message
 
-        async def guarded_send(message):
+        async def guarded_send(message: Message) -> None:
             if message["type"] == "http.response.start":
-                if state["tripped"]:
+                if tripped:
                     # Replace whatever the app produced from the truncated
                     # body with the 413.
                     await self._send_413(send)
                     raise _ResponseSent()
-                state["response_started"] = True
             # A response that started before the cap tripped (streaming
             # handler) passes through untouched — too late to replace it.
             await send(message)
@@ -81,7 +93,7 @@ class BodySizeLimitMiddleware:
             pass
 
     @staticmethod
-    async def _send_413(send):
+    async def _send_413(send: Send) -> None:
         body = json.dumps({"detail": "Request body is too large."}).encode()
         await send({
             "type": "http.response.start",

--- a/app/api/middleware/errors.py
+++ b/app/api/middleware/errors.py
@@ -20,6 +20,7 @@ tools without parsing the free-form message.
 import logging
 
 from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from app.logging_context import get_request_id
 
@@ -27,10 +28,15 @@ logger = logging.getLogger(__name__)
 
 
 class ExceptionLoggingMiddleware:
-    def __init__(self, app):
+    def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
         if scope["type"] not in ("http", "websocket"):
             await self.app(scope, receive, send)
             return

--- a/app/api/middleware/logging.py
+++ b/app/api/middleware/logging.py
@@ -9,6 +9,8 @@ correlate their own logs with ours.
 
 from urllib.parse import parse_qs
 
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
 from app.logging_context import (
     new_request_id,
     oid_var,
@@ -21,10 +23,15 @@ REQUEST_ID_HEADER = b"x-request-id"
 class RequestContextMiddleware:
     """Pure-ASGI middleware: works for both ``http`` and ``websocket`` scopes."""
 
-    def __init__(self, app):
+    def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
         if scope["type"] not in ("http", "websocket"):
             await self.app(scope, receive, send)
             return
@@ -35,7 +42,7 @@ class RequestContextMiddleware:
         rid_token = request_id_var.set(rid)
         oid_token = oid_var.set(oid or "-")
 
-        async def send_wrapper(message):
+        async def send_wrapper(message: Message) -> None:
             if (
                 scope["type"] == "http"
                 and message.get("type") == "http.response.start"
@@ -52,14 +59,14 @@ class RequestContextMiddleware:
             oid_var.reset(oid_token)
 
 
-def _extract_request_id(scope) -> str | None:
+def _extract_request_id(scope: Scope) -> str | None:
     for key, value in scope.get("headers") or ():
         if key == REQUEST_ID_HEADER:
             return value.decode("latin-1").strip() or None
     return None
 
 
-def _extract_oid(scope) -> str | None:
+def _extract_oid(scope: Scope) -> str | None:
     qs = scope.get("query_string") or b""
     if not qs:
         return None

--- a/app/api/middleware/metrics.py
+++ b/app/api/middleware/metrics.py
@@ -15,14 +15,21 @@ from __future__ import annotations
 
 import time
 
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
 from app.metrics import http_request_duration_seconds
 
 
 class MetricsMiddleware:
-    def __init__(self, app):
+    def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
@@ -30,7 +37,7 @@ class MetricsMiddleware:
         start = time.monotonic()
         status_code_holder = {"code": 0}
 
-        async def _send(message):
+        async def _send(message: Message) -> None:
             if message["type"] == "http.response.start":
                 status_code_holder["code"] = int(message.get("status", 0))
             await send(message)

--- a/app/api/middleware/security_headers.py
+++ b/app/api/middleware/security_headers.py
@@ -44,6 +44,7 @@ from collections.abc import Iterable
 from urllib.parse import urlsplit
 
 import idna
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.env_vars_manager import EnvVarsManager
 
@@ -304,7 +305,12 @@ class SecurityHeadersMiddleware:
     ``bootstrap`` are respected).
     """
 
-    def __init__(self, app, *, hsts_seconds: int | None = None) -> None:
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        hsts_seconds: int | None = None,
+    ) -> None:
         self.app = app
         # HSTS is opt-in: setting it on a deployment that's not HTTPS-only
         # will lock browsers out. Operators enable it via env var.
@@ -316,14 +322,19 @@ class SecurityHeadersMiddleware:
                 hsts_seconds = None
         self._hsts_seconds = hsts_seconds
 
-    async def __call__(self, scope, receive, send):
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
 
         path = scope.get("path", "") or ""
 
-        async def send_wrapper(message):
+        async def send_wrapper(message: Message) -> None:
             if message.get("type") != "http.response.start":
                 await send(message)
                 return

--- a/app/api/overlay_links_service.py
+++ b/app/api/overlay_links_service.py
@@ -13,14 +13,17 @@ from app.env_vars_manager import EnvVarsManager
 logger = logging.getLogger(__name__)
 
 
-async def build_overlay_links(request: Request, session: GameSession):
+async def build_overlay_links(
+    request: Request,
+    session: GameSession,
+) -> dict[str, str]:
     """Return overlay, preview, and spectator links for the session."""
     # ``raw_oid`` for backend resolution; ``skey`` (== session.oid) for
     # per-user archive lookups.
     oid = session.raw_oid
     skey = session.oid
     output = session.conf.output
-    links = {}
+    links: dict[str, str] = {}
 
     if output and output.strip():
         links["overlay"] = output
@@ -77,7 +80,7 @@ async def build_overlay_links(request: Request, session: GameSession):
     return links
 
 
-def _latest_match_id_for(oid: str):
+def _latest_match_id_for(oid: str) -> str | None:
     """Return the most-recent ``match_id`` archived for *oid*, or ``None``."""
     summaries = match_archive.list_matches(oid=oid, limit=1)
     return summaries[0]["match_id"] if summaries else None

--- a/app/api/routes/admin_users.py
+++ b/app/api/routes/admin_users.py
@@ -51,7 +51,7 @@ def list_users(
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
     page: Page = PageDep,
-):
+) -> list[UserOut]:
     with_total(response, service.count_users(db))
     rows = service.list_users(db, limit=page.limit, offset=page.offset)
     return [UserOut.from_user(u) for u in rows]
@@ -62,7 +62,7 @@ def create_user(
     body: AdminCreateUserRequest,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> TempPasswordResponse:
     """Create a user. With no password, a temp one is minted and returned;
     the user must change it on first login."""
     # Treat a falsy password (None or "") uniformly: mint a temp password and
@@ -90,7 +90,7 @@ def update_user(
     body: AdminUpdateUserRequest,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> UserOut:
     user = service.get_by_id(db, user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found.")
@@ -110,7 +110,7 @@ def reset_password(
     user_id: int,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> TempPasswordResponse:
     """Reset a user to a temporary password (forced change on next login)
     and log out all their existing sessions."""
     from app.auth import sessions
@@ -128,7 +128,7 @@ def delete_user(
     user_id: int,
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, bool]:
     user = service.get_by_id(db, user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found.")
@@ -155,7 +155,10 @@ def delete_user(
 
 
 @router.get("/registration", response_model=RegistrationSetting)
-def get_registration(_admin: User = Depends(require_admin), db: Session = Depends(get_db, scope="function")):
+def get_registration(
+    _admin: User = Depends(require_admin),
+    db: Session = Depends(get_db, scope="function"),
+) -> RegistrationSetting:
     return RegistrationSetting(registration_open=settings_service.registration_open(db))
 
 
@@ -164,7 +167,7 @@ def set_registration(
     body: RegistrationSetting,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> RegistrationSetting:
     settings_service.set_registration_open(db, body.registration_open)
     return RegistrationSetting(registration_open=body.registration_open)
 
@@ -176,7 +179,7 @@ async def replay_dead_letter_webhooks(
         None, description="Only replay records whose ts is >= this Unix-seconds value."),
     max_records: int = Query(
         50, ge=1, le=500, description="Cap the records redelivered in this call."),
-):
+) -> dict[str, int]:
     """Replay a slice of the webhook dead-letter file (oldest first).
 
     Successful redeliveries are removed; unknown-URL and still-failing records

--- a/app/api/routes/audit.py
+++ b/app/api/routes/audit.py
@@ -1,5 +1,7 @@
 """GET /audit — read recent action audit records for a session."""
 
+from typing import Any
+
 from fastapi import APIRouter, Depends, Query
 
 from app.api import action_log
@@ -24,7 +26,7 @@ async def get_audit_log(
             "the previous response. Omit for the first page."
         ),
     ),
-):
+) -> dict[str, Any]:
     """Return one page of audit records, newest page first.
 
     First call (``before_ts`` omitted) returns the most recent

--- a/app/api/routes/customization.py
+++ b/app/api/routes/customization.py
@@ -14,6 +14,7 @@ both sources in a single list. System presets cannot be deleted.
 """
 
 import logging
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Response, status
 from sqlalchemy.orm import Session
@@ -43,7 +44,9 @@ router = APIRouter()
 
 
 @router.get("/customization")
-async def get_customization(session: GameSession = Depends(get_session)):
+async def get_customization(
+    session: GameSession = Depends(get_session),
+) -> dict[str, Any]:
     return await run_in_threadpool(GameService.refresh_customization, session)
 
 
@@ -54,7 +57,7 @@ async def get_customization(session: GameSession = Depends(get_session)):
 async def update_customization(
     data: CustomizationUpdateRequest,
     session: GameSession = Depends(get_session),
-):
+) -> ActionResponse:
     async with session.lock:
         logger.debug("Customization updated (%d keys)", len(data.root))
         return GameService.update_customization(session, data.root)
@@ -176,7 +179,7 @@ def admin_set_preset_active(
     slug: str = Path(..., min_length=1, max_length=120),
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, str | bool]:
     preset = presets_service.set_global_active(db, slug, body.is_active)
     return {"slug": preset.slug, "is_active": preset.is_active}
 
@@ -199,7 +202,7 @@ def admin_delete_preset(
 def admin_export_presets(
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, dict[str, Any]]:
     return presets_service.export_app_themes(db)
 
 
@@ -208,6 +211,6 @@ def admin_import_presets(
     body: ImportThemesRequest,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, int]:
     count = presets_service.import_app_themes(db, body.themes, replace=body.replace)
     return {"imported": count}

--- a/app/api/routes/display.py
+++ b/app/api/routes/display.py
@@ -26,7 +26,7 @@ router = APIRouter()
     response_model=ActionResponse,
 )
 async def set_visibility(req: VisibilityRequest,
-                         session: GameSession = Depends(get_session)):
+                         session: GameSession = Depends(get_session)) -> ActionResponse:
     async with session.lock:
         logger.debug("Overlay visibility set to %s", req.visible)
         return GameService.set_visibility(session, req.visible)
@@ -37,7 +37,7 @@ async def set_visibility(req: VisibilityRequest,
     response_model=ActionResponse,
 )
 async def set_simple_mode(req: SimpleModeRequest,
-                          session: GameSession = Depends(get_session)):
+                          session: GameSession = Depends(get_session)) -> ActionResponse:
     async with session.lock:
         logger.debug("Simple mode set to %s", req.enabled)
         return GameService.set_simple_mode(session, req.enabled)
@@ -48,7 +48,7 @@ async def set_simple_mode(req: SimpleModeRequest,
     response_model=ActionResponse,
 )
 async def set_swap_sides(req: SwapSidesRequest,
-                         session: GameSession = Depends(get_session)):
+                         session: GameSession = Depends(get_session)) -> ActionResponse:
     """Set the effective display orientation (True = team 2 left)."""
     async with session.lock:
         logger.debug("Sides swapped set to %s", req.swapped)
@@ -60,7 +60,7 @@ async def set_swap_sides(req: SwapSidesRequest,
     response_model=ActionResponse,
 )
 async def set_auto_swap_sides(req: AutoSwapSidesRequest,
-                              session: GameSession = Depends(get_session)):
+                              session: GameSession = Depends(get_session)) -> ActionResponse:
     """Toggle automatic side swapping (set changes + mid-set points)."""
     async with session.lock:
         logger.debug("Auto swap sides set to %s", req.enabled)
@@ -72,7 +72,7 @@ async def set_auto_swap_sides(req: AutoSwapSidesRequest,
     response_model=ActionResponse,
 )
 async def set_set_summary(req: SetSummaryRequest,
-                          session: GameSession = Depends(get_session)):
+                          session: GameSession = Depends(get_session)) -> ActionResponse:
     """Toggle the set-summary overlay panel on/off."""
     async with session.lock:
         logger.debug("Set summary mode set to %s", req.enabled)
@@ -84,7 +84,7 @@ async def set_set_summary(req: SetSummaryRequest,
     response_model=ActionResponse,
 )
 async def set_set_summary_style(req: SetSummaryStyleRequest,
-                                session: GameSession = Depends(get_session)):
+                                session: GameSession = Depends(get_session)) -> ActionResponse:
     """Pick the visual variant for the set-summary overlay."""
     async with session.lock:
         logger.debug("Set summary style set to %s", req.style)

--- a/app/api/routes/game.py
+++ b/app/api/routes/game.py
@@ -22,7 +22,7 @@ router = APIRouter()
     response_model=ActionResponse,
 )
 async def add_point(req: AddPointRequest,
-                    session: GameSession = Depends(get_session)):
+                    session: GameSession = Depends(get_session)) -> ActionResponse:
     async with session.lock:
         return GameService.add_point(
             session, req.team, req.undo,
@@ -35,7 +35,7 @@ async def add_point(req: AddPointRequest,
     response_model=ActionResponse,
 )
 async def add_set(req: TeamActionRequest,
-                  session: GameSession = Depends(get_session)):
+                  session: GameSession = Depends(get_session)) -> ActionResponse:
     async with session.lock:
         return GameService.add_set(session, req.team, req.undo)
 
@@ -45,7 +45,7 @@ async def add_set(req: TeamActionRequest,
     response_model=ActionResponse,
 )
 async def add_timeout(req: TeamActionRequest,
-                      session: GameSession = Depends(get_session)):
+                      session: GameSession = Depends(get_session)) -> ActionResponse:
     async with session.lock:
         return GameService.add_timeout(session, req.team, req.undo)
 
@@ -55,7 +55,7 @@ async def add_timeout(req: TeamActionRequest,
     response_model=ActionResponse,
 )
 async def change_serve(req: ServeRequest,
-                       session: GameSession = Depends(get_session)):
+                       session: GameSession = Depends(get_session)) -> ActionResponse:
     async with session.lock:
         return GameService.change_serve(session, req.team)
 
@@ -65,7 +65,7 @@ async def change_serve(req: ServeRequest,
     response_model=ActionResponse,
 )
 async def set_score(req: SetScoreRequest,
-                    session: GameSession = Depends(get_session)):
+                    session: GameSession = Depends(get_session)) -> ActionResponse:
     async with session.lock:
         return GameService.set_score(session, req.team, req.set_number, req.value)
 
@@ -75,7 +75,7 @@ async def set_score(req: SetScoreRequest,
     response_model=ActionResponse,
 )
 async def set_sets(req: SetSetsRequest,
-                   session: GameSession = Depends(get_session)):
+                   session: GameSession = Depends(get_session)) -> ActionResponse:
     async with session.lock:
         return GameService.set_sets_value(session, req.team, req.value)
 
@@ -84,7 +84,7 @@ async def set_sets(req: SetSetsRequest,
     "/game/reset",
     response_model=ActionResponse,
 )
-async def reset_game(session: GameSession = Depends(get_session)):
+async def reset_game(session: GameSession = Depends(get_session)) -> ActionResponse:
     async with session.lock:
         return GameService.reset(session)
 
@@ -94,7 +94,7 @@ async def reset_game(session: GameSession = Depends(get_session)):
     response_model=ActionResponse,
     summary="Arm the match-start timer without scoring a point",
 )
-async def start_match(session: GameSession = Depends(get_session)):
+async def start_match(session: GameSession = Depends(get_session)) -> ActionResponse:
     """Stamps ``match_started_at`` with the current wallclock if the
     match isn't already armed. Idempotent — a second call leaves the
     original anchor in place. The HUD timer / report duration / undo
@@ -109,7 +109,7 @@ async def start_match(session: GameSession = Depends(get_session)):
     response_model=ActionResponse,
     summary="Reverse the most recent undoable action",
 )
-async def undo_last(session: GameSession = Depends(get_session)):
+async def undo_last(session: GameSession = Depends(get_session)) -> ActionResponse:
     """Pops the most recent forward ``add_point`` / ``add_set`` /
     ``add_timeout`` from the audit log and applies the inverse via
     ``undo=True``. Returns ``success=false`` with message

--- a/app/api/routes/icons.py
+++ b/app/api/routes/icons.py
@@ -240,7 +240,7 @@ def list_icons(
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
     page: Page = PageDep,
-):
+) -> IconLibraryOut:
     """Globals + the caller's own + quota.
 
     ``limit``/``offset`` page the **global** library, which is deliberately
@@ -272,7 +272,7 @@ async def upload_my_icon(
     file: UploadFile = File(...),
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> IconOut:
     return await _create_icon_endpoint(db, name=name, file=file, user_id=user.id)
 
 
@@ -282,7 +282,7 @@ def rename_my_icon(
     body: IconRenameRequest,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> IconOut:
     return _rename_endpoint(db, icon_id, body.name, user_id=user.id)
 
 
@@ -291,7 +291,7 @@ def my_icon_usage(
     icon_id: int,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> IconUsageOut:
     icon = _get_scoped_or_404(db, icon_id, user_id=user.id)
     return IconUsageOut(teams=icons_service.usage_count(db, icon))
 
@@ -301,7 +301,7 @@ def delete_my_icon(
     icon_id: int,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> IconDeleteOut:
     return _delete_endpoint(db, icon_id, user_id=user.id)
 
 
@@ -310,7 +310,7 @@ def import_icons_from_my_teams(
     body: IconImportRequest,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> IconImportOut:
     return _import_endpoint(db, body.team_ids, scope_user_id=user.id)
 
 
@@ -328,7 +328,7 @@ async def admin_upload_icon(
     file: UploadFile = File(...),
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> IconOut:
     return await _create_icon_endpoint(db, name=name, file=file, user_id=None)
 
 
@@ -338,7 +338,7 @@ def admin_rename_icon(
     body: IconRenameRequest,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> IconOut:
     return _rename_endpoint(db, icon_id, body.name, user_id=None)
 
 
@@ -347,7 +347,7 @@ def admin_icon_usage(
     icon_id: int,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> IconUsageOut:
     icon = _get_scoped_or_404(db, icon_id, user_id=None)
     return IconUsageOut(teams=icons_service.usage_count(db, icon))
 
@@ -357,7 +357,7 @@ def admin_delete_icon(
     icon_id: int,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> IconDeleteOut:
     return _delete_endpoint(db, icon_id, user_id=None)
 
 
@@ -366,5 +366,5 @@ def admin_import_icons_from_teams(
     body: IconImportRequest,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> IconImportOut:
     return _import_endpoint(db, body.team_ids, scope_user_id=None)

--- a/app/api/routes/lifespan.py
+++ b/app/api/routes/lifespan.py
@@ -2,8 +2,11 @@
 
 import asyncio
 import logging
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from weakref import WeakValueDictionary
+
+from fastapi import FastAPI
 
 from app.api.session_manager import SessionManager
 from app.api.webhooks import webhook_dispatcher
@@ -17,8 +20,8 @@ logger = logging.getLogger(__name__)
 # so the two knobs stay independent.
 _GAME_SESSION_CLEANUP_INTERVAL_SECONDS = 3600
 
-_cleanup_task: asyncio.Task | None = None
-_auth_sweep_task: asyncio.Task | None = None
+_cleanup_task: asyncio.Task[None] | None = None
+_auth_sweep_task: asyncio.Task[None] | None = None
 # WeakValueDictionary auto-evicts entries once all strong refs to the lock are
 # released — i.e. once every caller has exited its ``async with get_init_lock``
 # block. This avoids a race where a manual cleanup could delete a lock between
@@ -36,7 +39,7 @@ def get_init_lock(oid: str) -> asyncio.Lock:
     return lock
 
 
-async def _session_cleanup_loop():
+async def _session_cleanup_loop() -> None:
     """Periodically remove expired in-memory game sessions."""
     while True:
         await asyncio.sleep(_GAME_SESSION_CLEANUP_INTERVAL_SECONDS)
@@ -61,7 +64,7 @@ def purge_expired_auth_sessions() -> int:
         return auth_sessions.purge_expired(db)
 
 
-async def _auth_session_sweep_loop():
+async def _auth_session_sweep_loop() -> None:
     """Periodically purge expired login sessions from the database.
 
     ``resolve_session`` only drops an expired row when its own token is
@@ -87,7 +90,7 @@ async def _auth_session_sweep_loop():
 
 
 @asynccontextmanager
-async def router_lifespan(app):
+async def router_lifespan(app: FastAPI) -> AsyncIterator[None]:
     global _cleanup_task, _auth_sweep_task
     _cleanup_task = asyncio.create_task(_session_cleanup_loop())
     # 0 disables the sweep entirely (operators running an external janitor).

--- a/app/api/routes/live_stats.py
+++ b/app/api/routes/live_stats.py
@@ -1,5 +1,7 @@
 """GET /matches/live/stats — live match statistics derived from audit."""
 
+from typing import Any
+
 from fastapi import APIRouter, Depends, Query
 
 from app.api.dependencies import get_session
@@ -21,7 +23,7 @@ async def get_live_stats(
         le=200,
         description="Maximum number of recent points returned in ``points_history``.",
     ),
-):
+) -> dict[str, Any]:
     """Return rolling stats computed from the per-OID audit log.
 
     The payload reconciles with the post-match report so external

--- a/app/api/routes/matches.py
+++ b/app/api/routes/matches.py
@@ -6,6 +6,7 @@ human-facing ``oid`` (never the internal storage key) in responses.
 """
 
 import time
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
@@ -18,7 +19,7 @@ from app.overlay_key import is_valid_skey, make_skey, split_skey
 router = APIRouter()
 
 
-def _present(summary: dict) -> dict:
+def _present(summary: dict[str, Any]) -> dict[str, Any]:
     """Return a copy with the storage-key ``oid`` mapped to the raw oid."""
     out = dict(summary)
     skey = out.get("oid")
@@ -48,7 +49,7 @@ def list_matches(
     limit: int = Query(100, ge=1, le=500, description="Page size"),
     offset: int = Query(0, ge=0, description="Rows to skip (newest first)"),
     user: User = Depends(require_user),
-):
+) -> dict[str, Any]:
     """Return a page of the caller's archived matches, newest first.
 
     ``count`` is the total in scope (not the page length), so a client can
@@ -76,7 +77,10 @@ def list_matches(
 
 
 @router.get("/matches/{match_id}", summary="Full archived match snapshot")
-def get_match(match_id: str, user: User = Depends(require_user)):
+def get_match(
+    match_id: str,
+    user: User = Depends(require_user),
+) -> dict[str, Any]:
     payload = match_archive.load_match(match_id)
     if payload is None or not _owns(payload.get("oid"), user):
         raise HTTPException(status_code=404, detail="Match not found.")
@@ -84,7 +88,7 @@ def get_match(match_id: str, user: User = Depends(require_user)):
 
 
 @router.delete("/matches/{match_id}", status_code=204, summary="Delete one of the caller's matches")
-def delete_match(match_id: str, user: User = Depends(require_user)):
+def delete_match(match_id: str, user: User = Depends(require_user)) -> None:
     _require_owned(match_id, user)
     match_archive.delete_match(match_id)
 
@@ -95,7 +99,7 @@ def sign_match_url(
     request: Request,
     ttl_seconds: int | None = Query(None, description="URL lifetime in seconds."),
     user: User = Depends(require_user),
-):
+) -> dict[str, str | int]:
     """Return a short-lived capability URL for the caller's own match report.
 
     The URL embeds an HMAC signature (key: SESSION_SECRET), so it can be

--- a/app/api/routes/metrics.py
+++ b/app/api/routes/metrics.py
@@ -29,7 +29,7 @@ router = APIRouter()
     summary="Prometheus exposition",
     response_class=Response,
 )
-def metrics_endpoint():
+def metrics_endpoint() -> Response:
     """Return the registry's current exposition in Prometheus text format."""
     if not PROMETHEUS_AVAILABLE:
         raise HTTPException(

--- a/app/api/routes/overlays.py
+++ b/app/api/routes/overlays.py
@@ -3,6 +3,7 @@
 import logging
 import urllib.parse
 from functools import partial
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from sqlalchemy.orm import Session
@@ -17,6 +18,7 @@ from app.api.schemas import CreateOverlayRequest, OverlayOut, UpdateOverlayReque
 from app.api.session_manager import GameSession
 from app.auth.dependencies import require_user
 from app.db.engine import after_commit, get_db
+from app.db.models.overlay import UserOverlay
 from app.db.models.user import User
 from app.env_vars_manager import EnvVarsManager
 
@@ -37,7 +39,12 @@ def _delete_overlay_runtime(skey: str) -> None:
     match_archive.delete_for_oid(skey)
 
 
-def _overlay_out(request: Request, overlay, *, username: str | None = None) -> OverlayOut:
+def _overlay_out(
+    request: Request,
+    overlay: UserOverlay,
+    *,
+    username: str | None = None,
+) -> OverlayOut:
     public_url = (EnvVarsManager.get_env_var("OVERLAY_PUBLIC_URL", "") or "").rstrip("/")
     base = public_url or str(request.base_url).rstrip("/")
     local_url = f"{base}/overlay/{overlay.public_token}"
@@ -68,7 +75,7 @@ def list_my_overlays(
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
     page: Page = PageDep,
-):
+) -> list[OverlayOut]:
     """Return the overlays owned by the caller."""
     with_total(response, overlays_service.count_overlays(db, user.id))
     return [
@@ -85,7 +92,7 @@ def create_my_overlay(
     request: Request,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> OverlayOut:
     """Register a new overlay for the caller (mints a public output token)."""
     overlay = overlays_service.create_overlay(
         db,
@@ -103,7 +110,7 @@ def update_my_overlay(
     request: Request,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> OverlayOut:
     """Edit an overlay's description and no-login control toggle.
 
     Only the fields present in the request body are changed (``exclude_unset``),
@@ -123,7 +130,7 @@ def delete_my_overlay(
     oid: str,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, bool]:
     """Delete one of the caller's overlays and its in-process session/state.
 
     Sync handler — the whole body (DB delete, state-store and archive file
@@ -144,7 +151,7 @@ def regenerate_control_token(
     request: Request,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> OverlayOut:
     """Mint a fresh control token for one of the caller's overlays.
 
     This revokes any previously-shared control link for that board.
@@ -162,19 +169,23 @@ def regenerate_control_token(
 async def get_links(
     request: Request,
     session: GameSession = Depends(get_session),
-):
+) -> dict[str, str]:
     """Return overlay, preview, spectator, and public-report links."""
     return await build_overlay_links(request, session)
 
 
 @router.get("/styles")
-async def get_styles(session: GameSession = Depends(get_session)):
+async def get_styles(
+    session: GameSession = Depends(get_session),
+) -> list[str]:
     """Return available overlay styles."""
     return await run_in_threadpool(session.backend.get_available_styles)
 
 
 @router.get("/style-capabilities")
-async def get_style_capabilities(session: GameSession = Depends(get_session)):
+async def get_style_capabilities(
+    session: GameSession = Depends(get_session),
+) -> dict[str, Any]:
     """Per-style UI capability flags (theme / vertical-anchor support).
 
     The control UI uses this to only surface the dark/light theme selector

--- a/app/api/routes/session.py
+++ b/app/api/routes/session.py
@@ -25,7 +25,7 @@ router = APIRouter()
 async def init_session(
     req: InitRequest,
     access: BoardAccess = Depends(board_access),
-):
+) -> ActionResponse:
     """Initialise (or re-use) a game session for an overlay.
 
     Reachable by the owner (cookie + ``oid``), an operator holding the overlay's
@@ -112,7 +112,7 @@ async def init_session(
 async def set_rules(
     req: SetRulesRequest,
     session: GameSession = Depends(get_session),
-):
+) -> ActionResponse:
     """Update match-rule preset for the session.
 
     All fields are optional. ``mode`` accepts ``"indoor"`` or

--- a/app/api/routes/state.py
+++ b/app/api/routes/state.py
@@ -14,12 +14,16 @@ router = APIRouter()
     "/state",
     response_model=GameStateResponse,
 )
-async def get_state(session: GameSession = Depends(get_session)):
+async def get_state(
+    session: GameSession = Depends(get_session),
+) -> GameStateResponse:
     return GameService.get_state(session)
 
 
 @router.get("/config")
-async def get_config(session: GameSession = Depends(get_session)):
+async def get_config(
+    session: GameSession = Depends(get_session),
+) -> dict[str, int]:
     return {
         "points_limit": session.points_limit,
         "points_limit_last_set": session.points_limit_last_set,

--- a/app/api/routes/teams.py
+++ b/app/api/routes/teams.py
@@ -17,7 +17,7 @@ deletes one outright. Ownership alone puts a team in the virtual "All" group.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from sqlalchemy.orm import Session
@@ -73,7 +73,7 @@ def catalog(
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
     page: Page = PageDep,
-):
+) -> list[TeamOut]:
     """The team catalog, paged.
 
     ``scope=all`` exists so the "All teams" roster has a pageable home of its
@@ -98,7 +98,7 @@ def create_my_custom_team(
     body: CustomTeamRequest,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> TeamOut:
     """Create a personal team and add it to the caller's list."""
     team = teams_service.create_user_team(
         db,
@@ -117,7 +117,7 @@ def update_my_custom_team(
     body: CustomTeamUpdateRequest,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> TeamOut:
     """Edit one of the caller's own custom teams."""
     team = teams_service.update_user_team(
         db,
@@ -136,7 +136,7 @@ def delete_my_custom_team(
     team_id: int,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, bool]:
     """Delete one of the caller's own custom teams, dropping it from every group.
 
     Global teams belong to the admin catalog — remove those from a single group
@@ -155,7 +155,7 @@ def admin_create_team(
     body: AdminTeamRequest,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> TeamOut:
     team = teams_service.upsert_global(
         db,
         body.name,
@@ -172,7 +172,7 @@ def admin_update_team(
     body: AdminTeamUpdateRequest,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> TeamOut:
     team = teams_service.update_global(
         db,
         team_id,
@@ -189,7 +189,7 @@ def admin_delete_team(
     team_id: int,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, bool]:
     if not teams_service.delete_global(db, team_id):
         raise HTTPException(status_code=404, detail="Team not found.")
     return {"ok": True}
@@ -199,7 +199,7 @@ def admin_delete_team(
 def admin_export_teams(
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, dict[str, Any]]:
     """Export the global catalog as an APP_TEAMS JSON map."""
     return teams_service.export_app_teams(db)
 
@@ -209,7 +209,7 @@ def admin_import_teams(
     body: ImportTeamsRequest,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, int]:
     """Import an APP_TEAMS JSON map into the global catalog (upsert by name)."""
     count = teams_service.import_app_teams(db, body.teams, replace=body.replace)
     return {"imported": count}
@@ -224,7 +224,7 @@ def admin_list_groups(
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
     page: Page = PageDep,
-):
+) -> list[TeamGroupOut]:
     """Every group (active and inactive) with its members — drives the admin
     group manager."""
     with_total(response, teams_service.count_all_groups(db))
@@ -238,7 +238,7 @@ def admin_create_group(
     body: CreateGroupRequest,
     admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> TeamGroupOut:
     group = teams_service.create_group(db, body.name, created_by_user_id=admin.id)
     return TeamGroupOut(id=group.id, name=group.name, is_active=group.is_active, teams=[])
 
@@ -249,7 +249,7 @@ def admin_add_group_member(
     body: GroupMemberRequest,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, bool]:
     if teams_service.get_shared_group(db, group_id) is None:
         raise HTTPException(status_code=404, detail="Group not found.")
     team = db.get(Team, body.team_id)
@@ -268,7 +268,7 @@ def admin_remove_group_member(
     team_id: int,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, bool | int]:
     if teams_service.get_shared_group(db, group_id) is None:
         raise HTTPException(status_code=404, detail="Group not found.")
     removed = teams_service.remove_group_member(db, group_id, team_id)
@@ -281,7 +281,7 @@ def admin_set_group_active(
     body: TeamGroupSetActiveRequest,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, bool | int]:
     group = teams_service.set_group_active(db, group_id, body.is_active)
     return {"id": group.id, "is_active": group.is_active}
 
@@ -291,7 +291,7 @@ def admin_delete_group(
     group_id: int,
     _admin: User = Depends(require_admin),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, bool]:
     if not teams_service.delete_group(db, group_id):
         raise HTTPException(status_code=404, detail="Group not found.")
     return {"ok": True}
@@ -308,7 +308,7 @@ def admin_delete_group(
 def board_team_groups(
     skey: str = Depends(board_skey),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> BoardGroupListOut:
     owner_id, _oid = split_skey(skey)
     return team_groups_service.board_group_list(db, owner_id, skey)
 
@@ -318,7 +318,7 @@ def board_group_teams(
     group_key: str,
     skey: str = Depends(board_skey),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, dict[str, Any]]:
     """The APP_TEAMS map for one group, consumed by the board team selectors."""
     owner_id, _oid = split_skey(skey)
     group_id = team_groups_service.parse_group_key(group_key)
@@ -330,7 +330,7 @@ def board_select_group(
     body: SelectGroupRequest,
     session: GameSession = Depends(get_session),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, bool | int | None]:
     owner_id, _oid = split_skey(session.skey)
     if (
         body.group_id is not None
@@ -359,7 +359,7 @@ def my_visible_groups(
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
     page: Page = PageDep,
-):
+) -> list[GroupDetailOut]:
     """The caller's selectable groups: the synthetic "All" first, then shared
     published groups and the user's own private groups, each with their teams.
 
@@ -389,7 +389,7 @@ def create_my_group(
     body: CreateMyGroupRequest,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> GroupDetailOut:
     group = teams_service.create_private_group(db, user.id, body.name)
     return team_groups_service.group_detail(db, user.id, group)
 
@@ -400,7 +400,7 @@ def rename_my_group(
     body: RenameMyGroupRequest,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> GroupDetailOut:
     group = teams_service.rename_private_group(db, user.id, group_id, body.name)
     return team_groups_service.group_detail(db, user.id, group)
 
@@ -410,7 +410,7 @@ def delete_my_group(
     group_id: int,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, bool]:
     if not teams_service.delete_private_group(db, user.id, group_id):
         raise HTTPException(status_code=404, detail="Group not found.")
     return {"ok": True}
@@ -422,7 +422,7 @@ def add_teams_to_my_group(
     body: GroupTeamsRequest,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, int]:
     added = teams_service.add_user_group_teams(db, user.id, group_id, body.team_ids)
     return {"added": added}
 
@@ -433,7 +433,7 @@ def remove_team_from_my_group(
     team_id: int,
     user: User = Depends(require_user),
     db: Session = Depends(get_db, scope="function"),
-):
+) -> dict[str, bool | int]:
     if teams_service.get_visible_group(db, user.id, group_id) is None:
         raise HTTPException(status_code=404, detail="Group not found.")
     removed = teams_service.remove_user_group_team(db, user.id, group_id, team_id)

--- a/app/api/routes/websocket.py
+++ b/app/api/routes/websocket.py
@@ -54,7 +54,7 @@ async def websocket_endpoint(
     control: str | None = Query(None, description="Alias of `oid` for backward compatibility"),
     c: str | None = Query(None, description="Control capability token (shareable board link)"),
     u: str | None = Query(None, description="Username for a public ?u=&oid= board URL"),
-):
+) -> None:
     resolved = oid or control
     if not resolved and not c:
         await ws.close(code=4400, reason="Missing 'oid' (or 'c' control token) query parameter.")

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -20,7 +20,7 @@ class InitRequest(BaseModel):
 
     @field_validator("oid")
     @classmethod
-    def validate_oid(cls, v):
+    def validate_oid(cls, v: str) -> str:
         if not API_OID_PATTERN.match(v):
             raise ValueError(
                 'OID must contain only alphanumeric characters, hyphens, underscores, slashes, and dots. ".." is not allowed.'

--- a/app/api/session_manager.py
+++ b/app/api/session_manager.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import threading
 import time
+from typing import Any
 
 from app.api import action_log
 from app.api.match_rules import is_valid_mode
@@ -22,8 +23,15 @@ logger = logging.getLogger(__name__)
 class GameSession:
     """Holds all state for one overlay/match session."""
 
-    def __init__(self, oid, conf, backend,
-                 points_limit=None, points_limit_last_set=None, sets_limit=None):
+    def __init__(
+        self,
+        oid: str,
+        conf: Conf,
+        backend: Backend,
+        points_limit: int | None = None,
+        points_limit_last_set: int | None = None,
+        sets_limit: int | None = None,
+    ) -> None:
         # ``oid`` here is the *storage key* (``<user_id>:<oid>`` for a
         # logged-in user, or a bare id in standalone/legacy/test paths). It
         # is what every per-overlay persistence surface keys on — overlay
@@ -47,7 +55,8 @@ class GameSession:
         # dependency is part of Backend's public surface.
         backend.set_rule_overrides_getter(self._build_rule_overrides)
         self.customization = Customization(
-            backend.get_current_customization())
+            backend.get_current_customization() or {})
+        self._last_customization_fetch: float | None = None
         self.visible = backend.is_visible()
         self.simple = False
         # Set summary overlay (off by default — feature is hidden in the
@@ -120,7 +129,7 @@ class GameSession:
         # set_score, change_serve, set_sets_value) so a stale cache
         # can't trigger a false-positive recovery after the operator
         # moved on.
-        self.rapid_pair_cache: dict[int, dict] = {}
+        self.rapid_pair_cache: dict[int, dict[str, Any]] = {}
         self.points_limit = points_limit if points_limit is not None else conf.points
         self.points_limit_last_set = (
             points_limit_last_set if points_limit_last_set is not None
@@ -143,7 +152,7 @@ class GameSession:
             oid, self.points_limit, self.points_limit_last_set,
             self.sets_limit)
 
-    def _compute_current_set(self):
+    def _compute_current_set(self) -> int:
         state = self.game_manager.get_current_state()
         t1sets = state.get_sets(1)
         t2sets = state.get_sets(2)
@@ -152,7 +161,7 @@ class GameSession:
             current += 1
         return max(1, min(current, self.sets_limit))
 
-    def _build_rule_overrides(self) -> dict:
+    def _build_rule_overrides(self) -> dict[str, Any]:
         """Snapshot of the session's rule fields for the backend payload."""
         return {
             "mode": self.mode,
@@ -174,11 +183,11 @@ class GameSession:
             "auto_swap_sides": bool(self.auto_swap_sides),
         }
 
-    def touch(self):
+    def touch(self) -> None:
         """Update last access time."""
         self.last_accessed = time.monotonic()
 
-    def to_meta_dict(self) -> dict:
+    def to_meta_dict(self) -> dict[str, Any]:
         """Return the session-level fields that should survive restart.
 
         Match-state fields (scores, sets, current_set, serve, timeouts)
@@ -211,7 +220,7 @@ class GameSession:
             ),
         }
 
-    def apply_meta(self, meta: dict) -> None:
+    def apply_meta(self, meta: dict[str, Any]) -> None:
         """Restore session-level fields from a previously persisted dict.
 
         Silently ignores missing or malformed keys so a stale meta file
@@ -259,7 +268,7 @@ class GameSession:
                 except (TypeError, ValueError):
                     pass
 
-    def _restore_optional_float(self, meta: dict, key: str) -> None:
+    def _restore_optional_float(self, meta: dict[str, Any], key: str) -> None:
         """Restore an optional ``float | None`` attribute from *meta*.
 
         Missing key → left untouched. Explicit ``None`` → cleared.
@@ -280,7 +289,7 @@ class GameSession:
         """Best-effort save of :meth:`to_meta_dict` to disk."""
         save_session_meta(self.oid, self.to_meta_dict())
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         """Clean up background resources to prevent leaks."""
         if hasattr(self.backend, 'shutdown'):
             self.backend.shutdown()
@@ -290,13 +299,19 @@ class GameSession:
 class SessionManager:
     """Thread-safe singleton managing GameSession instances by OID."""
 
-    _sessions: dict = {}
+    _sessions: dict[str, GameSession] = {}
     _lock = threading.Lock()
 
     @classmethod
-    def get_or_create(cls, oid, conf=None, backend=None,
-                      points_limit=None, points_limit_last_set=None,
-                      sets_limit=None):
+    def get_or_create(
+        cls,
+        oid: str,
+        conf: Conf | None = None,
+        backend: Backend | None = None,
+        points_limit: int | None = None,
+        points_limit_last_set: int | None = None,
+        sets_limit: int | None = None,
+    ) -> GameSession:
         """Get an existing session or create a new one.
 
         If *conf* or *backend* are ``None`` and the session doesn't exist yet,
@@ -308,7 +323,7 @@ class SessionManager:
         + ``requests.Session``). Lock contention is bounded because the
         fast path (existing session) never enters the construction block.
         """
-        def _apply_limits(session):
+        def _apply_limits(session: GameSession) -> None:
             changed = False
             if points_limit is not None and session.points_limit != points_limit:
                 session.points_limit = points_limit
@@ -365,7 +380,7 @@ class SessionManager:
             return new_session
 
     @classmethod
-    def get(cls, oid):
+    def get(cls, oid: str) -> GameSession | None:
         """Return an existing session or ``None``."""
         with cls._lock:
             session = cls._sessions.get(oid)
@@ -374,7 +389,7 @@ class SessionManager:
             return session
 
     @classmethod
-    def peek(cls, oid):
+    def peek(cls, oid: str) -> GameSession | None:
         """Return an existing session without bumping ``last_accessed``.
 
         Used by inspect-only paths (admin usage endpoint) that need to
@@ -384,7 +399,7 @@ class SessionManager:
             return cls._sessions.get(oid)
 
     @classmethod
-    def _release_oid_caches(cls, oid):
+    def _release_oid_caches(cls, oid: str) -> None:
         """Drop the process-local caches keyed by *oid*.
 
         Both the parsed audit records and the live-stats payload are held
@@ -401,7 +416,7 @@ class SessionManager:
             logger.exception("Failed to release caches for OID=%s", oid)
 
     @classmethod
-    def remove(cls, oid):
+    def remove(cls, oid: str) -> None:
         """Remove a session (e.g. on disconnect)."""
         with cls._lock:
             session = cls._sessions.pop(oid, None)
@@ -411,7 +426,7 @@ class SessionManager:
         cls._release_oid_caches(oid)
 
     @classmethod
-    def clear(cls):
+    def clear(cls) -> None:
         """Remove all sessions (mainly for testing)."""
         with cls._lock:
             for session in cls._sessions.values():
@@ -420,7 +435,7 @@ class SessionManager:
             set_active_sessions(0)
 
     @classmethod
-    def cleanup_expired(cls):
+    def cleanup_expired(cls) -> int:
         """Remove sessions that have not been accessed within the TTL."""
         now = time.monotonic()
         with cls._lock:

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -87,7 +87,7 @@ def _safe_json_list(raw: str) -> list[dict]:
     return [item for item in parsed if isinstance(item, dict)]
 
 
-def _normalise_events(value) -> set[str] | None:
+def _normalise_events(value: object) -> set[str] | None:
     if value is None:
         return None
     if isinstance(value, str):
@@ -107,7 +107,7 @@ class WebhookTarget:
 
     def __init__(self, url: str, secret: str | None = None,
                  events: Iterable[str] | None = None,
-                 timeout_s: float = _DEFAULT_TIMEOUT_S):
+                 timeout_s: float = _DEFAULT_TIMEOUT_S) -> None:
         self.url = url
         self.secret = secret or None
         self.events = _normalise_events(events)
@@ -127,7 +127,7 @@ class WebhookDispatcher:
     pick up monkey-patched env vars between cases.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._lock = threading.Lock()
         self._targets: list[WebhookTarget] | None = None
         self._executor: ThreadPoolExecutor | None = None

--- a/app/api/ws_hub.py
+++ b/app/api/ws_hub.py
@@ -2,6 +2,8 @@ import asyncio
 import json
 import logging
 import time
+from collections.abc import Callable, Coroutine
+from typing import Any
 
 from fastapi import WebSocket
 
@@ -26,7 +28,7 @@ class WSHubFull(Exception):
     log correlation.
     """
 
-    def __init__(self, oid: str, cap: int):
+    def __init__(self, oid: str, cap: int) -> None:
         super().__init__(
             f"OID {oid!r} is at the {cap}-client cap.")
         self.oid = oid
@@ -42,17 +44,17 @@ class WSHub:
     """
 
     # {oid: set[WebSocket]}
-    _connections: dict = {}
+    _connections: dict[str, set[WebSocket]] = {}
     # Strong references to in-flight fire-and-forget broadcast tasks. Without
     # this, the asyncio event loop may garbage-collect a task created via
     # ``loop.create_task(...)`` before it finishes, dropping the broadcast.
-    _pending_tasks: set = set()
+    _pending_tasks: set[asyncio.Task[None]] = set()
     # {WebSocket: monotonic timestamp of last client activity}. Populated
     # by ``connect`` and bumped by the endpoint on every received frame
     # so the heartbeat loop can tell zombies from healthy idle clients.
-    _last_seen: dict = {}
+    _last_seen: dict[WebSocket, float] = {}
     # Background heartbeat task (created by ``start_heartbeat``).
-    _heartbeat_task = None
+    _heartbeat_task: asyncio.Task[None] | None = None
     # The application's event loop, captured at startup. The sync broadcast
     # helpers are called from ``GameService``, which runs in a worker thread
     # (routes hand it to ``run_in_threadpool`` so its blocking I/O stays off
@@ -66,7 +68,7 @@ class WSHub:
 
     @classmethod
     async def connect(cls, ws: WebSocket, oid: str, *,
-                      subprotocol: str | None = None):
+                      subprotocol: str | None = None) -> None:
         """Accept *ws* and register it under *oid*.
 
         Raises :class:`WSHubFull` (without ``accept``-ing) when the OID
@@ -127,7 +129,7 @@ class WSHub:
         set_ws_gauges(total, len(cls._connections))
 
     @classmethod
-    def disconnect(cls, ws: WebSocket, oid: str):
+    def disconnect(cls, ws: WebSocket, oid: str) -> None:
         conns = cls._connections.get(oid)
         if conns:
             conns.discard(ws)
@@ -143,7 +145,7 @@ class WSHub:
     _BROADCAST_SEND_TIMEOUT = WS_BROADCAST_SEND_TIMEOUT_SECONDS
 
     @classmethod
-    async def _broadcast_text(cls, oid: str, message: str):
+    async def _broadcast_text(cls, oid: str, message: str) -> None:
         """Send the pre-serialized *message* to every client for *oid*.
 
         Sends run concurrently with a per-socket timeout so a single stuck
@@ -156,7 +158,7 @@ class WSHub:
 
         targets = list(conns)
 
-        async def _send(ws):
+        async def _send(ws: WebSocket) -> WebSocket | None:
             try:
                 await asyncio.wait_for(
                     ws.send_text(message),
@@ -188,13 +190,17 @@ class WSHub:
             cls._refresh_gauges()
 
     @classmethod
-    async def broadcast(cls, oid: str, data: dict):
+    async def broadcast(
+        cls,
+        oid: str,
+        data: dict[str, Any],
+    ) -> None:
         """Send a JSON ``state_update`` message to every client for *oid*."""
         message = json.dumps({"type": "state_update", "data": data})
         await cls._broadcast_text(oid, message)
 
     @classmethod
-    async def broadcast_payload_json(cls, oid: str, payload_json: str):
+    async def broadcast_payload_json(cls, oid: str, payload_json: str) -> None:
         """Variant of :meth:`broadcast` that accepts the ``data`` field
         already serialized to JSON. Wraps it in the standard
         ``{"type":"state_update","data":<payload>}`` envelope and sends.
@@ -217,7 +223,11 @@ class WSHub:
         cls._loop = asyncio.get_running_loop()
 
     @classmethod
-    def _schedule(cls, oid: str, coro_factory):
+    def _schedule(
+        cls,
+        oid: str,
+        coro_factory: Callable[[], Coroutine[Any, Any, None]],
+    ) -> None:
         """Schedule a broadcast coroutine, on- or off-loop.
 
         On the loop, create the task directly. Off it (``GameService``
@@ -225,7 +235,7 @@ class WSHub:
         via ``call_soon_threadsafe``. Only when no loop can be found at all
         — genuinely synchronous unit tests — is the broadcast skipped.
         """
-        def _create():
+        def _create() -> None:
             task = asyncio.ensure_future(coro_factory())
             cls._pending_tasks.add(task)
             task.add_done_callback(cls._pending_tasks.discard)
@@ -244,18 +254,18 @@ class WSHub:
         _create()
 
     @classmethod
-    def broadcast_sync(cls, oid: str, data: dict):
+    def broadcast_sync(cls, oid: str, data: dict[str, Any]) -> None:
         """Fire-and-forget broadcast usable from synchronous code."""
         cls._schedule(oid, lambda: cls.broadcast(oid, data))
 
     @classmethod
-    def broadcast_payload_json_sync(cls, oid: str, payload_json: str):
+    def broadcast_payload_json_sync(cls, oid: str, payload_json: str) -> None:
         """Sync wrapper around :meth:`broadcast_payload_json` for use from
         synchronous code paths (the ``GameService`` action methods)."""
         cls._schedule(oid, lambda: cls.broadcast_payload_json(oid, payload_json))
 
     @classmethod
-    def clear(cls):
+    def clear(cls) -> None:
         """Remove all connections (for testing)."""
         cls._connections.clear()
         cls._last_seen.clear()
@@ -340,7 +350,7 @@ class WSHub:
         healthy_coros = [_ping_healthy(oid, ws) for oid, ws in healthy]
         if zombie_coros:
             await asyncio.gather(*zombie_coros, return_exceptions=True)
-        ping_results: list = []
+        ping_results: list[bool | BaseException] = []
         if healthy_coros:
             ping_results = await asyncio.gather(
                 *healthy_coros, return_exceptions=True,

--- a/app/auth/bootstrap.py
+++ b/app/auth/bootstrap.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 from app import security_bootstrap, settings_service
 from app.auth import service
 from app.db.engine import session_scope
+from app.db.models.user import User
 from app.settings_service import set_admin_bootstrap_claimed
 
 logger = logging.getLogger(__name__)
@@ -95,7 +96,7 @@ def claim_first_admin(
     password: str,
     display_name: str | None = None,
     email: str | None = None,
-):
+) -> User:
     """Create the first admin if the token matches and no admin exists.
 
     Returns the created :class:`User`. Raises ``ValueError`` subclasses /

--- a/app/backend.py
+++ b/app/backend.py
@@ -1,14 +1,16 @@
 import copy
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from typing import Any
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from app.conf import Conf
 from app.customization_cache import CustomizationCache
 from app.customization_cache_ttl import (
     BACKEND_DEFAULT_TTL_SECONDS,
@@ -32,7 +34,7 @@ _REMOTE_CALL_WARN_MS = 500.0
 
 
 @contextmanager
-def _timed(label: str, logger: logging.Logger):
+def _timed(label: str, logger: logging.Logger) -> Iterator[None]:
     """Log perf_counter-based duration at DEBUG, or WARNING above the threshold."""
     t0 = time.perf_counter()
     try:
@@ -50,7 +52,7 @@ class Backend:
 
     logger = logging.getLogger(__name__)
 
-    def __init__(self, config):
+    def __init__(self, config: Conf) -> None:
         self.conf = config
         self.session = requests.Session()
         self.session.headers.update(
@@ -78,20 +80,20 @@ class Backend:
         self._customization_cache = CustomizationCache(
             _CUSTOMIZATION_CACHE_TTL_SECONDS
         )
-        self._rule_overrides_getter: Callable[[], dict] | None = None
+        self._rule_overrides_getter: Callable[[], dict[str, Any]] | None = None
         self._overlay = self._create_overlay_backend()
 
     def set_rule_overrides_getter(
-        self, getter: Callable[[], dict] | None
+        self, getter: Callable[[], dict[str, Any]] | None
     ) -> None:
         """Register the per-session rule-overrides callable."""
         self._rule_overrides_getter = getter
 
-    def _remember_customization(self, data):
+    def _remember_customization(self, data: dict[str, Any]) -> None:
         """Store a copy of *data* in the cache so callers can't mutate it."""
         self._customization_cache.remember(data)
 
-    def _fresh_customization_cache(self):
+    def _fresh_customization_cache(self) -> dict[str, Any] | None:
         """Return a fresh copy of the cached customization, or None if stale."""
         return self._customization_cache.fresh()
 
@@ -102,29 +104,35 @@ class Backend:
         key = self.conf.skey or overlay_id
         return bool(key) and overlay_state_store.overlay_exists(key)
 
-    def _oid_or_default(self, oid):
-        return oid if oid is not None else self.conf.oid
+    def _oid_or_default(self, oid: str | None) -> str:
+        return oid if oid is not None else (self.conf.oid or "")
 
-    def _resolve_kind(self, oid=None) -> OverlayKind:
+    def _resolve_kind(self, oid: str | None = None) -> OverlayKind:
         return resolve_overlay_kind(
             self._oid_or_default(oid), self._local_overlay_exists
         )
 
-    def _create_overlay_backend(self, oid=None):
+    def _create_overlay_backend(
+        self,
+        oid: str | None = None,
+    ) -> LocalOverlayBackend:
         """Instantiate the sole, in-process overlay backend."""
         backend = LocalOverlayBackend(self.conf)
         backend._build_payload = self._build_overlay_payload
         return backend
 
-    def _ensure_overlay_backend(self, oid=None):
+    def _ensure_overlay_backend(self, oid: str | None = None) -> None:
         """No-op retained for call-site compatibility."""
 
     # -- Public interface --------------------------------------------------
 
-    def is_custom_overlay(self, oid=None):
+    def is_custom_overlay(self, oid: str | None = None) -> bool:
         return self._resolve_kind(oid) == OverlayKind.CUSTOM
 
-    def get_custom_overlay_id(self, oid=None):
+    def get_custom_overlay_id(
+        self,
+        oid: str | None = None,
+    ) -> tuple[str, str | None]:
         check_oid = self._oid_or_default(oid)
         if self._resolve_kind(check_oid) == OverlayKind.CUSTOM:
             return LocalOverlayBackend.get_overlay_id(check_oid)
@@ -132,13 +140,13 @@ class Backend:
 
     # -- WebSocket lifecycle ----------------------------------------------
 
-    def init_ws_client(self, oid=None):
+    def init_ws_client(self, oid: str | None = None) -> None:
         self._overlay.init_ws_client(self._oid_or_default(oid))
 
-    def close_ws_client(self):
+    def close_ws_client(self) -> None:
         self._overlay.close_ws_client()
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         self._overlay.shutdown()
         executor = getattr(self, "executor", None)
         if executor is None:
@@ -146,22 +154,22 @@ class Backend:
         executor.shutdown(wait=True, cancel_futures=False)
 
     @property
-    def ws_connected(self):
+    def ws_connected(self) -> bool:
         return self._overlay.ws_connected
 
     @property
-    def obs_client_count(self):
+    def obs_client_count(self) -> int:
         return self._overlay.obs_client_count
 
     # -- Overlay payload builder ------------------------------------------
 
     def _build_overlay_payload(
         self,
-        current_model,
-        force_visibility=None,
-        customization_state=None,
-        show_only_current_set=None,
-    ):
+        current_model: dict[str, Any],
+        force_visibility: bool | None = None,
+        customization_state: dict[str, Any] | None = None,
+        show_only_current_set: bool | None = None,
+    ) -> dict[str, Any]:
         """Build the standardized overlay state JSON payload."""
         if customization_state is None:
             cached = self._fresh_customization_cache()
@@ -182,7 +190,11 @@ class Backend:
 
     # -- Model persistence -------------------------------------------------
 
-    def save_model(self, current_model, simple):
+    def save_model(
+        self,
+        current_model: dict[str, Any],
+        simple: bool,
+    ) -> None:
         Backend.logger.debug("saving model...")
         self._ensure_overlay_backend()
         with _timed("save_model.model", Backend.logger):
@@ -197,7 +209,7 @@ class Backend:
                 to_save.get(State.CURRENT_SET_INT, "1")
             )
 
-        def _push():
+        def _push() -> None:
             with _timed("save_model.push", Backend.logger):
                 self._overlay.push_model_update(
                     current_model,
@@ -210,22 +222,22 @@ class Backend:
         else:
             _push()
 
-    def reduce_games_to_one(self):
+    def reduce_games_to_one(self) -> None:
         self._ensure_overlay_backend()
         self._overlay.reduce_games_to_one()
 
-    def save_json_model(self, to_save):
+    def save_json_model(self, to_save: dict[str, Any]) -> None:
         Backend.logger.debug("saving JSON model...")
         self._ensure_overlay_backend()
         self._overlay.send_json_model(to_save)
 
-    def save_json_customization(self, to_save):
+    def save_json_customization(self, to_save: dict[str, Any]) -> None:
         Backend.logger.debug("saving JSON customization...")
         self._ensure_overlay_backend()
         self._remember_customization(to_save)
         self._overlay.save_customization(to_save)
 
-        def get_model():
+        def get_model() -> dict[str, Any] | None:
             return self.get_current_model(self.conf.oid)
 
         if self.conf.multithread:
@@ -237,7 +249,7 @@ class Backend:
         else:
             self._overlay.on_customization_saved(get_model, to_save)
 
-    def change_overlay_visibility(self, show):
+    def change_overlay_visibility(self, show: bool) -> None:
         Backend.logger.debug("changing overlay visibility, show: %s", show)
         self._ensure_overlay_backend()
         self._overlay.change_visibility_with_fallback(
@@ -247,14 +259,21 @@ class Backend:
 
     # -- Model/customization retrieval ------------------------------------
 
-    def get_current_model(self, customOid=None, saveResult=False):
+    def get_current_model(
+        self,
+        customOid: str | None = None,
+        saveResult: bool = False,
+    ) -> dict[str, Any] | None:
         oid = customOid if customOid is not None else self.conf.oid
         Backend.logger.debug("getting state for oid %s", oid)
         with _timed("get_current_model", Backend.logger):
             self._ensure_overlay_backend(oid)
             return self._overlay.get_model(oid=oid, save_result=saveResult)
 
-    def get_current_customization(self, customOid=None):
+    def get_current_customization(
+        self,
+        customOid: str | None = None,
+    ) -> dict[str, Any] | None:
         Backend.logger.debug("getting customization")
         with _timed("get_current_customization", Backend.logger):
             oid = customOid if customOid is not None else self.conf.oid
@@ -264,49 +283,58 @@ class Backend:
                 self._remember_customization(data)
             return data
 
-    def is_visible(self):
+    def is_visible(self) -> bool:
         self._ensure_overlay_backend()
         return self._overlay.is_visible()
 
-    def get_available_styles(self, oid: str = None) -> list:
+    def get_available_styles(
+        self,
+        oid: str | None = None,
+    ) -> list[str]:
         check_oid = self._oid_or_default(oid)
         self._ensure_overlay_backend(check_oid)
         return self._overlay.get_available_styles(check_oid)
 
-    def get_style_capabilities(self, oid: str = None) -> dict:
+    def get_style_capabilities(
+        self,
+        oid: str | None = None,
+    ) -> dict[str, Any]:
         check_oid = self._oid_or_default(oid)
         self._ensure_overlay_backend(check_oid)
         return self._overlay.get_style_capabilities(check_oid)
 
     # -- OID validation / output token ------------------------------------
 
-    def validate_and_store_model_for_oid(self, oid: str):
+    def validate_and_store_model_for_oid(self, oid: str) -> State.OIDStatus:
         if not oid or not oid.strip():
             return State.OIDStatus.EMPTY
         self._ensure_overlay_backend(oid)
         return self._overlay.validate_oid(oid)
 
-    def fetch_and_update_overlay_id(self, oid: str):
+    def fetch_and_update_overlay_id(self, oid: str) -> None:
         self._ensure_overlay_backend(oid)
         self._overlay.fetch_and_update_overlay_id(oid)
 
-    def fetch_output_token(self, oid):
+    def fetch_output_token(self, oid: str) -> str | None:
         self._ensure_overlay_backend(oid)
         return self._overlay.fetch_output_token(oid)
 
     # -- High-level helpers ------------------------------------------------
 
-    def reset(self, state):
+    def reset(self, state: State) -> None:
         current = state.get_current_model()
         reset_model = state.get_reset_model()
         new_state = copy.copy(current)
         new_state.update(reset_model)
         self.save_model(new_state, False)
 
-    def save(self, state, simple):
+    def save(self, state: State, simple: bool) -> None:
         self.save_model(state.get_current_model(), simple)
 
-    def process_response(self, response):
+    def process_response(
+        self,
+        response: requests.Response,
+    ) -> requests.Response:
         if response.status_code >= 400:
             logging.warning(
                 "response %s: '%s'",
@@ -320,11 +348,11 @@ class Backend:
 
     def update_local_overlay(
         self,
-        current_model,
-        force_visibility=None,
-        customization_state=None,
-        show_only_current_set=None,
-    ):
+        current_model: dict[str, Any],
+        force_visibility: bool | None = None,
+        customization_state: dict[str, Any] | None = None,
+        show_only_current_set: bool | None = None,
+    ) -> None:
         try:
             payload = self._build_overlay_payload(
                 current_model,

--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -47,7 +48,7 @@ OVERLAY_STATIC_DIR = Path("overlay_static")
 
 
 @asynccontextmanager
-async def _lifespan(application: FastAPI):
+async def _lifespan(application: FastAPI) -> AsyncIterator[None]:
     """Capture the event loop for background-thread broadcasts."""
     try:
         from app.overlay import obs_broadcast_hub

--- a/app/conf.py
+++ b/app/conf.py
@@ -22,7 +22,7 @@ def _int_env(key: str, default: int) -> int:
 
 
 class Conf:
-    def __init__(self):
+    def __init__(self) -> None:
         # Legacy layout id (used only for the championship-layout special case
         # in ``Backend.save_model``). Kept as a constant default — no env knob.
         self.id = '8637cb0f-df01-45bb-9782-c6d705aeff46'

--- a/app/config_validator.py
+++ b/app/config_validator.py
@@ -5,7 +5,7 @@ import os
 logger = logging.getLogger(__name__)
 
 
-def validate_config():
+def validate_config() -> None:
     """
     Validates critical environment variables on startup.
     Logs warnings and sets safe defaults in os.environ for invalid configurations.

--- a/app/customization.py
+++ b/app/customization.py
@@ -1,5 +1,7 @@
 import json
 import logging
+from collections.abc import KeysView
+from typing import Any, cast
 
 from app.env_vars_manager import EnvVarsManager
 
@@ -105,7 +107,7 @@ class Customization:
     THEMES: dict[str, dict[str, str | int | float]] = {}
 
     @staticmethod
-    def refresh():
+    def refresh() -> None:
         provided_teams_json = EnvVarsManager.get_env_var('APP_TEAMS', None)
 
         if provided_teams_json is None or provided_teams_json == '':
@@ -131,95 +133,97 @@ class Customization:
 
 
 
-    def __init__(self, current_customization_state):
+    def __init__(
+        self,
+        current_customization_state: dict[str, Any],
+    ) -> None:
         Customization.refresh()
         self.customization_model = current_customization_state
 
-    def get_model(self):
+    def get_model(self) -> dict[str, Any]:
         return self.customization_model
 
-    def set_model(self, new_model):
+    def set_model(self, new_model: dict[str, Any]) -> None:
         self.customization_model = new_model
 
-    def get_team_color(self, team):
+    def get_team_color(self, team: int) -> str:
         if team == 1:
-            return self.customization_model.get(Customization.T1_COLOR, "#060f8a")
-        else:
-            return self.customization_model.get(Customization.T2_COLOR, "#ffffff")
+            return cast(str, self.customization_model.get(Customization.T1_COLOR, "#060f8a"))
+        return cast(str, self.customization_model.get(Customization.T2_COLOR, "#ffffff"))
 
-    def get_team_text_color(self, team):
+    def get_team_text_color(self, team: int) -> str:
         if team == 1:
-            return self.customization_model.get(Customization.T1_TEXT_COLOR, "#ffffff")
-        else:
-            return self.customization_model.get(Customization.T2_TEXT_COLOR, "#000000")
+            return cast(str, self.customization_model.get(Customization.T1_TEXT_COLOR, "#ffffff"))
+        return cast(str, self.customization_model.get(Customization.T2_TEXT_COLOR, "#000000"))
 
-    def get_team_logo(self, team):
+    def get_team_logo(self, team: int) -> str:
         if team == 1:
-            return Customization.fix_icon(self.customization_model.get(Customization.T1_LOGO, Customization.DEFAULT_IMAGE))
+            logo = self.customization_model.get(Customization.T1_LOGO, Customization.DEFAULT_IMAGE)
         else:
-            return Customization.fix_icon(self.customization_model.get(Customization.T2_LOGO, Customization.DEFAULT_IMAGE))
+            logo = self.customization_model.get(Customization.T2_LOGO, Customization.DEFAULT_IMAGE)
+        return Customization.fix_icon(cast(str, logo))
 
-    def set_team_text_color(self, team, color):
+    def set_team_text_color(self, team: int, color: str) -> None:
         if team == 1:
             self.customization_model[Customization.T1_TEXT_COLOR] = color
         else:
             self.customization_model[Customization.T2_TEXT_COLOR] = color
 
-    def set_team_color(self, team, color):
+    def set_team_color(self, team: int, color: str) -> None:
         if team == 1:
             self.customization_model[Customization.T1_COLOR] = color
         else:
             self.customization_model[Customization.T2_COLOR] = color
 
-    def set_team_logo(self, team, logo):
+    def set_team_logo(self, team: int, logo: str) -> None:
         if team == 1:
             self.customization_model[Customization.T1_LOGO] = logo
         else:
             self.customization_model[Customization.T2_LOGO] = logo
 
 
-    def set_theme(self, theme:str):
+    def set_theme(self, theme: str) -> None:
         if theme in Customization.THEMES:
             for key, value in Customization.THEMES[theme].items():
                 self.customization_model[key] = value
 
-    def get_theme_names(self):
+    def get_theme_names(self) -> KeysView[str]:
         return Customization.THEMES.keys()
 
 
-    def get_set_color(self):
-        return self.customization_model[Customization.SET_COLOR]
+    def get_set_color(self) -> str:
+        return cast(str, self.customization_model[Customization.SET_COLOR])
 
 
-    def get_game_color(self):
-        return self.customization_model[Customization.GAME_COLOR]
+    def get_game_color(self) -> str:
+        return cast(str, self.customization_model[Customization.GAME_COLOR])
 
-    def get_set_text_color(self):
-        return self.customization_model[Customization.SET_TEXT_COLOR]
+    def get_set_text_color(self) -> str:
+        return cast(str, self.customization_model[Customization.SET_TEXT_COLOR])
 
 
-    def get_game_text_color(self):
-        return self.customization_model[Customization.GAME_TEXT_COLOR]
+    def get_game_text_color(self) -> str:
+        return cast(str, self.customization_model[Customization.GAME_TEXT_COLOR])
 
-    def set_set_color(self, color):
+    def set_set_color(self, color: str) -> None:
         self.customization_model[Customization.SET_COLOR] = color
 
 
-    def set_game_color(self, color):
+    def set_game_color(self, color: str) -> None:
         self.customization_model[Customization.GAME_COLOR] = color
 
-    def set_set_text_color(self, color):
+    def set_set_text_color(self, color: str) -> None:
         self.customization_model[Customization.SET_TEXT_COLOR] = color
 
-    def get_team_name(self, team):
+    def get_team_name(self, team: int) -> str:
         old_key = Customization.A_TEAM if team == 1 else Customization.B_TEAM
         new_key = "Team 1 Name" if team == 1 else "Team 2 Name"
 
         if old_key in self.customization_model:
-            return self.customization_model[old_key]
-        return self.customization_model.get(new_key, "")
+            return cast(str, self.customization_model[old_key])
+        return cast(str, self.customization_model.get(new_key, ""))
 
-    def set_team_name(self, team, name):
+    def set_team_name(self, team: int, name: str) -> None:
         old_key = Customization.A_TEAM if team == 1 else Customization.B_TEAM
         new_key = "Team 1 Name" if team == 1 else "Team 2 Name"
 
@@ -228,13 +232,13 @@ class Customization:
         else:
             self.customization_model[new_key] = name
 
-    def is_show_logos(self):
+    def is_show_logos(self) -> bool | str:
         return self.customization_model.get(Customization.LOGOS_BOOL, "true")
 
-    def set_show_logos(self, value):
+    def set_show_logos(self, value: bool | str) -> None:
         self.customization_model[Customization.LOGOS_BOOL] = value
 
-    def is_show_stats(self):
+    def is_show_stats(self) -> bool:
         """Whether the overlay should render the live stats panel.
 
         Default ``False`` so existing overlays look unchanged; the
@@ -244,88 +248,91 @@ class Customization:
             Customization.SHOW_STATS_BOOL, False
         ) not in (False, "false", "False", 0, "0", None, "")
 
-    def set_show_stats(self, value):
+    def set_show_stats(self, value: bool | str) -> None:
         self.customization_model[Customization.SHOW_STATS_BOOL] = value
 
-    def is_show_points_history(self):
+    def is_show_points_history(self) -> bool:
         """Whether the overlay should render the points-history strip."""
         return self.customization_model.get(
             Customization.SHOW_POINTS_HISTORY_BOOL, False
         ) not in (False, "false", "False", 0, "0", None, "")
 
-    def set_show_points_history(self, value):
+    def set_show_points_history(self, value: bool | str) -> None:
         self.customization_model[Customization.SHOW_POINTS_HISTORY_BOOL] = value
 
 
-    def set_game_text_color(self, color):
+    def set_game_text_color(self, color: str) -> None:
         self.customization_model[Customization.GAME_TEXT_COLOR] = color
 
-    def is_glossy(self):
+    def is_glossy(self) -> bool | str:
         return self.customization_model.get(Customization.GLOSS_EFFECT_BOOL, False)
 
-    def set_glossy(self, value):
+    def set_glossy(self, value: bool | str) -> None:
         self.customization_model[Customization.GLOSS_EFFECT_BOOL] = value
 
-    def get_preferred_style(self):
-        return self.customization_model.get(Customization.PREFERRED_STYLE, None)
+    def get_preferred_style(self) -> str | None:
+        return cast(
+            str | None,
+            self.customization_model.get(Customization.PREFERRED_STYLE),
+        )
 
-    def set_preferred_style(self, style):
+    def set_preferred_style(self, style: str | None) -> None:
         if style:
             self.customization_model[Customization.PREFERRED_STYLE] = style
         elif Customization.PREFERRED_STYLE in self.customization_model:
             del self.customization_model[Customization.PREFERRED_STYLE]
 
-    def get_width(self):
+    def get_width(self) -> float:
         val = self.customization_model.get(Customization.WIDTH_FLOAT, 30)
         return float(val) if val not in [None, 'None', ''] else 30.0
 
-    def set_width(self, width):
+    def set_width(self, width: int | float | str) -> None:
         self.customization_model[Customization.WIDTH_FLOAT] = width
 
-    def get_height(self):
+    def get_height(self) -> float:
         val = self.customization_model.get(Customization.HEIGHT_FLOAT, 10)
         return float(val) if val not in [None, 'None', ''] else 10.0
 
-    def get_hpos(self):
+    def get_hpos(self) -> float:
         val = self.customization_model.get(Customization.HPOS_FLOAT, -33)
         return float(val) if val not in [None, 'None', ''] else -33.0
 
-    def get_vpos(self):
+    def get_vpos(self) -> float:
         val = self.customization_model.get(Customization.VPOS_FLOAT, -41.1)
         return float(val) if val not in [None, 'None', ''] else -41.1
 
-    def set_height(self, float_val):
+    def set_height(self, float_val: int | float | str | None) -> None:
         self.customization_model[Customization.HEIGHT_FLOAT] = float_val
 
-    def get_h_pos(self):
+    def get_h_pos(self) -> float:
         val = self.customization_model.get(Customization.HPOS_FLOAT, -33)
         return float(val) if val not in [None, 'None', ''] else -33.0
 
-    def set_h_pos(self, width):
+    def set_h_pos(self, width: int | float | str) -> None:
         self.customization_model[Customization.HPOS_FLOAT] = width
 
-    def get_v_pos(self):
+    def get_v_pos(self) -> float:
         val = self.customization_model.get(Customization.VPOS_FLOAT, -41.1)
         return float(val) if val not in [None, 'None', ''] else -41.1
 
-    def set_v_pos(self, float_val):
+    def set_v_pos(self, float_val: int | float | str | None) -> None:
         self.customization_model[Customization.VPOS_FLOAT] = float_val
 
-    def get_scale(self):
+    def get_scale(self) -> float:
         val = self.customization_model.get(Customization.SCALE_FLOAT, 100)
         return float(val) if val not in [None, 'None', ''] else 100.0
 
-    def set_scale(self, float_val):
+    def set_scale(self, float_val: int | float | str | None) -> None:
         self.customization_model[Customization.SCALE_FLOAT] = float_val
 
-    def get_margin(self):
+    def get_margin(self) -> float:
         val = self.customization_model.get(Customization.MARGIN_FLOAT, 0)
         return float(val) if val not in [None, 'None', ''] else 0.0
 
-    def set_margin(self, float_val):
+    def set_margin(self, float_val: int | float | str | None) -> None:
         self.customization_model[Customization.MARGIN_FLOAT] = float_val
 
-    def get_anchor(self):
+    def get_anchor(self) -> str:
         """Return the placement anchor, normalised to lowercase.
 
         Falls back to :data:`ANCHOR_FREE` (legacy absolute positioning)
@@ -340,16 +347,16 @@ class Customization:
             return Customization.ANCHOR_FREE
         return val.strip().lower()
 
-    def set_anchor(self, value):
+    def set_anchor(self, value: str | None) -> None:
         self.customization_model[Customization.ANCHOR] = value
 
     @staticmethod
-    def get_predefined_teams():
+    def get_predefined_teams() -> dict[str, dict[str, str]]:
         Customization.refresh()
         return Customization.predefined_teams
 
     @staticmethod
-    def fix_icon(url):
+    def fix_icon(url: str) -> str:
         if url.startswith("//"):
             return "https:" + url
         return url

--- a/app/customization_cache.py
+++ b/app/customization_cache.py
@@ -24,7 +24,7 @@ import time
 class CustomizationCache:
     """A single-slot TTL cache for an overlay-customization dict."""
 
-    def __init__(self, ttl_seconds: float):
+    def __init__(self, ttl_seconds: float) -> None:
         if ttl_seconds <= 0:
             raise ValueError("ttl_seconds must be positive")
         self._ttl = float(ttl_seconds)

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from sqlalchemy import DateTime, MetaData, func
+from sqlalchemy.engine import Dialect
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy.types import TypeDecorator
 
@@ -41,14 +42,22 @@ class TZDateTime(TypeDecorator[datetime]):
     impl = DateTime(timezone=True)
     cache_ok = True
 
-    def process_bind_param(self, value, dialect):
+    def process_bind_param(
+        self,
+        value: datetime | None,
+        dialect: Dialect,
+    ) -> datetime | None:
         if value is None:
             return None
         if value.tzinfo is None:
             return value.replace(tzinfo=UTC)
         return value.astimezone(UTC)
 
-    def process_result_value(self, value, dialect):
+    def process_result_value(
+        self,
+        value: datetime | None,
+        dialect: Dialect,
+    ) -> datetime | None:
         if value is not None and value.tzinfo is None:
             return value.replace(tzinfo=UTC)
         return value

--- a/app/db/engine.py
+++ b/app/db/engine.py
@@ -96,7 +96,7 @@ def _enable_sqlite_fk(engine: Engine) -> None:
     """
 
     @event.listens_for(engine, "connect")
-    def _set_pragma(dbapi_conn, _record):
+    def _set_pragma(dbapi_conn: Any, _record: Any) -> None:
         cursor = dbapi_conn.cursor()
         cursor.execute("PRAGMA foreign_keys=ON")
         cursor.close()

--- a/app/db/migrate.py
+++ b/app/db/migrate.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -36,7 +37,7 @@ def _alembic_config() -> Config:
 
 
 @contextmanager
-def _migration_lock():
+def _migration_lock() -> Iterator[None]:
     """Best-effort cross-process lock so concurrent workers don't double-migrate.
 
     Uses an ``flock`` on a file in the data dir. If locking is unavailable

--- a/app/env_vars_manager.py
+++ b/app/env_vars_manager.py
@@ -3,6 +3,7 @@ import logging
 import os
 import threading
 import time
+from typing import Any
 
 import requests
 
@@ -19,7 +20,7 @@ def is_truthy(value: object) -> bool:
 
 
 class EnvVarsManager:
-    _remote_config_cache: dict[str, str] = {}
+    _remote_config_cache: dict[str, Any] = {}
     _cache_timestamp: float = 0
     _CACHE_EXPIRATION_SECONDS = 10
     # Serialises the refetch so concurrent callers (request pool + webhook
@@ -29,7 +30,11 @@ class EnvVarsManager:
     _refresh_in_flight = False
 
     @classmethod
-    def get_env_var(cls, key, default=None):
+    def get_env_var(
+        cls,
+        key: str,
+        default: Any = None,
+    ) -> Any:
         cls._load_remote_config_if_needed()
         return cls._remote_config_cache.get(key, os.environ.get(key, default))
 
@@ -42,7 +47,7 @@ class EnvVarsManager:
         return is_truthy(raw if isinstance(raw, str) else str(raw))
 
     @classmethod
-    def _load_remote_config_if_needed(cls):
+    def _load_remote_config_if_needed(cls) -> None:
         remote_config_url = os.environ.get('REMOTE_CONFIG_URL', None)
         if remote_config_url is None:
             cls._remote_config_cache = {}
@@ -97,7 +102,7 @@ class EnvVarsManager:
             cls._remote_config_cache = {}
 
     @staticmethod
-    def _unwrap_remote_config(payload):
+    def _unwrap_remote_config(payload: Any) -> dict[str, Any]:
         """Return the flat env-var mapping from a remote config payload.
 
         The remote config is expected to be a flat ``{KEY: value}`` object

--- a/app/game_manager.py
+++ b/app/game_manager.py
@@ -12,7 +12,7 @@ class GameManager:
     Manages the game logic, state, and backend communication.
     """
 
-    def __init__(self, conf: Conf, backend: Backend):
+    def __init__(self, conf: Conf, backend: Backend) -> None:
         logger.debug("Initializing GameManager")
         self.conf = conf
         self.backend = backend
@@ -23,19 +23,19 @@ class GameManager:
         logger.debug("Getting current state")
         return self.main_state
 
-    def reset(self):
+    def reset(self) -> None:
         """Resets the game state."""
         logger.debug("Resetting game state")
         self.backend.reset(self.main_state)
         self.main_state = State(self.backend.get_current_model())
 
-    def save(self, simple: bool, current_set: int):
+    def save(self, simple: bool, current_set: int) -> None:
         """Saves the current game state."""
         logger.debug("Saving state, simple mode: %s, current set: %s", simple, current_set)
         self.main_state.set_current_set(current_set)
         self.backend.save(self.main_state, simple)
 
-    def change_serve(self, team: int, force: bool = False):
+    def change_serve(self, team: int, force: bool = False) -> None:
         """Changes the serving team."""
         logger.debug("Changing serve to team %s, force: %s", team, force)
         current_serve = self.main_state.get_current_serve()
@@ -48,7 +48,7 @@ class GameManager:
                 new_serve = State.SERVE_2
         self.main_state.set_current_serve(new_serve)
 
-    def add_timeout(self, team: int, undo: bool):
+    def add_timeout(self, team: int, undo: bool) -> None:
         """Adds or removes a timeout for a team."""
         logger.debug("Adding timeout for team %s, undo: %s", team, undo)
         current_timeouts = self.main_state.get_timeout(team)
@@ -59,12 +59,12 @@ class GameManager:
             if current_timeouts < 2:
                 self.main_state.set_timeout(team, current_timeouts + 1)
 
-    def set_game_value(self, team: int, value: int, current_set: int):
+    def set_game_value(self, team: int, value: int, current_set: int) -> None:
         """Directly sets the game score for a team."""
         logger.debug("Setting game value for team %s to %s in set %s", team, value, current_set)
         self.main_state.set_game(current_set, team, value)
 
-    def set_sets_value(self, team: int, value: int):
+    def set_sets_value(self, team: int, value: int) -> None:
         """Directly sets the sets won for a team."""
         logger.debug("Setting sets value for team %s to %s", team, value)
         self.main_state.set_sets(team, value)
@@ -121,7 +121,12 @@ class GameManager:
                 return True
         return False
 
-    def add_set(self, team: int, undo: bool, sets_limit: int = None):
+    def add_set(
+        self,
+        team: int,
+        undo: bool,
+        sets_limit: int | None = None,
+    ) -> None:
         """Adds or removes a set to a team."""
         logger.debug("Adding set for team %s, undo: %s", team, undo)
         if not undo and self.match_finished(sets_limit):
@@ -141,7 +146,7 @@ class GameManager:
             self.change_serve(0)
 
 
-    def match_finished(self, sets_limit: int = None) -> bool:
+    def match_finished(self, sets_limit: int | None = None) -> bool:
         """Checks if the match has finished.
 
         ``sets_limit`` is the per-session "best of N" rule; when omitted it

--- a/app/match_report/cards.py
+++ b/app/match_report/cards.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import html
+from collections.abc import Callable
+from typing import Any
 
 from app.api.schemas import ERROR_TYPES
 from app.match_report.i18n import t as _t
+
+CardWriter = Callable[[str, str, str], None]
+TeamLabel = Callable[[int | None], str]
 
 
 def _fmt_seconds(seconds: float | None) -> str:
@@ -41,7 +46,11 @@ def _pct(n: int, denom: int) -> int:
 
 
 def _comeback_card(
-    card, team_label, locale: str, data: dict, *,
+    card: CardWriter,
+    team_label: TeamLabel,
+    locale: str,
+    data: dict[Any, Any],
+    *,
     qualifies: bool, label_key: str, value_key: str,
     field: str = "deficit",
 ) -> None:
@@ -75,8 +84,11 @@ def _comeback_card(
 
 
 def _point_composition_cards(
-    card, team_label, locale: str,
-    point_types: dict, totals_by_team: dict,
+    card: CardWriter,
+    team_label: TeamLabel,
+    locale: str,
+    point_types: dict[Any, Any],
+    totals_by_team: dict[Any, Any],
 ) -> None:
     """Point composition: how each team scored, each type as a share
     of that team's total points won (the remainder, if any, is
@@ -107,8 +119,12 @@ def _point_composition_cards(
 
 
 def _own_error_cards(
-    card, team_label, locale: str,
-    point_types: dict, error_types: dict, totals_by_team: dict,
+    card: CardWriter,
+    team_label: TeamLabel,
+    locale: str,
+    point_types: dict[Any, Any],
+    error_types: dict[Any, Any],
+    totals_by_team: dict[Any, Any],
 ) -> None:
     """Own errors: points a team gave away through its own faults,
     i.e. the opponent's ``opp_error`` tally (and its cause breakdown),
@@ -144,7 +160,10 @@ def _own_error_cards(
 
 
 def _serve_receive_cards(
-    card, team_label, locale: str, serve_receive: dict,
+    card: CardWriter,
+    team_label: TeamLabel,
+    locale: str,
+    serve_receive: dict[Any, Any],
 ) -> None:
     """Serve/receive split: how many of a team's points came on its
     own serve vs on receive (side-outs). One card per team with at
@@ -184,7 +203,8 @@ def _serve_receive_cards(
 
 
 def _render_highlights(
-    stats: dict, locale: str,
+    stats: dict[str, Any],
+    locale: str,
     *, team1_name: str, team2_name: str,
 ) -> str:
     """Build the Highlights grid (longest streak / comeback / totals / set durations).

--- a/app/match_report/history.py
+++ b/app/match_report/history.py
@@ -432,7 +432,7 @@ def match_history(
     page: int = Query(default=1, ge=1),
     lang: str | None = Query(default=None),
     accept_language: str | None = Header(default=None),
-):
+) -> HTMLResponse:
     resolved = _resolve_overlay(public_token)
     if resolved is None:
         raise HTTPException(status_code=404, detail="Not found.")

--- a/app/match_report/routes.py
+++ b/app/match_report/routes.py
@@ -135,7 +135,7 @@ def match_report(
         ),
     ),
     accept_language: str | None = Header(default=None),
-):
+) -> HTMLResponse:
     check_read_access(request, match_id, exp=exp, sig=sig)
     payload = match_archive.load_match(match_id)
     if payload is None:

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -33,6 +33,7 @@ without the cardinality risk.
 from __future__ import annotations
 
 import logging
+from typing import Any, Literal
 
 logger = logging.getLogger(__name__)
 
@@ -66,37 +67,40 @@ except ImportError:  # pragma: no cover — handled at runtime
         ``prometheus_client`` is missing.
         """
 
-        def __init__(self, *_args, **_kwargs):
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
             pass
 
-        def labels(self, **_kwargs):
+        def labels(self, **_kwargs: Any) -> _NoOp:
             return self
 
-        def inc(self, *_a, **_kw):
-            return None
+        def inc(self, *_a: Any, **_kw: Any) -> None:
+            pass
 
-        def dec(self, *_a, **_kw):
-            return None
+        def dec(self, *_a: Any, **_kw: Any) -> None:
+            pass
 
-        def set(self, *_a, **_kw):
-            return None
+        def set(self, *_a: Any, **_kw: Any) -> None:
+            pass
 
-        def observe(self, *_a, **_kw):
-            return None
+        def observe(self, *_a: Any, **_kw: Any) -> None:
+            pass
 
-        def time(self):  # context manager fallback
+        def time(self) -> _NoOpTimer:  # context manager fallback
             return _NoOpTimer()
 
     class _NoOpTimer:
-        def __enter__(self):
+        def __enter__(self) -> _NoOpTimer:
             return self
 
-        def __exit__(self, *args):
+        def __exit__(self, *args: object) -> Literal[False]:
             return False
 
     Counter = Gauge = Histogram = _NoOp  # type: ignore[assignment, misc, unused-ignore]
 
-    def generate_latest(*_a, **_kw):  # type: ignore[misc, unused-ignore]
+    def generate_latest(  # type: ignore[misc, unused-ignore]
+        *_a: Any,
+        **_kw: Any,
+    ) -> bytes:
         return b""
 
 

--- a/app/net_guard.py
+++ b/app/net_guard.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import ipaddress
 import socket
+from typing import Any
 from urllib.parse import urljoin, urlparse, urlunparse
 
 import requests
@@ -135,11 +136,17 @@ class _PinnedTLSAdapter(HTTPAdapter):
     verification against it (urllib3 v2 pool kwargs).
     """
 
-    def __init__(self, hostname: str):
+    def __init__(self, hostname: str) -> None:
         self._hostname = hostname
         super().__init__()
 
-    def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
+    def init_poolmanager(
+        self,
+        connections: int,
+        maxsize: int,
+        block: bool = False,
+        **pool_kwargs: Any,
+    ) -> None:
         pool_kwargs["server_hostname"] = self._hostname
         pool_kwargs["assert_hostname"] = self._hostname
         return super().init_poolmanager(

--- a/app/overlay/__init__.py
+++ b/app/overlay/__init__.py
@@ -20,10 +20,10 @@ overlay_state_store = OverlayStateStore(_data_dir, _templates_dir)
 obs_broadcast_hub = ObsBroadcastHub()
 
 
-def _on_state_changed(overlay_id):
+def _on_state_changed(overlay_id: str) -> None:
     """Broadcast callback — triggered after every state change."""
     obs_broadcast_hub.schedule_broadcast_from_sync(
-        overlay_id, lambda oid=overlay_id: overlay_state_store.get_state(oid)
+        overlay_id, lambda: overlay_state_store.get_state(overlay_id)
     )
 
 

--- a/app/overlay/broadcast.py
+++ b/app/overlay/broadcast.py
@@ -8,6 +8,8 @@ import asyncio
 import functools
 import json
 import logging
+from collections.abc import Callable
+from typing import Any
 
 from fastapi import WebSocket
 
@@ -26,7 +28,7 @@ class ObsHubFull(Exception):
     upgrade with WebSocket code 1013 ("Try Again Later").
     """
 
-    def __init__(self, overlay_id: str, cap: int):
+    def __init__(self, overlay_id: str, cap: int) -> None:
         super().__init__(
             f"overlay '{overlay_id}' is at its client cap ({cap})"
         )
@@ -42,9 +44,9 @@ class ObsBroadcastHub:
     _BROADCAST_SEND_TIMEOUT = WS_BROADCAST_SEND_TIMEOUT_SECONDS
     _MAX_CLIENTS_PER_OVERLAY = OBS_MAX_CLIENTS_PER_OVERLAY
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._clients: dict[str, list[WebSocket]] = {}
-        self._broadcast_tasks: dict[str, asyncio.Task] = {}
+        self._broadcast_tasks: dict[str, asyncio.Task[None]] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
 
     def capture_event_loop(self) -> None:
@@ -83,7 +85,11 @@ class ObsBroadcastHub:
 
     # -- Broadcasting ------------------------------------------------------
 
-    def schedule_broadcast(self, overlay_id: str, get_state) -> None:
+    def schedule_broadcast(
+        self,
+        overlay_id: str,
+        get_state: Callable[[], dict[str, Any]],
+    ) -> None:
         """Cancel any pending broadcast and schedule a new 50ms debounced one.
 
         *get_state* is a callable returning the current state dict.
@@ -98,12 +104,20 @@ class ObsBroadcastHub:
         self._broadcast_tasks[overlay_id] = task
         task.add_done_callback(functools.partial(self._reap_task, overlay_id))
 
-    def _reap_task(self, overlay_id: str, task: asyncio.Task) -> None:
+    def _reap_task(
+        self,
+        overlay_id: str,
+        task: asyncio.Task[None],
+    ) -> None:
         """Drop the task-map entry once its task finishes (if still current)."""
         if self._broadcast_tasks.get(overlay_id) is task:
             del self._broadcast_tasks[overlay_id]
 
-    def schedule_broadcast_from_sync(self, overlay_id: str, get_state) -> None:
+    def schedule_broadcast_from_sync(
+        self,
+        overlay_id: str,
+        get_state: Callable[[], dict[str, Any]],
+    ) -> None:
         """Schedule a broadcast from a synchronous context (e.g. ThreadPoolExecutor)."""
         loop = self._loop
         if loop is None or loop.is_closed():
@@ -116,7 +130,7 @@ class ObsBroadcastHub:
         if not clients:
             return
 
-        async def _send(client):
+        async def _send(client: WebSocket) -> WebSocket | None:
             try:
                 # A slow or wedged client (TCP backpressure from a stuck
                 # OBS source) must not stall delivery to the rest — treat
@@ -150,7 +164,10 @@ class ObsBroadcastHub:
             )
 
     async def _debounced_broadcast(
-        self, overlay_id: str, get_state, delay: float = 0.05
+        self,
+        overlay_id: str,
+        get_state: Callable[[], dict[str, Any]],
+        delay: float = 0.05,
     ) -> None:
         """Wait *delay* seconds then broadcast the current state."""
         try:
@@ -167,7 +184,11 @@ class ObsBroadcastHub:
                 "Broadcast for overlay '%s' failed", overlay_id,
             )
 
-    async def broadcast_now(self, overlay_id: str, state: dict) -> None:
+    async def broadcast_now(
+        self,
+        overlay_id: str,
+        state: dict[str, Any],
+    ) -> None:
         """Immediately broadcast *state* to all clients (no debounce)."""
         message = json.dumps(state)
         await self._send_to_clients(overlay_id, message)

--- a/app/overlay/routes.py
+++ b/app/overlay/routes.py
@@ -16,7 +16,7 @@ from fastapi.routing import APIRoute
 from fastapi.templating import Jinja2Templates
 from starlette.concurrency import run_in_threadpool
 
-from app.overlay.broadcast import ObsHubFull
+from app.overlay.broadcast import ObsBroadcastHub, ObsHubFull
 from app.overlay.locale import _resolve_overlay_locale
 from app.overlay.state_store import OverlayStateStore
 from app.overlay.themes import get_theme_names
@@ -73,7 +73,7 @@ def _deterministic_operation_id(route: APIRoute) -> str:
 
 def create_overlay_router(
     store: OverlayStateStore,
-    broadcast,  # ObsBroadcastHub — not type-hinted to avoid circular import
+    broadcast: ObsBroadcastHub,
     templates: Jinja2Templates,
 ) -> APIRouter:
     """Create and return the overlay router with injected dependencies."""
@@ -89,7 +89,7 @@ def create_overlay_router(
 def _register_page_routes(
     router: APIRouter,
     store: OverlayStateStore,
-    broadcast,
+    broadcast: ObsBroadcastHub,
     templates: Jinja2Templates,
 ) -> None:
     """HTML pages + the OBS browser-source WebSocket."""
@@ -97,16 +97,18 @@ def _register_page_routes(
     # -- Favicon -----------------------------------------------------------
 
     @router.get("/favicon.ico", include_in_schema=False)
-    async def favicon():
+    async def favicon() -> Response:
         return Response(content=b"", media_type="image/x-icon", status_code=200)
 
     # -- Overlay HTML rendering --------------------------------------------
 
     @router.get("/overlay/{public_token}", response_class=HTMLResponse)
     async def serve_overlay(
-        request: Request, public_token: str, style: str = None,
-        lang: str = None,
-    ):
+        request: Request,
+        public_token: str,
+        style: str | None = None,
+        lang: str | None = None,
+    ) -> Response:
         skey = await run_in_threadpool(_resolve_public_token, public_token)
         if skey is None:
             raise HTTPException(status_code=404, detail="Overlay ID not found.")
@@ -164,7 +166,10 @@ def _register_page_routes(
     # -- Public spectator (follow) page ------------------------------------
 
     @router.get("/follow/{public_token}", response_class=HTMLResponse)
-    async def serve_spectator(request: Request, public_token: str):
+    async def serve_spectator(
+        request: Request,
+        public_token: str,
+    ) -> Response:
         """Mobile-friendly read-only follow view.
 
         Resolves the public token like ``/overlay/{token}`` and serves a
@@ -191,7 +196,7 @@ def _register_page_routes(
     # -- OBS browser source WebSocket --------------------------------------
 
     @router.websocket("/ws/{public_token}")
-    async def obs_websocket(websocket: WebSocket, public_token: str):
+    async def obs_websocket(websocket: WebSocket, public_token: str) -> None:
         skey = await run_in_threadpool(_resolve_public_token, public_token)
         if skey is None:
             await websocket.close(code=4004, reason="Overlay not found")
@@ -225,7 +230,7 @@ def _register_page_routes(
 def _register_api_routes(
     router: APIRouter,
     store: OverlayStateStore,
-    broadcast,
+    broadcast: ObsBroadcastHub,
 ) -> None:
     """Public JSON API for the in-process overlay engine.
 
@@ -236,5 +241,5 @@ def _register_api_routes(
     """
 
     @router.get("/api/themes")
-    async def list_themes():
+    async def list_themes() -> dict[str, list[str]]:
         return {"themes": get_theme_names()}

--- a/app/overlay/state_store.py
+++ b/app/overlay/state_store.py
@@ -13,7 +13,7 @@ import logging
 import os
 import re
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 
 from app.api._persistence_paths import DEFAULT_HASH_LEN, atomic_write_json, hashed_filename
 from app.id_validation import is_valid_overlay_id, validate_overlay_id
@@ -190,7 +190,7 @@ class OverlayStateStore:
     ``_meta.overlay_id`` so listings and cache lookups can recover it.
     """
 
-    def __init__(self, data_dir: str, templates_dir: str):
+    def __init__(self, data_dir: str, templates_dir: str) -> None:
         self._data_dir = data_dir
         self._overlays: dict[str, dict] = {}
         self._lock = threading.RLock()
@@ -199,7 +199,7 @@ class OverlayStateStore:
         # without making unrelated overlays wait on one another. These locks
         # are always acquired before ``self._lock``.
         self._persistence_locks: dict[str, threading.Lock] = {}
-        self._broadcast_callback: Callable | None = None
+        self._broadcast_callback: Callable[[str], None] | None = None
         # Maps any accepted URL token (output_key or raw overlay_id) to the
         # real overlay id. Populated lazily by resolve_overlay_id and kept
         # in sync by create/copy/delete.
@@ -207,7 +207,10 @@ class OverlayStateStore:
         self._all_overlays_scanned = False
         os.makedirs(data_dir, exist_ok=True)
 
-    def set_broadcast_callback(self, callback: Callable) -> None:
+    def set_broadcast_callback(
+        self,
+        callback: Callable[[str], None],
+    ) -> None:
         """Set the callback invoked after state changes to trigger broadcasts."""
         self._broadcast_callback = callback
 
@@ -366,7 +369,7 @@ class OverlayStateStore:
             self._populate_cache_locked()
             return self._output_key_cache.get(token)
 
-    def _iter_persisted_ids(self):
+    def _iter_persisted_ids(self) -> Iterator[tuple[str, str]]:
         """Yield ``(overlay_id, basename)`` for every state file on disk.
 
         Filenames are hash-based so the id is recovered from
@@ -406,10 +409,10 @@ class OverlayStateStore:
 
     # -- Available styles --------------------------------------------------
 
-    def get_available_styles_list(self) -> list:
+    def get_available_styles_list(self) -> list[str]:
         return self._style_catalog.get_available_styles_list()
 
-    def get_renderable_styles(self) -> list:
+    def get_renderable_styles(self) -> list[str]:
         return self._style_catalog.get_renderable_styles()
 
     # -- Style capabilities ------------------------------------------------
@@ -420,27 +423,30 @@ class OverlayStateStore:
     # Compatibility properties for fixtures and extensions that clear the
     # historical store-level caches between test/application lifecycles.
     @property
-    def _available_styles(self):
+    def _available_styles(self) -> list[str] | None:
         return self._style_catalog._available_styles
 
     @_available_styles.setter
-    def _available_styles(self, value):
+    def _available_styles(self, value: list[str] | None) -> None:
         self._style_catalog._available_styles = value
 
     @property
-    def _renderable_styles(self):
+    def _renderable_styles(self) -> list[str] | None:
         return self._style_catalog._renderable_styles
 
     @_renderable_styles.setter
-    def _renderable_styles(self, value):
+    def _renderable_styles(self, value: list[str] | None) -> None:
         self._style_catalog._renderable_styles = value
 
     @property
-    def _style_capabilities(self):
+    def _style_capabilities(self) -> dict[str, dict[str, bool]] | None:
         return self._style_catalog._style_capabilities
 
     @_style_capabilities.setter
-    def _style_capabilities(self, value):
+    def _style_capabilities(
+        self,
+        value: dict[str, dict[str, bool]] | None,
+    ) -> None:
         self._style_catalog._style_capabilities = value
 
     # -- CRUD --------------------------------------------------------------

--- a/app/overlay_backends/base.py
+++ b/app/overlay_backends/base.py
@@ -2,7 +2,8 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from app.overlay_backends.utils import split_custom_oid
 from app.state import State
@@ -46,11 +47,11 @@ class OverlayBackend(ABC):
     """Abstract interface for overlay communication."""
 
     @abstractmethod
-    def save_model(self, current_model: dict) -> None:
+    def save_model(self, current_model: dict[str, Any]) -> None:
         """Persist the raw game model to the overlay backend."""
 
     @abstractmethod
-    def save_customization(self, data: dict) -> None:
+    def save_customization(self, data: dict[str, Any]) -> None:
         """Persist customization data."""
 
     @abstractmethod
@@ -58,11 +59,18 @@ class OverlayBackend(ABC):
         """Toggle overlay visibility."""
 
     @abstractmethod
-    def get_model(self, oid: str = None, save_result: bool = False) -> dict | None:
+    def get_model(
+        self,
+        oid: str | None = None,
+        save_result: bool = False,
+    ) -> dict[str, Any] | None:
         """Retrieve the current raw game model."""
 
     @abstractmethod
-    def get_customization(self, oid: str = None) -> dict | None:
+    def get_customization(
+        self,
+        oid: str | None = None,
+    ) -> dict[str, Any] | None:
         """Retrieve the current customization dict."""
 
     @abstractmethod
@@ -70,15 +78,21 @@ class OverlayBackend(ABC):
         """Return whether the overlay is currently visible."""
 
     @abstractmethod
-    def get_available_styles(self, oid: str = None) -> list:
+    def get_available_styles(
+        self,
+        oid: str | None = None,
+    ) -> list[str]:
         """Return list of available overlay styles."""
 
-    def get_style_capabilities(self, oid: str = None) -> dict:
+    def get_style_capabilities(
+        self,
+        oid: str | None = None,
+    ) -> dict[str, Any]:
         """Per-style UI capability flags (theme / vertical-anchor support)."""
         return {}
 
     @abstractmethod
-    def fetch_output_token(self, oid: str = None) -> str | None:
+    def fetch_output_token(self, oid: str | None = None) -> str | None:
         """Fetch the output URL or token for this overlay."""
 
     @abstractmethod
@@ -90,21 +104,29 @@ class OverlayBackend(ABC):
         """Fetch the specific overlay layout ID from the provider."""
 
     @abstractmethod
-    def send_overlay_state(self, payload: dict, force_visibility=None,
-                           customization_state=None,
-                           show_only_current_set=None) -> None:
+    def send_overlay_state(
+        self,
+        payload: dict[str, Any],
+        force_visibility: bool | None = None,
+        customization_state: dict[str, Any] | None = None,
+        show_only_current_set: bool | None = None,
+    ) -> None:
         """Push a full overlay state update to connected displays."""
 
     @abstractmethod
-    def send_json_model(self, to_save: dict) -> None:
+    def send_json_model(self, to_save: dict[str, Any]) -> None:
         """Send a partial model update to the overlay provider."""
 
     @abstractmethod
     def reduce_games_to_one(self) -> None:
         """Reset scores of sets 2-5 to zero."""
 
-    def push_model_update(self, current_model: dict, to_save: dict,
-                          show_only_current_set=None) -> None:
+    def push_model_update(
+        self,
+        current_model: dict[str, Any],
+        to_save: dict[str, Any],
+        show_only_current_set: bool | None = None,
+    ) -> None:
         """Push a model update using the backend-appropriate mechanism.
 
         :class:`LocalOverlayBackend` overrides this to send a full overlay
@@ -112,15 +134,21 @@ class OverlayBackend(ABC):
         """
         self.send_json_model(to_save)
 
-    def on_customization_saved(self, get_model,
-                               customization: dict) -> None:
+    def on_customization_saved(
+        self,
+        get_model: Callable[[], dict[str, Any] | None],
+        customization: dict[str, Any],
+    ) -> None:
         """Hook called after customization is persisted (no-op by default).
 
         *get_model* is a callable returning the current model dict.
         """
 
-    def change_visibility_with_fallback(self, show: bool,
-                                        get_model=None) -> None:
+    def change_visibility_with_fallback(
+        self,
+        show: bool,
+        get_model: Callable[[], dict[str, Any] | None] | None = None,
+    ) -> None:
         """Toggle visibility with an optional HTTP fallback.
 
         *get_model* is a callable returning the current model dict (called
@@ -129,7 +157,7 @@ class OverlayBackend(ABC):
         """
         self.change_visibility(show)
 
-    def init_ws_client(self, oid: str = None) -> None:
+    def init_ws_client(self, oid: str | None = None) -> None:
         """Initialize WebSocket client (no-op by default)."""
 
     def close_ws_client(self) -> None:

--- a/app/overlay_backends/local.py
+++ b/app/overlay_backends/local.py
@@ -2,10 +2,17 @@
 
 import copy
 import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from app.env_vars_manager import EnvVarsManager
 from app.overlay_backends.base import CustomOidMixin, OverlayBackend
 from app.state import State
+
+if TYPE_CHECKING:
+    from app.conf import Conf
+    from app.overlay.broadcast import ObsBroadcastHub
+    from app.overlay.state_store import OverlayStateStore
 
 logger = logging.getLogger(__name__)
 
@@ -17,16 +24,16 @@ class LocalOverlayBackend(CustomOidMixin, OverlayBackend):
     of sending HTTP requests or WebSocket messages to an external server.
     """
 
-    def __init__(self, conf):
+    def __init__(self, conf: Conf) -> None:
         self.conf = conf
         # Build overlay payload callback — set by Backend after construction
-        self._build_payload = None
+        self._build_payload: Callable[..., dict[str, Any]] | None = None
 
-    def _store(self):
+    def _store(self) -> OverlayStateStore:
         from app.overlay import overlay_state_store
         return overlay_state_store
 
-    def _custom_id(self, oid=None):
+    def _custom_id(self, oid: str | None = None) -> str:
         """Per-user storage key for this session's overlay.
 
         A ``LocalOverlayBackend`` is bound to one session's ``conf``; when
@@ -35,11 +42,11 @@ class LocalOverlayBackend(CustomOidMixin, OverlayBackend):
         which raw ``oid`` a caller passes. Falls back to the mixin's bare-id
         behaviour for standalone/legacy construction.
         """
-        if getattr(self.conf, "skey", None):
+        if self.conf.skey:
             return self.conf.skey
         return super()._custom_id(oid)
 
-    def _broadcast(self):
+    def _broadcast(self) -> ObsBroadcastHub:
         from app.overlay import obs_broadcast_hub
         return obs_broadcast_hub
 
@@ -53,12 +60,12 @@ class LocalOverlayBackend(CustomOidMixin, OverlayBackend):
 
     # -- OverlayBackend interface --
 
-    def save_model(self, current_model: dict) -> None:
+    def save_model(self, current_model: dict[str, Any]) -> None:
         custom_id = self._custom_id()
         self._store().ensure_overlay(custom_id)
         self._store().set_raw_config(custom_id, model=current_model)
 
-    def save_customization(self, data: dict) -> None:
+    def save_customization(self, data: dict[str, Any]) -> None:
         custom_id = self._custom_id()
         self._store().ensure_overlay(custom_id)
         self._store().set_raw_config(custom_id, customization=data)
@@ -68,14 +75,22 @@ class LocalOverlayBackend(CustomOidMixin, OverlayBackend):
         self._store().ensure_overlay(custom_id)
         self._store().set_visibility(custom_id, show)
 
-    def get_model(self, oid: str = None, save_result: bool = False) -> dict | None:
+    def get_model(
+        self,
+        oid: str | None = None,
+        save_result: bool = False,
+    ) -> dict[str, Any] | None:
         custom_id = self._custom_id(oid)
         self._store().ensure_overlay(custom_id)
         raw = self._store().get_raw_config(custom_id)
         model = raw.get("model", {})
         return model if model else State().get_reset_model()
 
-    def _get_default_customization(self, style, custom_id):
+    def _get_default_customization(
+        self,
+        style: str | None,
+        custom_id: str,
+    ) -> dict[str, Any]:
         """Return a default customization dict, persisting preferredStyle."""
         from app.customization import Customization
         data = copy.copy(Customization.reset_state)
@@ -84,7 +99,10 @@ class LocalOverlayBackend(CustomOidMixin, OverlayBackend):
         self._store().set_raw_config(custom_id, customization=data)
         return data
 
-    def get_customization(self, oid: str = None) -> dict | None:
+    def get_customization(
+        self,
+        oid: str | None = None,
+    ) -> dict[str, Any] | None:
         check_oid = oid if oid is not None else self.conf.oid
         custom_id = self._custom_id(check_oid)
         style = self._style(check_oid)
@@ -109,13 +127,19 @@ class LocalOverlayBackend(CustomOidMixin, OverlayBackend):
             False, "false", 0, "0",
         )
 
-    def get_available_styles(self, oid: str = None) -> list:
+    def get_available_styles(
+        self,
+        oid: str | None = None,
+    ) -> list[str]:
         return self._store().get_available_styles_list()
 
-    def get_style_capabilities(self, oid: str = None) -> dict:
+    def get_style_capabilities(
+        self,
+        oid: str | None = None,
+    ) -> dict[str, Any]:
         return self._store().get_style_capabilities()
 
-    def fetch_output_token(self, oid: str = None) -> str | None:
+    def fetch_output_token(self, oid: str | None = None) -> str | None:
         from app.overlay.state_store import OverlayStateStore
         # The public OBS URL uses the per-overlay capability token when one
         # is bound to the session; otherwise fall back to the derived output
@@ -139,30 +163,42 @@ class LocalOverlayBackend(CustomOidMixin, OverlayBackend):
     def fetch_and_update_overlay_id(self, oid: str) -> None:
         logger.debug('Local overlay detected, skipping ID fetch')
 
-    def send_overlay_state(self, payload: dict, force_visibility=None,
-                           customization_state=None,
-                           show_only_current_set=None) -> None:
+    def send_overlay_state(
+        self,
+        payload: dict[str, Any],
+        force_visibility: bool | None = None,
+        customization_state: dict[str, Any] | None = None,
+        show_only_current_set: bool | None = None,
+    ) -> None:
         """Push state update into the in-process state store."""
         custom_id = self._custom_id()
         self._store().ensure_overlay(custom_id)
         self._store().update_state_sync(custom_id, payload)
 
-    def send_json_model(self, to_save: dict) -> None:
+    def send_json_model(self, to_save: dict[str, Any]) -> None:
         pass  # Local overlays don't use Uno's SetOverlayContent
 
     def reduce_games_to_one(self) -> None:
         pass  # Local overlays don't use Uno's SetOverlayContent
 
-    def push_model_update(self, current_model, to_save,
-                          show_only_current_set=None):
+    def push_model_update(
+        self,
+        current_model: dict[str, Any],
+        to_save: dict[str, Any],
+        show_only_current_set: bool | None = None,
+    ) -> None:
         if self._build_payload:
             payload = self._build_payload(
                 current_model, show_only_current_set=show_only_current_set,
             )
             self.send_overlay_state(payload)
 
-    def on_customization_saved(self, get_model, customization):
-        if self._build_payload and get_model:
+    def on_customization_saved(
+        self,
+        get_model: Callable[[], dict[str, Any] | None],
+        customization: dict[str, Any],
+    ) -> None:
+        if self._build_payload:
             current_model = get_model()
             if current_model:
                 payload = self._build_payload(
@@ -170,7 +206,11 @@ class LocalOverlayBackend(CustomOidMixin, OverlayBackend):
                 )
                 self.send_overlay_state(payload)
 
-    def change_visibility_with_fallback(self, show, get_model=None):
+    def change_visibility_with_fallback(
+        self,
+        show: bool,
+        get_model: Callable[[], dict[str, Any] | None] | None = None,
+    ) -> None:
         self.change_visibility(show)
         if self._build_payload and get_model:
             current_model = get_model()
@@ -181,11 +221,11 @@ class LocalOverlayBackend(CustomOidMixin, OverlayBackend):
                 self.send_overlay_state(payload)
 
     # WebSocket lifecycle not needed — no external WS connection
-    def init_ws_client(self, oid=None):
+    def init_ws_client(self, oid: str | None = None) -> None:
         pass
 
-    def close_ws_client(self):
+    def close_ws_client(self) -> None:
         pass
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         pass

--- a/app/overlay_backends/local.py
+++ b/app/overlay_backends/local.py
@@ -1,5 +1,7 @@
 """In-process overlay backend — no external server required."""
 
+from __future__ import annotations
+
 import copy
 import logging
 from collections.abc import Callable

--- a/app/overlay_backends/utils.py
+++ b/app/overlay_backends/utils.py
@@ -5,6 +5,8 @@ from collections.abc import Callable
 from enum import Enum
 from typing import Any
 
+import requests
+
 logger = logging.getLogger(__name__)
 
 # DEPRECATED — removal target: 7.0.0.
@@ -25,7 +27,7 @@ class OverlayKind(str, Enum):
     INVALID = "invalid"
 
 
-def is_custom_overlay(oid: str) -> bool:
+def is_custom_overlay(oid: str | None) -> bool:
     """Return True when *oid* uses the legacy ``C-`` custom overlay prefix.
 
     Kept for backward compatibility — new code should prefer
@@ -60,7 +62,7 @@ def split_custom_oid(oid: str | None) -> tuple[str, str | None]:
 
 
 def resolve_overlay_kind(
-    oid: str,
+    oid: str | None,
     local_overlay_exists: Callable[[str], bool],
 ) -> OverlayKind:
     """Decide whether *oid* refers to a known local overlay.
@@ -80,7 +82,10 @@ def resolve_overlay_kind(
     return OverlayKind.INVALID
 
 
-def safe_json(response, default: Any = None) -> Any:
+def safe_json(
+    response: requests.Response,
+    default: Any = None,
+) -> Any:
     """Decode *response*'s JSON body, returning *default* on parse error.
 
     Overlay responses occasionally come back as HTML error pages even on 2xx,
@@ -94,7 +99,10 @@ def safe_json(response, default: Any = None) -> Any:
         return default
 
 
-def _mock_response(status_code=200, payload=None):
+def _mock_response(
+    status_code: int = 200,
+    payload: Any = None,
+) -> Any:
     """Create a minimal response-like object for error paths."""
     body = payload or {}
     return type('MockResponse', (object,), {
@@ -102,4 +110,3 @@ def _mock_response(status_code=200, payload=None):
         'text': '',
         'json': lambda self: body,
     })()
-

--- a/app/overlays_service.py
+++ b/app/overlays_service.py
@@ -12,7 +12,7 @@ import secrets
 
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import InstrumentedAttribute, Session
 
 from app.db.models.overlay import UserOverlay
 from app.id_validation import validate_overlay_id
@@ -32,7 +32,10 @@ class OverlayNotFoundError(OverlayError, NotFoundServiceError):
     status_code = 404
 
 
-def _generate_token(db: Session, column) -> str:
+def _generate_token(
+    db: Session,
+    column: InstrumentedAttribute[str | None],
+) -> str:
     """Return a fresh, collision-checked url-safe token unique on *column*."""
     for _ in range(8):
         token = secrets.token_urlsafe(_PUBLIC_TOKEN_BYTES)

--- a/app/presets_service.py
+++ b/app/presets_service.py
@@ -15,6 +15,7 @@ from typing import Any
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import ColumnElement
 
 from app.api.preset_categories import categories_for_keys, filter_to_known
 from app.constants import PRESETS_MAX_NAME_LEN
@@ -115,7 +116,7 @@ def create_user_preset(db: Session, user_id: int, name: str, values: dict) -> Pr
     return preset
 
 
-def _for_user_where(user_id: int):
+def _for_user_where(user_id: int) -> ColumnElement[bool]:
     return ((Preset.scope == SCOPE_GLOBAL) & (Preset.is_active.is_(True))) | (
         Preset.owner_user_id == user_id
     )

--- a/app/state.py
+++ b/app/state.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
 
 
 class Serve(str, Enum):
@@ -100,7 +101,7 @@ class State:
         return f'Team {team} Set {set_num} Timeouts'
 
     @staticmethod
-    def keys_to_reset_simple_mode():
+    def keys_to_reset_simple_mode() -> set[str]:
         keys = {State.T1SET7_INT,
                 State.T2SET7_INT,
                 State.T1SET6_INT,
@@ -124,7 +125,7 @@ class State:
     # Construction & serialization
     # ------------------------------------------------------------------
 
-    def __init__(self, new_state=None):
+    def __init__(self, new_state: dict[str, Any] | None = None) -> None:
         if new_state is None:
             self._state = GameState()
         else:
@@ -196,10 +197,10 @@ class State:
             d[State._t_timeouts_key(2, i)] = str(s.team2_timeouts_by_set[i])
         return d
 
-    def get_reset_model(self):
+    def get_reset_model(self) -> dict[str, str]:
         return self.reset_model.copy()
 
-    def get_current_model(self):
+    def get_current_model(self) -> dict[str, str]:
         return self._to_dict()
 
     # ------------------------------------------------------------------
@@ -207,8 +208,8 @@ class State:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def simplify_model(simplified):
-        current_set = simplified[State.CURRENT_SET_INT]
+    def simplify_model(simplified: dict[str, str]) -> dict[str, str]:
+        current_set = int(simplified[State.CURRENT_SET_INT])
         t1_points = simplified[f'Team 1 Game {current_set} Score']
         t2_points = simplified[f'Team 2 Game {current_set} Score']
         # Capture per-set timeout values for the current set before we
@@ -236,10 +237,10 @@ class State:
     # Typed getters & setters
     # ------------------------------------------------------------------
 
-    def set_current_set(self, value):
+    def set_current_set(self, value: int | str) -> None:
         self._state.current_set = int(value)
 
-    def get_timeout(self, team, set_num=None):
+    def get_timeout(self, team: int, set_num: int | None = None) -> int:
         """Return the timeouts taken by *team* in *set_num*.
 
         ``set_num`` defaults to the current set when omitted, preserving
@@ -264,7 +265,12 @@ class State:
         )
         return slots[set_num]
 
-    def set_timeout(self, team, value, set_num=None):
+    def set_timeout(
+        self,
+        team: int,
+        value: int | str,
+        set_num: int | None = None,
+    ) -> None:
         """Set the timeout count for *team* in *set_num* (defaults to
         the current set).
 
@@ -285,7 +291,7 @@ class State:
         )
         slots[set_num] = int(value)
 
-    def get_timeouts_by_set(self, team) -> dict[int, int]:
+    def get_timeouts_by_set(self, team: int) -> dict[int, int]:
         """Return the full per-set timeout history for *team* as a
         1-indexed dict (set 1 through 5)."""
         if team not in (1, 2):
@@ -296,12 +302,12 @@ class State:
         )
         return {i: slots[i] for i in range(1, 8)}
 
-    def get_sets(self, team):
+    def get_sets(self, team: int) -> int:
         if team not in (1, 2):
             raise KeyError(f'Team {team} Sets')
         return self._state.team1_sets if team == 1 else self._state.team2_sets
 
-    def set_sets(self, team, value):
+    def set_sets(self, team: int, value: int | str) -> None:
         if team not in (1, 2):
             raise KeyError(f'Team {team} Sets')
         if team == 1:
@@ -309,7 +315,7 @@ class State:
         else:
             self._state.team2_sets = int(value)
 
-    def get_game(self, team, set_num):
+    def get_game(self, team: int, set_num: int) -> int:
         if team not in (1, 2):
             raise KeyError(f'Team {team} Game {set_num} Score')
         if not (1 <= set_num <= 7):
@@ -317,7 +323,12 @@ class State:
         scores = self._state.team1_scores if team == 1 else self._state.team2_scores
         return scores[set_num]
 
-    def set_game(self, set_num, team, value):
+    def set_game(
+        self,
+        set_num: int,
+        team: int,
+        value: int | str,
+    ) -> None:
         if team not in (1, 2):
             raise KeyError(f'Team {team} Game {set_num} Score')
         if not (1 <= set_num <= 7):
@@ -325,11 +336,11 @@ class State:
         scores = self._state.team1_scores if team == 1 else self._state.team2_scores
         scores[set_num] = int(value)
 
-    def set_current_serve(self, value):
+    def set_current_serve(self, value: Serve | str) -> None:
         if isinstance(value, Serve):
             self._state.serve = value
         else:
             self._state.serve = Serve(value)
 
-    def get_current_serve(self):
+    def get_current_serve(self) -> Serve:
         return self._state.serve

--- a/app/static_files.py
+++ b/app/static_files.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.responses import Response
+from starlette.types import Scope
 
 from app.app_config import get_app_title
 from app.pwa_manifest import _render_index_html
@@ -15,7 +18,7 @@ from app.pwa_manifest import _render_index_html
 class SPAStaticFiles(StaticFiles):
     """Serve the SPA shell for unknown paths and rewrite its runtime title."""
 
-    async def get_response(self, path, scope):
+    async def get_response(self, path: str, scope: Scope) -> Response:
         try:
             response = await super().get_response(path, scope)
         except StarletteHTTPException as exc:
@@ -26,7 +29,7 @@ class SPAStaticFiles(StaticFiles):
             return await self._index_response(scope)
         return response
 
-    async def _index_response(self, scope):
+    async def _index_response(self, scope: Scope) -> Response:
         if self.directory is None:
             return await super().get_response("index.html", scope)
         index_path = Path(self.directory) / "index.html"
@@ -46,11 +49,16 @@ class SPAStaticFiles(StaticFiles):
 class CachedStaticFiles(StaticFiles):
     """Apply a shared cache policy to successful static-file responses."""
 
-    def __init__(self, *args, cache_control: str, **kwargs):
+    def __init__(
+        self,
+        *args: Any,
+        cache_control: str,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self._cache_control = cache_control
 
-    async def get_response(self, path, scope):
+    async def get_response(self, path: str, scope: Scope) -> Response:
         response = await super().get_response(path, scope)
         if response.status_code in (200, 206, 304):
             response.headers.setdefault("Cache-Control", self._cache_control)

--- a/app/system_routes.py
+++ b/app/system_routes.py
@@ -32,7 +32,7 @@ def register_system_routes(
     """Register runtime/system endpoints before the SPA catch-all."""
 
     @application.get("/sw.js")
-    def serve_sw():
+    def serve_sw() -> FileResponse:
         frontend_sw = frontend_dir / "sw.js"
         if not frontend_sw.is_file():
             raise HTTPException(
@@ -53,7 +53,7 @@ def register_system_routes(
     def serve_webmanifest(
         request: Request,
         db: Session = Depends(get_db, scope="function"),
-    ):
+    ) -> JSONResponse:
         source = _vite_manifest_path()
         if source is None:
             return JSONResponse(
@@ -91,7 +91,7 @@ def register_system_routes(
         )
 
     @application.get("/manifest.json")
-    def serve_manifest():
+    def serve_manifest() -> JSONResponse:
         source = _vite_manifest_path()
         if source is None:
             return JSONResponse(
@@ -108,7 +108,7 @@ def register_system_routes(
         )
 
     @application.get("/health")
-    def health_check():
+    def health_check() -> dict[str, str | int]:
         return {
             "status": "ok",
             "timestamp": int(time.time()),
@@ -116,7 +116,7 @@ def register_system_routes(
         }
 
     @application.get("/health/ready")
-    def readiness_check():
+    def readiness_check() -> JSONResponse:
         """Readiness probe for writable local persistence."""
         from app.api import action_log
 

--- a/app/teams_service.py
+++ b/app/teams_service.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import ColumnElement, Select
 
 from app.api.schemas import is_acceptable_catalog_icon
 from app.db.models.team import Team, TeamGroup, TeamGroupMember, UserGroupTeam
@@ -62,7 +63,11 @@ def team_to_entry(team: Team) -> dict[str, Any]:
 # ---- global catalog --------------------------------------------------------
 
 
-def _paged(stmt, limit: int | None, offset: int):
+def _paged(
+    stmt: Select[Any],
+    limit: int | None,
+    offset: int,
+) -> Select[Any]:
     """Push a ``limit``/``offset`` window into *stmt*; ``limit=None`` = all."""
     if offset:
         stmt = stmt.offset(offset)
@@ -109,7 +114,14 @@ def get_global_by_name(db: Session, name: str) -> Team | None:
     return db.execute(select(Team).where(Team.is_global.is_(True), Team.name == name)).scalars().first()
 
 
-def upsert_global(db: Session, name: str, *, icon=None, color=None, text_color=None) -> Team:
+def upsert_global(
+    db: Session,
+    name: str,
+    *,
+    icon: str | None = None,
+    color: str | None = None,
+    text_color: str | None = None,
+) -> Team:
     name = (name or "").strip()
     if not name:
         raise TeamError("Team name is required.")
@@ -429,7 +441,7 @@ def list_user_private_groups(db: Session, user_id: int) -> list[TeamGroup]:
     )
 
 
-def _visible_groups_where(user_id: int):
+def _visible_groups_where(user_id: int) -> ColumnElement[bool]:
     return or_(
         and_(TeamGroup.owner_user_id.is_(None), TeamGroup.is_active.is_(True)),
         TeamGroup.owner_user_id == user_id,

--- a/frontend/schema/openapi.json
+++ b/frontend/schema/openapi.json
@@ -2358,7 +2358,16 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "title": "Response List Themes Api Themes Get",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -2872,7 +2881,14 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "title": "Response Admin Export Presets Api V1 Admin Presets Export Get",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -2929,7 +2945,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "title": "Response Admin Import Presets Api V1 Admin Presets Import Post",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -3048,7 +3070,20 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ]
+                  },
+                  "title": "Response Admin Set Preset Active Api V1 Admin Presets  Slug  Patch",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -3357,7 +3392,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "title": "Response Admin Delete Group Api V1 Admin Team Groups  Group Id  Delete",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -3421,7 +3462,20 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Admin Set Group Active Api V1 Admin Team Groups  Group Id  Patch",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -3487,7 +3541,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "title": "Response Admin Add Group Member Api V1 Admin Team Groups  Group Id  Members Post",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -3552,7 +3612,20 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Admin Remove Group Member Api V1 Admin Team Groups  Group Id  Members  Team Id  Delete",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -3659,7 +3732,14 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "title": "Response Admin Export Teams Api V1 Admin Teams Export Get",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -3717,7 +3797,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "title": "Response Admin Import Teams Api V1 Admin Teams Import Post",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -3773,7 +3859,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "title": "Response Admin Delete Team Api V1 Admin Teams  Team Id  Delete",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -4042,7 +4134,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "title": "Response Delete User Api V1 Admin Users  User Id  Delete",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -4247,7 +4345,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "title": "Response Replay Dead Letter Webhooks Api V1 Admin Webhooks Replay Post",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -4437,7 +4541,11 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Audit Log Api V1 Audit Get",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -5026,7 +5134,23 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "title": "Response Board Select Group Api V1 Board Selected Group Put",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -5312,7 +5436,14 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "title": "Response Board Group Teams Api V1 Board Team Groups  Group Key  Teams Get",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -5449,7 +5580,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "title": "Response Get Config Api V1 Config Get",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -5586,7 +5723,11 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Customization Api V1 Customization Get",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -8664,7 +8805,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Get Links Api V1 Links Get",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -8757,7 +8904,11 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Matches Api V1 Matches Get",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -8909,7 +9060,11 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Live Stats Api V1 Matches Live Stats Get",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -9014,7 +9169,11 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Match Api V1 Matches  Match Id  Get",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -9089,7 +9248,20 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Sign Match Url Api V1 Matches  Match Id  Sign Url Post",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -9292,7 +9464,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "title": "Response Delete My Group Api V1 My Groups  Group Id  Delete",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -9424,7 +9602,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "type": "integer"
+                  },
+                  "title": "Response Add Teams To My Group Api V1 My Groups  Group Id  Teams Post",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -9489,7 +9673,20 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Remove Team From My Group Api V1 My Groups  Group Id  Teams  Team Id  Delete",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -9694,7 +9891,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "title": "Response Delete My Overlay Api V1 Overlays  Oid  Delete",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -10361,7 +10564,11 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Style Capabilities Api V1 Style Capabilities Get",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -10499,7 +10706,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "title": "Response Get Styles Api V1 Styles Get",
+                  "type": "array"
+                }
               }
             },
             "description": "Successful Response"
@@ -10791,7 +11004,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "title": "Response Delete My Custom Team Api V1 Teams Mine  Team Id  Delete",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -10863,7 +11082,20 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Health Check Health Get",
+                  "type": "object"
+                }
               }
             },
             "description": "Successful Response"
@@ -11266,8 +11498,15 @@
             "name": "style",
             "required": false,
             "schema": {
-              "title": "Style",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Style"
             }
           },
           {
@@ -11275,8 +11514,15 @@
             "name": "lang",
             "required": false,
             "schema": {
-              "title": "Lang",
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Lang"
             }
           }
         ],

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -235,7 +235,7 @@ async function getPage<B>(path: string, offset: number): Promise<{ body: B; tota
  */
 async function getAllPages<B, R>(path: string, extract: (body: B) => R[]): Promise<R[]> {
   const rows: R[] = [];
-  for (let offset = 0; ; ) {
+  for (let offset = 0; ;) {
     const { body, total } = await getPage<B>(path, offset);
     const page = extract(body);
     // A body that isn't the expected array (an error envelope, a shape change)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -235,7 +235,7 @@ async function getPage<B>(path: string, offset: number): Promise<{ body: B; tota
  */
 async function getAllPages<B, R>(path: string, extract: (body: B) => R[]): Promise<R[]> {
   const rows: R[] = [];
-  for (let offset = 0; ;) {
+  for (let offset = 0; ; ) {
     const { body, total } = await getPage<B>(path, offset);
     const page = extract(body);
     // A body that isn't the expected array (an error envelope, a shape change)

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -2688,7 +2688,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: string[];
+                    };
                 };
             };
         };
@@ -2987,7 +2989,11 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: {
+                            [key: string]: unknown;
+                        };
+                    };
                 };
             };
             /** @description Validation Error */
@@ -3022,7 +3028,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: number;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -3090,7 +3098,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: string | boolean;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -3262,7 +3272,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: boolean;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -3299,7 +3311,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: boolean | number;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -3336,7 +3350,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: boolean;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -3370,7 +3386,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: boolean | number;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -3436,7 +3454,11 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: {
+                            [key: string]: unknown;
+                        };
+                    };
                 };
             };
             /** @description Validation Error */
@@ -3471,7 +3493,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: number;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -3504,7 +3528,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: boolean;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -3647,7 +3673,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: boolean;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -3753,7 +3781,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: number;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -3819,7 +3849,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -4163,7 +4195,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: boolean | number | null;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -4251,7 +4285,11 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: {
+                            [key: string]: unknown;
+                        };
+                    };
                 };
             };
             /** @description Validation Error */
@@ -4294,7 +4332,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: number;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -4337,7 +4377,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -5435,7 +5477,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: string;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -5473,7 +5517,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -5518,7 +5564,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -5551,7 +5599,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -5618,7 +5668,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: string | number;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -5724,7 +5776,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: boolean;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -5798,7 +5852,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: number;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -5832,7 +5888,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: boolean | number;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -5938,7 +5996,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: boolean;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -6184,7 +6244,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -6227,7 +6289,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": string[];
                 };
             };
             /** @description Validation Error */
@@ -6372,7 +6434,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: boolean;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -6432,7 +6496,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": {
+                        [key: string]: string | number;
+                    };
                 };
             };
         };
@@ -6635,8 +6701,8 @@ export interface operations {
     serve_overlay_overlay__public_token__get: {
         parameters: {
             query?: {
-                style?: string;
-                lang?: string;
+                style?: string | null;
+                lang?: string | null;
             };
             header?: never;
             path: {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,6 @@ ignore = [
     # ``_connections: dict = {}`` pattern on classmethod-only registries).
     # Real but pre-existing; tighten in a follow-up.
     "RUF012",
-    # Implicit Optional in function signatures — large mechanical sweep.
-    # Kept off until a dedicated typing pass.
-    "RUF013",
     # ``str, Enum`` → ``StrEnum`` is a behaviour change (str() output) and
     # would need test coverage of the enum boundary; defer to refactor PR.
     "UP042",
@@ -99,16 +96,16 @@ files = [
 python_version = "3.11"
 follow_imports = "silent"
 ignore_missing_imports = true
-implicit_optional = true
+implicit_optional = false
 # ``check_untyped_defs`` is on: without it mypy skips the *body* of every
 # unannotated function, which hid 4 real errors across 3 modules while the
 # gate reported "no issues found in 114 source files".
 check_untyped_defs = true
-# Still off: ~374 functions lack a return/parameter annotation, so turning
-# this on wholesale would fail the build. It is the remaining typing debt,
-# to be flipped module-by-module (heaviest first: app/customization.py 51,
-# app/api/game_service.py 43, app/backend.py 38, app/api/routes/teams.py 30).
-disallow_untyped_defs = false
+# Keep every function signature inside the checked backend surface typed.
+# Dynamic framework/JSON boundaries use explicit ``Any`` where a narrower
+# contract is not available, so new untyped definitions cannot silently
+# bypass body checking.
+disallow_untyped_defs = true
 warn_unused_ignores = true
 warn_redundant_casts = true
 


### PR DESCRIPTION
## Summary

- annotate every remaining backend function, with exact GameSession and Backend types across the core request path
- enforce disallow_untyped_defs, explicit optional types, and Ruff RUF013
- regenerate the OpenAPI contract and frontend bindings after adding route return types

## Validation

- ruff check .
- mypy
- pytest tests/ --cov=app --cov-report=term-missing (1,308 passed; 87.75% coverage)
- frontend typecheck, lint, format check, stylelint
- frontend unit tests and coverage (824 passed)
- Bandit medium-and-higher scan

Fixes #443