### PR TITLE
Bump js-yaml to 4.3.0 and brace-expansion to 5.0.8+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,34 @@ archive by hand.
   and the reason the existing suite had to `importlib.reload` the module
   to change a limit. They are read per call now.
 
+- **Cleared two of the three open Dependabot advisories on the frontend
+  dev toolchain (build-time only).** `js-yaml` moves to 4.3.0 — the npm
+  `override` floor was still `^4.2.0`, which pinned the tree to the last
+  release affected by [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m)
+  (quadratic CPU on YAML merge-key chains). That also clears the
+  `@redocly/openapi-core` alert, which was flagged only for depending on
+  it. `brace-expansion` moves 5.0.6 → 5.0.9 in the modern `minimatch@10`
+  chain, patching [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg)
+  (unbounded expansion → OOM) and
+  [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp).
+  `npm audit` goes from 3 high to 1 high; nothing here ships to users.
+
+  The remaining `brace-expansion` alert has **no upstream fix available**
+  and is deliberately left alone rather than papered over. It is patched
+  only in 5.0.8+, which changed its CommonJS export from the bare
+  function to `{ expand, … }`. `minimatch` 3.x and 5.x do
+  `const expand = require('brace-expansion')` and call it directly, so
+  forcing 5.x on them throws `expand is not a function` and breaks
+  `eslint` outright — and `eslint-plugin-react` (7.37.5) and
+  `eslint-plugin-jsx-a11y` (6.10.2) are both already at their latest
+  release and still depend on `minimatch@^3.1.2`. The 1.x/2.x/3.x/4.x
+  maintenance backports do not clear the advisory either. Pinning those
+  chains to their newest in-line release buys nothing and makes `npm
+  audit` report 15 findings instead of 1, so the override is scoped to
+  `minimatch@10` where 5.x actually loads. The exposure is a DoS on
+  attacker-supplied glob patterns; these run at lint/build time over
+  patterns from this repo's own config, and none of it reaches runtime.
+
 ### Added
 
 - **Opt-in privacy-scrubbed Sentry reporting and live operational gauges.**

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4367,16 +4367,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -7317,9 +7317,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,6 +61,9 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.5",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.3.0",
+    "minimatch@10": {
+      "brace-expansion": "^5.0.8"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Update frontend dev dependencies to resolve two high-severity Dependabot advisories affecting the build toolchain. These are build-time only dependencies with no runtime exposure to users.

## Changes

- **js-yaml**: `^4.2.0` → `^4.3.0` — patches [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) (quadratic CPU on YAML merge-key chains). This also clears the `@redocly/openapi-core` alert, which was flagged only for depending on the vulnerable version.
- **brace-expansion**: `5.0.6` → `5.0.8+` (scoped to `minimatch@10`) — patches [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (unbounded expansion → OOM) and [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp).

`npm audit` improves from 3 high to 1 high severity finding.

## Implementation notes

The remaining `brace-expansion` advisory has no upstream fix available and is deliberately left unpatched. The fix (5.0.8+) changed the CommonJS export from a bare function to `{ expand, … }`, breaking `minimatch` 3.x and 5.x which do `const expand = require('brace-expansion')` and call it directly. Since `eslint-plugin-react` (7.37.5) and `eslint-plugin-jsx-a11y` (6.10.2) are at their latest releases and still depend on `minimatch@^3.1.2`, forcing the patch globally would break eslint entirely.

The override is scoped to `minimatch@10` where 5.x actually loads correctly. The exposure is a DoS on attacker-supplied glob patterns; these run at lint/build time over patterns from this repo's own config, with no runtime exposure to users.

## Test plan

- [ ] `cd frontend && npm run lint`
- [ ] `cd frontend && npm run typecheck`
- [ ] `npm audit` shows 1 high (down from 3)

## Checklist

- [x] Added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] No secrets, credentials, or `.env` files committed

https://claude.ai/code/session_01WiPxKwv1XDLGoK2j63kL7h