### PR TITLE
test: add test coverage for useDoubleTap, useScoreActions, and match_report_access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,20 @@ archive by hand.
 
 ### Added
 
+- **Backfilled tests for the three highest-risk untested surfaces.**
+  `frontend/src/test/useDoubleTap.test.tsx` covers the press-gesture state
+  machine behind every score, timeout and set button — single tap, double
+  tap, long press and their documented priority, the touch/mouse and
+  keyboard-repeat guards, the cancel paths, the browser defaults the hook
+  suppresses, and timer cleanup on unmount.
+  `frontend/src/test/useScoreActions.test.tsx` covers the scoring handlers
+  and the point-type-picker gate, including the referential stability that
+  keeps a WebSocket state push from re-rendering the board's action context.
+  `tests/test_match_report_access.py` covers the authorization gate on
+  `/match/{id}/report` directly: public mode, signed capability URLs, the
+  owner cookie, and every path that denies access.
+  Fixes [#442](https://github.com/JacoboSanchez/volley-overlay-control/issues/442).
+
 - **Opt-in privacy-scrubbed Sentry reporting and live operational gauges.**
   Setting `SENTRY_DSN` enables FastAPI error reporting and optional
   transaction sampling without sending request bodies, cookies, query strings,

--- a/frontend/src/test/useDoubleTap.test.tsx
+++ b/frontend/src/test/useDoubleTap.test.tsx
@@ -1,0 +1,449 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDoubleTap } from '../hooks/useDoubleTap';
+import type { UseDoubleTapOptions } from '../hooks/useDoubleTap';
+import { DOUBLE_TAP_MS, LONG_PRESS_MS } from '../constants';
+
+function mouseDown(): React.MouseEvent<HTMLElement> {
+  return new MouseEvent('mousedown', { bubbles: true }) as unknown as React.MouseEvent<HTMLElement>;
+}
+
+function mouseUp(): React.MouseEvent<HTMLElement> {
+  return new MouseEvent('mouseup', { bubbles: true }) as unknown as React.MouseEvent<HTMLElement>;
+}
+
+function touchStart(): React.TouchEvent<HTMLElement> {
+  return new TouchEvent('touchstart', {
+    bubbles: true,
+    touches: [{ identifier: 0, target: document.body, clientX: 0, clientY: 0 } as unknown as Touch],
+  }) as unknown as React.TouchEvent<HTMLElement>;
+}
+
+function touchEnd(): React.TouchEvent<HTMLElement> {
+  return new TouchEvent('touchend', {
+    bubbles: true,
+    touches: [],
+  }) as unknown as React.TouchEvent<HTMLElement>;
+}
+
+function keyDown(key: string, repeat = false): React.KeyboardEvent<HTMLElement> {
+  return new KeyboardEvent('keydown', { key, repeat, bubbles: true }) as unknown as React.KeyboardEvent<HTMLElement>;
+}
+
+function keyUp(key: string): React.KeyboardEvent<HTMLElement> {
+  return new KeyboardEvent('keyup', { key, bubbles: true }) as unknown as React.KeyboardEvent<HTMLElement>;
+}
+
+function render(options: UseDoubleTapOptions = {}) {
+  return renderHook((opts: UseDoubleTapOptions = options) => useDoubleTap(opts), {
+    initialProps: options,
+  });
+}
+
+describe('useDoubleTap', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ------------------------------------------------------------------
+  // No onDoubleTap — onClick fires immediately on press-end
+  // ------------------------------------------------------------------
+  describe('single-tap only (no onDoubleTap)', () => {
+    it('fires onClick immediately on mouseUp', () => {
+      const onClick = vi.fn();
+      const { result } = render({ onClick });
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it('fires onClick immediately on touchend', () => {
+      const onClick = vi.fn();
+      const { result } = render({ onClick });
+      result.current.onTouchStart(touchStart());
+      result.current.onTouchEnd(touchEnd());
+      // touchActive cleared after 50ms setTimeout
+      act(() => vi.advanceTimersByTime(50));
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it('fires onClick immediately on Enter keydown/keyup', () => {
+      const onClick = vi.fn();
+      const { result } = render({ onClick });
+      result.current.onKeyDown(keyDown('Enter'));
+      result.current.onKeyUp(keyUp('Enter'));
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it('fires onClick immediately on Space keydown/keyup', () => {
+      const onClick = vi.fn();
+      const { result } = render({ onClick });
+      result.current.onKeyDown(keyDown(' '));
+      result.current.onKeyUp(keyUp(' '));
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Double-tap detection (at press-start)
+  // ------------------------------------------------------------------
+  describe('double-tap', () => {
+    it('detects double tap on second mousedown within window', () => {
+      const onClick = vi.fn();
+      const onDoubleTap = vi.fn();
+      const { result } = render({ onClick, onDoubleTap });
+
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+
+      act(() => vi.advanceTimersByTime(150));
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+
+      expect(onDoubleTap).toHaveBeenCalledOnce();
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('fires single tap after double-tap window expires', () => {
+      const onClick = vi.fn();
+      const onDoubleTap = vi.fn();
+      const { result } = render({ onClick, onDoubleTap });
+
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+
+      act(() => vi.advanceTimersByTime(DOUBLE_TAP_MS + 10));
+      expect(onClick).toHaveBeenCalledOnce();
+      expect(onDoubleTap).not.toHaveBeenCalled();
+    });
+
+    it('treats slow second tap as a new first tap', () => {
+      const onClick = vi.fn();
+      const onDoubleTap = vi.fn();
+      const { result } = render({ onClick, onDoubleTap });
+
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+      act(() => vi.advanceTimersByTime(DOUBLE_TAP_MS + 10));
+      expect(onClick).toHaveBeenCalledOnce();
+
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+      act(() => vi.advanceTimersByTime(DOUBLE_TAP_MS + 10));
+      expect(onClick).toHaveBeenCalledTimes(2);
+      expect(onDoubleTap).not.toHaveBeenCalled();
+    });
+
+    it('keyboard double tap on Enter', () => {
+      const onClick = vi.fn();
+      const onDoubleTap = vi.fn();
+      const { result } = render({ onClick, onDoubleTap });
+
+      result.current.onKeyDown(keyDown('Enter'));
+      result.current.onKeyUp(keyUp('Enter'));
+
+      act(() => vi.advanceTimersByTime(100));
+      result.current.onKeyDown(keyDown('Enter'));
+      result.current.onKeyUp(keyUp('Enter'));
+
+      expect(onDoubleTap).toHaveBeenCalledOnce();
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Long-press detection
+  // ------------------------------------------------------------------
+  describe('long-press', () => {
+    it('fires onLongPress after hold duration', () => {
+      const onLongPress = vi.fn();
+      const onClick = vi.fn();
+      const { result } = render({ onClick, onLongPress });
+
+      result.current.onMouseDown(mouseDown());
+      act(() => vi.advanceTimersByTime(LONG_PRESS_MS));
+      result.current.onMouseUp(mouseUp());
+
+      expect(onLongPress).toHaveBeenCalledOnce();
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('does not fire onLongPress if released before threshold', () => {
+      const onLongPress = vi.fn();
+      const onClick = vi.fn();
+      const { result } = render({ onClick, onLongPress });
+
+      result.current.onMouseDown(mouseDown());
+      act(() => vi.advanceTimersByTime(LONG_PRESS_MS - 100));
+      result.current.onMouseUp(mouseUp());
+
+      expect(onLongPress).not.toHaveBeenCalled();
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it('long-press suppresses single tap even when onDoubleTap is set', () => {
+      const onLongPress = vi.fn();
+      const onClick = vi.fn();
+      const onDoubleTap = vi.fn();
+      const { result } = render({ onClick, onDoubleTap, onLongPress });
+
+      result.current.onMouseDown(mouseDown());
+      act(() => vi.advanceTimersByTime(LONG_PRESS_MS));
+      result.current.onMouseUp(mouseUp());
+
+      expect(onLongPress).toHaveBeenCalledOnce();
+      expect(onClick).not.toHaveBeenCalled();
+      expect(onDoubleTap).not.toHaveBeenCalled();
+    });
+
+    it('long-press overrides pending double-tap', () => {
+      const onLongPress = vi.fn();
+      const onClick = vi.fn();
+      const onDoubleTap = vi.fn();
+      const { result } = render({ onClick, onDoubleTap, onLongPress });
+
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+
+      act(() => vi.advanceTimersByTime(100));
+      result.current.onMouseDown(mouseDown());
+      act(() => vi.advanceTimersByTime(LONG_PRESS_MS));
+      result.current.onMouseUp(mouseUp());
+
+      expect(onLongPress).toHaveBeenCalledOnce();
+      expect(onDoubleTap).not.toHaveBeenCalled();
+    });
+
+    it('respects custom longPressMs', () => {
+      const onLongPress = vi.fn();
+      const { result } = render({ onLongPress, longPressMs: 500 });
+
+      result.current.onMouseDown(mouseDown());
+      act(() => vi.advanceTimersByTime(400));
+      result.current.onMouseUp(mouseUp());
+      expect(onLongPress).not.toHaveBeenCalled();
+
+      result.current.onMouseDown(mouseDown());
+      act(() => vi.advanceTimersByTime(500));
+      result.current.onMouseUp(mouseUp());
+      expect(onLongPress).toHaveBeenCalledOnce();
+    });
+
+    it('respects custom doubleTapMs', () => {
+      const onClick = vi.fn();
+      const onDoubleTap = vi.fn();
+      const { result } = render({ onClick, onDoubleTap, doubleTapMs: 500 });
+
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+
+      act(() => vi.advanceTimersByTime(300));
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+      expect(onDoubleTap).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Gesture priority: long-press > double-tap > single-tap
+  // ------------------------------------------------------------------
+  describe('gesture priority', () => {
+    it('long-press wins over double-tap when all three are provided', () => {
+      const onClick = vi.fn();
+      const onDoubleTap = vi.fn();
+      const onLongPress = vi.fn();
+      const { result } = render({ onClick, onDoubleTap, onLongPress });
+
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+
+      act(() => vi.advanceTimersByTime(100));
+      result.current.onMouseDown(mouseDown());
+      act(() => vi.advanceTimersByTime(LONG_PRESS_MS));
+      result.current.onMouseUp(mouseUp());
+
+      expect(onLongPress).toHaveBeenCalledOnce();
+      expect(onDoubleTap).not.toHaveBeenCalled();
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('double-tap wins over single-tap', () => {
+      const onClick = vi.fn();
+      const onDoubleTap = vi.fn();
+      const { result } = render({ onClick, onDoubleTap });
+
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+
+      act(() => vi.advanceTimersByTime(100));
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+
+      expect(onDoubleTap).toHaveBeenCalledOnce();
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Concurrent-input guards
+  // ------------------------------------------------------------------
+  describe('concurrent input guards', () => {
+    it('touch blocks mouse after touchstart', () => {
+      const onClick = vi.fn();
+      const { result } = render({ onClick });
+
+      result.current.onTouchStart(touchStart());
+
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+
+      result.current.onTouchEnd(touchEnd());
+      act(() => vi.advanceTimersByTime(50));
+
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it('touchActive cleared after 50ms debounce on touchend', () => {
+      const onClick = vi.fn();
+      const { result } = render({ onClick });
+
+      result.current.onTouchStart(touchStart());
+      result.current.onTouchEnd(touchEnd());
+      expect(onClick).toHaveBeenCalledOnce();
+
+      onClick.mockClear();
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+      expect(onClick).not.toHaveBeenCalled();
+
+      act(() => vi.advanceTimersByTime(50));
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it('mouse is not blocked when no touch active', () => {
+      const onClick = vi.fn();
+      const { result } = render({ onClick });
+
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it('keyboard repeat events are ignored', () => {
+      const onClick = vi.fn();
+      const { result } = render({ onClick });
+
+      result.current.onKeyDown(keyDown('Enter', false));
+      result.current.onKeyDown(keyDown('Enter', true));
+      result.current.onKeyDown(keyDown('Enter', true));
+      result.current.onKeyUp(keyUp('Enter'));
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it('keyUp without prior keyDown is ignored', () => {
+      const onClick = vi.fn();
+      const { result } = render({ onClick });
+
+      result.current.onKeyUp(keyUp('Enter'));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('ignores non-Enter/non-Space keys', () => {
+      const onClick = vi.fn();
+      const { result } = render({ onClick });
+
+      result.current.onKeyDown(keyDown('a'));
+      result.current.onKeyUp(keyUp('a'));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Cancel press (mouseLeave / touchMove / touchCancel)
+  // ------------------------------------------------------------------
+  describe('cancel press', () => {
+    it('mouseLeave cancels long-press timer', () => {
+      const onLongPress = vi.fn();
+      const { result } = render({ onLongPress });
+
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseLeave(mouseUp());
+
+      act(() => vi.advanceTimersByTime(LONG_PRESS_MS + 100));
+      expect(onLongPress).not.toHaveBeenCalled();
+    });
+
+    it('touchMove cancels long-press and clears touchActive', () => {
+      const onLongPress = vi.fn();
+      const onClick = vi.fn();
+      const { result } = render({ onClick, onLongPress });
+
+      result.current.onTouchStart(touchStart());
+      result.current.onTouchMove(
+        new TouchEvent('touchmove', { bubbles: true, touches: [] }) as unknown as React.TouchEvent<HTMLElement>,
+      );
+      act(() => vi.advanceTimersByTime(LONG_PRESS_MS + 100));
+      expect(onLongPress).not.toHaveBeenCalled();
+
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it('mouseLeave cancels in-flight long-press but not already-scheduled single tap', () => {
+      const onClick = vi.fn();
+      const onDoubleTap = vi.fn();
+      const { result } = render({ onClick, onDoubleTap });
+
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+
+      act(() => vi.advanceTimersByTime(50));
+      result.current.onMouseLeave(mouseUp());
+
+      act(() => vi.advanceTimersByTime(DOUBLE_TAP_MS + 100));
+      expect(onClick).toHaveBeenCalledOnce();
+      expect(onDoubleTap).not.toHaveBeenCalled();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Cleanup
+  // ------------------------------------------------------------------
+  describe('cleanup', () => {
+    it('clears timers on unmount', () => {
+      const onLongPress = vi.fn();
+      const onClick = vi.fn();
+      const { result, unmount } = render({ onClick, onLongPress });
+
+      result.current.onMouseDown(mouseDown());
+      unmount();
+
+      act(() => vi.advanceTimersByTime(LONG_PRESS_MS + 100));
+      expect(onLongPress).not.toHaveBeenCalled();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Defensive: concurrent press paths
+  // ------------------------------------------------------------------
+  describe('defensive concurrent press paths', () => {
+    it('a second press-start clears the first long-press timer', () => {
+      const onLongPress = vi.fn();
+      const { result } = render({ onLongPress });
+
+      result.current.onMouseDown(mouseDown());
+      act(() => vi.advanceTimersByTime(200));
+
+      result.current.onKeyDown(keyDown('Enter'));
+      act(() => vi.advanceTimersByTime(LONG_PRESS_MS));
+
+      expect(onLongPress).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/frontend/src/test/useDoubleTap.test.tsx
+++ b/frontend/src/test/useDoubleTap.test.tsx
@@ -4,6 +4,10 @@ import { useDoubleTap } from '../hooks/useDoubleTap';
 import type { UseDoubleTapOptions } from '../hooks/useDoubleTap';
 import { DOUBLE_TAP_MS, LONG_PRESS_MS } from '../constants';
 
+// Real DOM events, cast to their React synthetic counterparts: the hook only
+// reads ``type`` / ``key`` / ``repeat`` and calls ``preventDefault``, so the
+// native event is a faithful stand-in. They are ``cancelable`` so tests can
+// assert the default-suppression the hook promises (Space must not scroll).
 function mouseDown(): React.MouseEvent<HTMLElement> {
   return new MouseEvent('mousedown', { bubbles: true }) as unknown as React.MouseEvent<HTMLElement>;
 }
@@ -12,36 +16,52 @@ function mouseUp(): React.MouseEvent<HTMLElement> {
   return new MouseEvent('mouseup', { bubbles: true }) as unknown as React.MouseEvent<HTMLElement>;
 }
 
+function mouseLeave(): React.MouseEvent<HTMLElement> {
+  return new MouseEvent('mouseleave', {
+    bubbles: false,
+  }) as unknown as React.MouseEvent<HTMLElement>;
+}
+
 function touchStart(): React.TouchEvent<HTMLElement> {
   return new TouchEvent('touchstart', {
     bubbles: true,
+    cancelable: true,
     touches: [{ identifier: 0, target: document.body, clientX: 0, clientY: 0 } as unknown as Touch],
   }) as unknown as React.TouchEvent<HTMLElement>;
 }
 
-function touchEnd(): React.TouchEvent<HTMLElement> {
-  return new TouchEvent('touchend', {
+function touchEvent(type: 'touchend' | 'touchmove' | 'touchcancel'): React.TouchEvent<HTMLElement> {
+  return new TouchEvent(type, {
     bubbles: true,
+    cancelable: true,
     touches: [],
   }) as unknown as React.TouchEvent<HTMLElement>;
 }
 
 function keyDown(key: string, repeat = false): React.KeyboardEvent<HTMLElement> {
-  return new KeyboardEvent('keydown', { key, repeat, bubbles: true }) as unknown as React.KeyboardEvent<HTMLElement>;
+  return new KeyboardEvent('keydown', {
+    key,
+    repeat,
+    bubbles: true,
+    cancelable: true,
+  }) as unknown as React.KeyboardEvent<HTMLElement>;
 }
 
 function keyUp(key: string): React.KeyboardEvent<HTMLElement> {
-  return new KeyboardEvent('keyup', { key, bubbles: true }) as unknown as React.KeyboardEvent<HTMLElement>;
+  return new KeyboardEvent('keyup', {
+    key,
+    bubbles: true,
+    cancelable: true,
+  }) as unknown as React.KeyboardEvent<HTMLElement>;
 }
 
 function render(options: UseDoubleTapOptions = {}) {
-  return renderHook((opts: UseDoubleTapOptions = options) => useDoubleTap(opts), {
-    initialProps: options,
-  });
+  return renderHook(() => useDoubleTap(options));
 }
 
 describe('useDoubleTap', () => {
   beforeEach(() => {
+    // Fake timers also fake ``Date.now``, which the double-tap gap depends on.
     vi.useFakeTimers();
   });
   afterEach(() => {
@@ -64,9 +84,7 @@ describe('useDoubleTap', () => {
       const onClick = vi.fn();
       const { result } = render({ onClick });
       result.current.onTouchStart(touchStart());
-      result.current.onTouchEnd(touchEnd());
-      // touchActive cleared after 50ms setTimeout
-      act(() => vi.advanceTimersByTime(50));
+      result.current.onTouchEnd(touchEvent('touchend'));
       expect(onClick).toHaveBeenCalledOnce();
     });
 
@@ -88,6 +106,36 @@ describe('useDoubleTap', () => {
   });
 
   // ------------------------------------------------------------------
+  // Browser default suppression
+  // ------------------------------------------------------------------
+  describe('default suppression', () => {
+    it('preventDefaults Space so the page does not scroll under the button', () => {
+      const { result } = render({ onClick: vi.fn() });
+      const down = keyDown(' ');
+      const up = keyUp(' ');
+      result.current.onKeyDown(down);
+      result.current.onKeyUp(up);
+      expect((down as unknown as KeyboardEvent).defaultPrevented).toBe(true);
+      expect((up as unknown as KeyboardEvent).defaultPrevented).toBe(true);
+    });
+
+    it('leaves unhandled keys alone', () => {
+      const { result } = render({ onClick: vi.fn() });
+      const down = keyDown('a');
+      result.current.onKeyDown(down);
+      expect((down as unknown as KeyboardEvent).defaultPrevented).toBe(false);
+    });
+
+    it('preventDefaults touchend so the browser emits no synthetic click', () => {
+      const { result } = render({ onClick: vi.fn() });
+      const end = touchEvent('touchend');
+      result.current.onTouchStart(touchStart());
+      result.current.onTouchEnd(end);
+      expect((end as unknown as TouchEvent).defaultPrevented).toBe(true);
+    });
+  });
+
+  // ------------------------------------------------------------------
   // Double-tap detection (at press-start)
   // ------------------------------------------------------------------
   describe('double-tap', () => {
@@ -104,6 +152,9 @@ describe('useDoubleTap', () => {
       result.current.onMouseUp(mouseUp());
 
       expect(onDoubleTap).toHaveBeenCalledOnce();
+      // Double-tap wins over single-tap: the pending onClick is cancelled.
+      expect(onClick).not.toHaveBeenCalled();
+      act(() => vi.advanceTimersByTime(DOUBLE_TAP_MS + 10));
       expect(onClick).not.toHaveBeenCalled();
     });
 
@@ -199,24 +250,6 @@ describe('useDoubleTap', () => {
       expect(onDoubleTap).not.toHaveBeenCalled();
     });
 
-    it('long-press overrides pending double-tap', () => {
-      const onLongPress = vi.fn();
-      const onClick = vi.fn();
-      const onDoubleTap = vi.fn();
-      const { result } = render({ onClick, onDoubleTap, onLongPress });
-
-      result.current.onMouseDown(mouseDown());
-      result.current.onMouseUp(mouseUp());
-
-      act(() => vi.advanceTimersByTime(100));
-      result.current.onMouseDown(mouseDown());
-      act(() => vi.advanceTimersByTime(LONG_PRESS_MS));
-      result.current.onMouseUp(mouseUp());
-
-      expect(onLongPress).toHaveBeenCalledOnce();
-      expect(onDoubleTap).not.toHaveBeenCalled();
-    });
-
     it('respects custom longPressMs', () => {
       const onLongPress = vi.fn();
       const { result } = render({ onLongPress, longPressMs: 500 });
@@ -240,18 +273,21 @@ describe('useDoubleTap', () => {
       result.current.onMouseDown(mouseDown());
       result.current.onMouseUp(mouseUp());
 
+      // 300ms would be too slow for the default 280ms window.
       act(() => vi.advanceTimersByTime(300));
       result.current.onMouseDown(mouseDown());
       result.current.onMouseUp(mouseUp());
       expect(onDoubleTap).toHaveBeenCalledOnce();
+      expect(onClick).not.toHaveBeenCalled();
     });
   });
 
   // ------------------------------------------------------------------
-  // Gesture priority: long-press > double-tap > single-tap
+  // Gesture priority: long-press > double-tap > single-tap.
+  // (double-tap > single-tap is asserted in the double-tap block above.)
   // ------------------------------------------------------------------
   describe('gesture priority', () => {
-    it('long-press wins over double-tap when all three are provided', () => {
+    it('long-press wins over a pending double-tap and the single tap', () => {
       const onClick = vi.fn();
       const onDoubleTap = vi.fn();
       const onLongPress = vi.fn();
@@ -269,22 +305,6 @@ describe('useDoubleTap', () => {
       expect(onDoubleTap).not.toHaveBeenCalled();
       expect(onClick).not.toHaveBeenCalled();
     });
-
-    it('double-tap wins over single-tap', () => {
-      const onClick = vi.fn();
-      const onDoubleTap = vi.fn();
-      const { result } = render({ onClick, onDoubleTap });
-
-      result.current.onMouseDown(mouseDown());
-      result.current.onMouseUp(mouseUp());
-
-      act(() => vi.advanceTimersByTime(100));
-      result.current.onMouseDown(mouseDown());
-      result.current.onMouseUp(mouseUp());
-
-      expect(onDoubleTap).toHaveBeenCalledOnce();
-      expect(onClick).not.toHaveBeenCalled();
-    });
   });
 
   // ------------------------------------------------------------------
@@ -300,9 +320,10 @@ describe('useDoubleTap', () => {
       result.current.onMouseDown(mouseDown());
       result.current.onMouseUp(mouseUp());
 
-      result.current.onTouchEnd(touchEnd());
+      result.current.onTouchEnd(touchEvent('touchend'));
       act(() => vi.advanceTimersByTime(50));
 
+      // Only the touch path fired; the emulated mouse pair was swallowed.
       expect(onClick).toHaveBeenCalledOnce();
     });
 
@@ -311,7 +332,7 @@ describe('useDoubleTap', () => {
       const { result } = render({ onClick });
 
       result.current.onTouchStart(touchStart());
-      result.current.onTouchEnd(touchEnd());
+      result.current.onTouchEnd(touchEvent('touchend'));
       expect(onClick).toHaveBeenCalledOnce();
 
       onClick.mockClear();
@@ -372,7 +393,7 @@ describe('useDoubleTap', () => {
       const { result } = render({ onLongPress });
 
       result.current.onMouseDown(mouseDown());
-      result.current.onMouseLeave(mouseUp());
+      result.current.onMouseLeave(mouseLeave());
 
       act(() => vi.advanceTimersByTime(LONG_PRESS_MS + 100));
       expect(onLongPress).not.toHaveBeenCalled();
@@ -384,18 +405,28 @@ describe('useDoubleTap', () => {
       const { result } = render({ onClick, onLongPress });
 
       result.current.onTouchStart(touchStart());
-      result.current.onTouchMove(
-        new TouchEvent('touchmove', { bubbles: true, touches: [] }) as unknown as React.TouchEvent<HTMLElement>,
-      );
+      result.current.onTouchMove(touchEvent('touchmove'));
       act(() => vi.advanceTimersByTime(LONG_PRESS_MS + 100));
       expect(onLongPress).not.toHaveBeenCalled();
 
+      // touchActive was released, so the mouse path works again immediately.
       result.current.onMouseDown(mouseDown());
       result.current.onMouseUp(mouseUp());
       expect(onClick).toHaveBeenCalledOnce();
     });
 
-    it('mouseLeave cancels in-flight long-press but not already-scheduled single tap', () => {
+    it('touchCancel cancels the long-press timer', () => {
+      const onLongPress = vi.fn();
+      const { result } = render({ onLongPress });
+
+      result.current.onTouchStart(touchStart());
+      result.current.onTouchCancel(touchEvent('touchcancel'));
+
+      act(() => vi.advanceTimersByTime(LONG_PRESS_MS + 100));
+      expect(onLongPress).not.toHaveBeenCalled();
+    });
+
+    it('mouseLeave drops a pending double-tap but not an already-scheduled single tap', () => {
       const onClick = vi.fn();
       const onDoubleTap = vi.fn();
       const { result } = render({ onClick, onDoubleTap });
@@ -404,7 +435,7 @@ describe('useDoubleTap', () => {
       result.current.onMouseUp(mouseUp());
 
       act(() => vi.advanceTimersByTime(50));
-      result.current.onMouseLeave(mouseUp());
+      result.current.onMouseLeave(mouseLeave());
 
       act(() => vi.advanceTimersByTime(DOUBLE_TAP_MS + 100));
       expect(onClick).toHaveBeenCalledOnce();
@@ -416,7 +447,7 @@ describe('useDoubleTap', () => {
   // Cleanup
   // ------------------------------------------------------------------
   describe('cleanup', () => {
-    it('clears timers on unmount', () => {
+    it('clears the long-press timer on unmount', () => {
       const onLongPress = vi.fn();
       const onClick = vi.fn();
       const { result, unmount } = render({ onClick, onLongPress });
@@ -426,6 +457,22 @@ describe('useDoubleTap', () => {
 
       act(() => vi.advanceTimersByTime(LONG_PRESS_MS + 100));
       expect(onLongPress).not.toHaveBeenCalled();
+    });
+
+    it('clears the pending single-tap timer on unmount', () => {
+      const onClick = vi.fn();
+      const onDoubleTap = vi.fn();
+      const { result, unmount } = render({ onClick, onDoubleTap });
+
+      // A single tap leaves onClick scheduled for the length of the
+      // double-tap window; unmounting inside it must not score a point on
+      // a board the operator has already navigated away from.
+      result.current.onMouseDown(mouseDown());
+      result.current.onMouseUp(mouseUp());
+      unmount();
+
+      act(() => vi.advanceTimersByTime(DOUBLE_TAP_MS + 100));
+      expect(onClick).not.toHaveBeenCalled();
     });
   });
 
@@ -443,6 +490,8 @@ describe('useDoubleTap', () => {
       result.current.onKeyDown(keyDown('Enter'));
       act(() => vi.advanceTimersByTime(LONG_PRESS_MS));
 
+      // Without the defensive clear the orphaned first timer would also
+      // fire inside this window, making it two calls.
       expect(onLongPress).toHaveBeenCalledOnce();
     });
   });

--- a/frontend/src/test/useScoreActions.test.tsx
+++ b/frontend/src/test/useScoreActions.test.tsx
@@ -1,0 +1,359 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useScoreActions } from '../hooks/useScoreActions';
+import type { GameActions } from '../hooks/useGameState';
+import type { Settings } from '../hooks/useSettings';
+import type { HapticPattern } from '../hooks/useHaptics';
+
+function mockActions(overrides: Partial<GameActions> = {}): GameActions {
+  return {
+    addPoint: vi.fn(),
+    addSet: vi.fn(),
+    addTimeout: vi.fn(),
+    changeServe: vi.fn(),
+    setSimpleMode: vi.fn(),
+    undoLast: vi.fn(),
+    setScore: vi.fn(),
+    setSets: vi.fn(),
+    reset: vi.fn(),
+    startMatch: vi.fn(),
+    setVisibility: vi.fn(),
+    setSwapSides: vi.fn(),
+    setSetSummary: vi.fn(),
+    setSetSummaryStyle: vi.fn(),
+    ...overrides,
+  };
+}
+
+function mockSettings(overrides: Partial<Settings> = {}): Settings {
+  return {
+    trackPointTypes: false,
+    autoSimple: false,
+    autoSimpleOnTimeout: false,
+    ...overrides,
+  } as Settings;
+}
+
+function mockPulse(): (pattern: HapticPattern | string) => void {
+  return vi.fn();
+}
+
+function render({
+  actions = mockActions(),
+  settings = mockSettings(),
+  simpleMode = false,
+  matchFinished = false,
+  pulse = mockPulse(),
+}: {
+  actions?: GameActions;
+  settings?: Settings;
+  simpleMode?: boolean;
+  matchFinished?: boolean;
+  pulse?: ReturnType<typeof mockPulse>;
+} = {}) {
+  return renderHook(
+    ({ a, s, sm, mf, p }: {
+      a: GameActions;
+      s: Settings;
+      sm: boolean;
+      mf: boolean;
+      p: (pattern: HapticPattern | string) => void;
+    }) => useScoreActions({ actions: a, settings: s, simpleMode: sm, matchFinished: mf, pulse: p }),
+    {
+      initialProps: { a: actions, s: settings, sm: simpleMode, mf: matchFinished, p: pulse },
+    },
+  );
+}
+
+describe('useScoreActions', () => {
+  // ------------------------------------------------------------------
+  // handleAddPoint
+  // ------------------------------------------------------------------
+  describe('handleAddPoint', () => {
+    it('scores a point immediately when trackPointTypes is off', () => {
+      const actions = mockActions();
+      const { result: r } = render({ actions });
+      act(() => r.current.handleAddPoint(1));
+      expect(actions.addPoint).toHaveBeenCalledWith(1, false, undefined, undefined);
+    });
+
+    it('opens the point-type picker when trackPointTypes is on', () => {
+      const actions = mockActions();
+      const settings = mockSettings({ trackPointTypes: true });
+      const { result: r } = render({ actions, settings });
+      act(() => r.current.handleAddPoint(1));
+      expect(actions.addPoint).not.toHaveBeenCalled();
+      expect(r.current.pointPickerTeam).toBe(1);
+    });
+
+    it('is a no-op when match is finished', () => {
+      const actions = mockActions();
+      const { result: r } = render({ actions, matchFinished: true });
+      act(() => r.current.handleAddPoint(1));
+      expect(actions.addPoint).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when matchFinished and trackPointTypes are both on', () => {
+      const actions = mockActions();
+      const settings = mockSettings({ trackPointTypes: true });
+      const { result: r } = render({ actions, settings, matchFinished: true });
+      act(() => r.current.handleAddPoint(2));
+      expect(actions.addPoint).not.toHaveBeenCalled();
+      expect(r.current.pointPickerTeam).toBeNull();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // commitPoint
+  // ------------------------------------------------------------------
+  describe('commitPoint', () => {
+    it('scores with point type and error type', () => {
+      const actions = mockActions();
+      const { result: r } = render({ actions });
+      act(() => r.current.commitPoint(2, 'kill', 'serve_error'));
+      expect(actions.addPoint).toHaveBeenCalledWith(2, false, 'kill', 'serve_error');
+    });
+
+    it('scores without classification', () => {
+      const actions = mockActions();
+      const { result: r } = render({ actions });
+      act(() => r.current.commitPoint(1));
+      expect(actions.addPoint).toHaveBeenCalledWith(1, false, undefined, undefined);
+    });
+
+    it('enables simple mode via autoSimple when scoring and not already simple', () => {
+      const actions = mockActions();
+      const settings = mockSettings({ autoSimple: true });
+      const { result: r } = render({ actions, settings, simpleMode: false });
+      act(() => r.current.commitPoint(1));
+      expect(actions.addPoint).toHaveBeenCalled();
+      expect(actions.setSimpleMode).toHaveBeenCalledWith(true);
+    });
+
+    it('does not set simple mode when already in simple mode', () => {
+      const actions = mockActions();
+      const settings = mockSettings({ autoSimple: true });
+      const { result: r } = render({ actions, settings, simpleMode: true });
+      act(() => r.current.commitPoint(2));
+      expect(actions.setSimpleMode).not.toHaveBeenCalled();
+    });
+
+    it('does not set simple mode when autoSimple is off', () => {
+      const actions = mockActions();
+      const settings = mockSettings({ autoSimple: false });
+      const { result: r } = render({ actions, settings, simpleMode: false });
+      act(() => r.current.commitPoint(1));
+      expect(actions.setSimpleMode).not.toHaveBeenCalled();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // handleAddSet
+  // ------------------------------------------------------------------
+  describe('handleAddSet', () => {
+    it('adds a set for team 1', () => {
+      const actions = mockActions();
+      const { result: r } = render({ actions });
+      act(() => r.current.handleAddSet(1));
+      expect(actions.addSet).toHaveBeenCalledWith(1, false);
+    });
+
+    it('adds a set for team 2', () => {
+      const actions = mockActions();
+      const { result: r } = render({ actions });
+      act(() => r.current.handleAddSet(2));
+      expect(actions.addSet).toHaveBeenCalledWith(2, false);
+    });
+
+    it('is a no-op when matchFinished', () => {
+      const actions = mockActions();
+      const { result: r } = render({ actions, matchFinished: true });
+      act(() => r.current.handleAddSet(1));
+      expect(actions.addSet).not.toHaveBeenCalled();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // handleAddTimeout
+  // ------------------------------------------------------------------
+  describe('handleAddTimeout', () => {
+    it('registers a timeout for team 1', () => {
+      const actions = mockActions();
+      const { result: r } = render({ actions });
+      act(() => r.current.handleAddTimeout(1));
+      expect(actions.addTimeout).toHaveBeenCalledWith(1, false);
+    });
+
+    it('is a no-op when matchFinished', () => {
+      const actions = mockActions();
+      const { result: r } = render({ actions, matchFinished: true });
+      act(() => r.current.handleAddTimeout(1));
+      expect(actions.addTimeout).not.toHaveBeenCalled();
+    });
+
+    it('exits simple mode when autoSimple + autoSimpleOnTimeout are on and currently simple', () => {
+      const actions = mockActions();
+      const settings = mockSettings({ autoSimple: true, autoSimpleOnTimeout: true });
+      const { result: r } = render({ actions, settings, simpleMode: true });
+      act(() => r.current.handleAddTimeout(2));
+      expect(actions.setSimpleMode).toHaveBeenCalledWith(false);
+    });
+
+    it('does not exit simple mode when autoSimpleOnTimeout is off', () => {
+      const actions = mockActions();
+      const settings = mockSettings({ autoSimple: true, autoSimpleOnTimeout: false });
+      const { result: r } = render({ actions, settings, simpleMode: true });
+      act(() => r.current.handleAddTimeout(2));
+      expect(actions.setSimpleMode).not.toHaveBeenCalled();
+    });
+
+    it('does not exit simple mode when not currently in simple mode', () => {
+      const actions = mockActions();
+      const settings = mockSettings({ autoSimple: true, autoSimpleOnTimeout: true });
+      const { result: r } = render({ actions, settings, simpleMode: false });
+      act(() => r.current.handleAddTimeout(2));
+      expect(actions.setSimpleMode).not.toHaveBeenCalled();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // handleChangeServe
+  // ------------------------------------------------------------------
+  describe('handleChangeServe', () => {
+    it('changes serve to team 1', () => {
+      const actions = mockActions();
+      const { result: r } = render({ actions });
+      act(() => r.current.handleChangeServe(1));
+      expect(actions.changeServe).toHaveBeenCalledWith(1);
+    });
+
+    it('changes serve to team 2', () => {
+      const actions = mockActions();
+      const { result: r } = render({ actions });
+      act(() => r.current.handleChangeServe(2));
+      expect(actions.changeServe).toHaveBeenCalledWith(2);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // handleDoubleTapScore
+  // ------------------------------------------------------------------
+  describe('handleDoubleTapScore', () => {
+    it('undoes a point for team 1 and pulses haptics', () => {
+      const actions = mockActions();
+      const pulse = vi.fn();
+      const { result: r } = render({ actions, pulse });
+      act(() => r.current.handleDoubleTapScore(1));
+      expect(pulse).toHaveBeenCalledWith('confirm');
+      expect(actions.addPoint).toHaveBeenCalledWith(1, true);
+    });
+
+    it('undoes a point for team 2 and pulses haptics', () => {
+      const actions = mockActions();
+      const pulse = vi.fn();
+      const { result: r } = render({ actions, pulse });
+      act(() => r.current.handleDoubleTapScore(2));
+      expect(pulse).toHaveBeenCalledWith('confirm');
+      expect(actions.addPoint).toHaveBeenCalledWith(2, true);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // handleDoubleTapTimeout
+  // ------------------------------------------------------------------
+  describe('handleDoubleTapTimeout', () => {
+    it('undoes a timeout for team 1 and pulses haptics', () => {
+      const actions = mockActions();
+      const pulse = vi.fn();
+      const { result: r } = render({ actions, pulse });
+      act(() => r.current.handleDoubleTapTimeout(1));
+      expect(pulse).toHaveBeenCalledWith('confirm');
+      expect(actions.addTimeout).toHaveBeenCalledWith(1, true);
+    });
+
+    it('undoes a timeout for team 2 and pulses haptics', () => {
+      const actions = mockActions();
+      const pulse = vi.fn();
+      const { result: r } = render({ actions, pulse });
+      act(() => r.current.handleDoubleTapTimeout(2));
+      expect(pulse).toHaveBeenCalledWith('confirm');
+      expect(actions.addTimeout).toHaveBeenCalledWith(2, true);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // pointPickerTeam state
+  // ------------------------------------------------------------------
+  describe('pointPickerTeam', () => {
+    it('starts null', () => {
+      const { result: r } = render();
+      expect(r.current.pointPickerTeam).toBeNull();
+    });
+
+    it('can be closed via setPointPickerTeam(null)', () => {
+      const actions = mockActions();
+      const settings = mockSettings({ trackPointTypes: true });
+      const { result: r } = render({ actions, settings });
+      act(() => r.current.handleAddPoint(1));
+      expect(r.current.pointPickerTeam).toBe(1);
+      act(() => r.current.setPointPickerTeam(null));
+      expect(r.current.pointPickerTeam).toBeNull();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Callback stability (inputsRef pattern)
+  // ------------------------------------------------------------------
+  describe('callback stability through inputsRef', () => {
+    it('reads up-to-date matchFinished from ref on subsequent renders', () => {
+      const actions = mockActions();
+      const pulse = vi.fn();
+      const { result: r, rerender } = renderHook(
+        ({ mf }: { mf: boolean }) =>
+          useScoreActions({
+            actions,
+            settings: mockSettings(),
+            simpleMode: false,
+            matchFinished: mf,
+            pulse,
+          }),
+        { initialProps: { mf: false } },
+      );
+
+      act(() => r.current.handleAddPoint(1));
+      expect(actions.addPoint).toHaveBeenCalledTimes(1);
+
+      (actions.addPoint as ReturnType<typeof vi.fn>).mockClear();
+      rerender({ mf: true });
+
+      act(() => r.current.handleAddPoint(1));
+      expect(actions.addPoint).not.toHaveBeenCalled();
+    });
+
+    it('reads up-to-date autoSimple from ref on subsequent renders', () => {
+      const actions = mockActions();
+      const pulse = vi.fn();
+      const { result: r, rerender } = renderHook(
+        ({ autoSimple }: { autoSimple: boolean }) =>
+          useScoreActions({
+            actions,
+            settings: mockSettings({ autoSimple }),
+            simpleMode: false,
+            matchFinished: false,
+            pulse,
+          }),
+        { initialProps: { autoSimple: false } },
+      );
+
+      act(() => r.current.commitPoint(1));
+      expect(actions.setSimpleMode).not.toHaveBeenCalled();
+
+      (actions.addPoint as ReturnType<typeof vi.fn>).mockClear();
+      (actions.setSimpleMode as ReturnType<typeof vi.fn>).mockClear();
+      rerender({ autoSimple: true });
+
+      act(() => r.current.commitPoint(2));
+      expect(actions.setSimpleMode).toHaveBeenCalledWith(true);
+    });
+  });
+});

--- a/frontend/src/test/useScoreActions.test.tsx
+++ b/frontend/src/test/useScoreActions.test.tsx
@@ -3,7 +3,19 @@ import { renderHook, act } from '@testing-library/react';
 import { useScoreActions } from '../hooks/useScoreActions';
 import type { GameActions } from '../hooks/useGameState';
 import type { Settings } from '../hooks/useSettings';
-import type { HapticPattern } from '../hooks/useHaptics';
+import type { useHaptics } from '../hooks/useHaptics';
+
+// Mirrors the alias inside useScoreActions so a change to the haptics
+// signature surfaces here as a type error instead of drifting silently.
+type Pulse = ReturnType<typeof useHaptics>['pulse'];
+
+interface HookProps {
+  actions: GameActions;
+  settings: Settings;
+  simpleMode: boolean;
+  matchFinished: boolean;
+  pulse: Pulse;
+}
 
 function mockActions(overrides: Partial<GameActions> = {}): GameActions {
   return {
@@ -26,6 +38,8 @@ function mockActions(overrides: Partial<GameActions> = {}): GameActions {
 }
 
 function mockSettings(overrides: Partial<Settings> = {}): Settings {
+  // The hook reads only these three flags; the cast keeps the fixture from
+  // having to restate every unrelated field of Settings.
   return {
     trackPointTypes: false,
     autoSimple: false,
@@ -34,35 +48,26 @@ function mockSettings(overrides: Partial<Settings> = {}): Settings {
   } as Settings;
 }
 
-function mockPulse(): (pattern: HapticPattern | string) => void {
-  return vi.fn();
+function render(overrides: Partial<HookProps> = {}) {
+  const initialProps: HookProps = {
+    actions: mockActions(),
+    settings: mockSettings(),
+    simpleMode: false,
+    matchFinished: false,
+    pulse: vi.fn(),
+    ...overrides,
+  };
+  const view = renderHook((props: HookProps) => useScoreActions(props), { initialProps });
+  return {
+    ...view,
+    /** Re-render with some inputs changed, as a live state push would. */
+    update: (next: Partial<HookProps>) => view.rerender({ ...initialProps, ...next }),
+  };
 }
 
-function render({
-  actions = mockActions(),
-  settings = mockSettings(),
-  simpleMode = false,
-  matchFinished = false,
-  pulse = mockPulse(),
-}: {
-  actions?: GameActions;
-  settings?: Settings;
-  simpleMode?: boolean;
-  matchFinished?: boolean;
-  pulse?: ReturnType<typeof mockPulse>;
-} = {}) {
-  return renderHook(
-    ({ a, s, sm, mf, p }: {
-      a: GameActions;
-      s: Settings;
-      sm: boolean;
-      mf: boolean;
-      p: (pattern: HapticPattern | string) => void;
-    }) => useScoreActions({ actions: a, settings: s, simpleMode: sm, matchFinished: mf, pulse: p }),
-    {
-      initialProps: { a: actions, s: settings, sm: simpleMode, mf: matchFinished, p: pulse },
-    },
-  );
+/** Narrow a mocked action back to its vi.fn() handle. */
+function asMock(fn: unknown): ReturnType<typeof vi.fn> {
+  return fn as ReturnType<typeof vi.fn>;
 }
 
 describe('useScoreActions', () => {
@@ -303,28 +308,59 @@ describe('useScoreActions', () => {
 
   // ------------------------------------------------------------------
   // Callback stability (inputsRef pattern)
+  //
+  // The handlers go into BoardActionsContext, whose memoized value must not
+  // change just because a WebSocket push updated the score. That requires
+  // two properties at once: the identities stay put across re-renders, and
+  // the bodies still read the *current* inputs through inputsRef. A
+  // regression in either direction is a real bug, so both are asserted.
   // ------------------------------------------------------------------
   describe('callback stability through inputsRef', () => {
+    it('keeps every handler identity stable when the inputs change', () => {
+      const { result: r, update } = render();
+      const before = r.current;
+
+      update({
+        actions: mockActions(),
+        settings: mockSettings({ autoSimple: true, trackPointTypes: true }),
+        simpleMode: true,
+        matchFinished: true,
+        pulse: vi.fn(),
+      });
+
+      // Guard against a vacuous pass: the hook really did re-render.
+      expect(r.current).not.toBe(before);
+      expect(r.current.commitPoint).toBe(before.commitPoint);
+      expect(r.current.handleAddPoint).toBe(before.handleAddPoint);
+      expect(r.current.handleAddSet).toBe(before.handleAddSet);
+      expect(r.current.handleAddTimeout).toBe(before.handleAddTimeout);
+      expect(r.current.handleChangeServe).toBe(before.handleChangeServe);
+      expect(r.current.handleDoubleTapScore).toBe(before.handleDoubleTapScore);
+      expect(r.current.handleDoubleTapTimeout).toBe(before.handleDoubleTapTimeout);
+      expect(r.current.setPointPickerTeam).toBe(before.setPointPickerTeam);
+    });
+
+    it('routes through to the replacement actions object, not the captured one', () => {
+      const first = mockActions();
+      const { result: r, update } = render({ actions: first });
+      const second = mockActions();
+
+      update({ actions: second });
+      act(() => r.current.handleAddPoint(1));
+
+      expect(first.addPoint).not.toHaveBeenCalled();
+      expect(second.addPoint).toHaveBeenCalledWith(1, false, undefined, undefined);
+    });
+
     it('reads up-to-date matchFinished from ref on subsequent renders', () => {
       const actions = mockActions();
-      const pulse = vi.fn();
-      const { result: r, rerender } = renderHook(
-        ({ mf }: { mf: boolean }) =>
-          useScoreActions({
-            actions,
-            settings: mockSettings(),
-            simpleMode: false,
-            matchFinished: mf,
-            pulse,
-          }),
-        { initialProps: { mf: false } },
-      );
+      const { result: r, update } = render({ actions });
 
       act(() => r.current.handleAddPoint(1));
       expect(actions.addPoint).toHaveBeenCalledTimes(1);
 
-      (actions.addPoint as ReturnType<typeof vi.fn>).mockClear();
-      rerender({ mf: true });
+      asMock(actions.addPoint).mockClear();
+      update({ matchFinished: true });
 
       act(() => r.current.handleAddPoint(1));
       expect(actions.addPoint).not.toHaveBeenCalled();
@@ -332,25 +368,12 @@ describe('useScoreActions', () => {
 
     it('reads up-to-date autoSimple from ref on subsequent renders', () => {
       const actions = mockActions();
-      const pulse = vi.fn();
-      const { result: r, rerender } = renderHook(
-        ({ autoSimple }: { autoSimple: boolean }) =>
-          useScoreActions({
-            actions,
-            settings: mockSettings({ autoSimple }),
-            simpleMode: false,
-            matchFinished: false,
-            pulse,
-          }),
-        { initialProps: { autoSimple: false } },
-      );
+      const { result: r, update } = render({ actions });
 
       act(() => r.current.commitPoint(1));
       expect(actions.setSimpleMode).not.toHaveBeenCalled();
 
-      (actions.addPoint as ReturnType<typeof vi.fn>).mockClear();
-      (actions.setSimpleMode as ReturnType<typeof vi.fn>).mockClear();
-      rerender({ autoSimple: true });
+      update({ settings: mockSettings({ autoSimple: true }) });
 
       act(() => r.current.commitPoint(2));
       expect(actions.setSimpleMode).toHaveBeenCalledWith(true);

--- a/tests/test_match_report_access.py
+++ b/tests/test_match_report_access.py
@@ -2,8 +2,8 @@
 gate behind ``/match/{id}/report``.
 
 The integration surface (``TestMatchReportAuth`` in ``test_match_report.py``)
-covers the full HTTP stack; this file focuses on the five early-return exits
-in ``cookie_user_owns`` and the three-way decision in ``check_read_access``
+covers the full HTTP stack; this file focuses on the early-return exits in
+``cookie_user_owns`` and the three-way decision in ``check_read_access``
 that the integration suite can only exercise indirectly.
 """
 
@@ -15,10 +15,20 @@ import pytest
 from fastapi import HTTPException, Request
 
 from app.match_report.access import _public_mode_enabled, check_read_access, cookie_user_owns
+from app.overlay_key import make_skey
+
+
+def make_request(cookie: str | None = None) -> MagicMock:
+    """A request stub carrying (or lacking) a ``vsession`` cookie."""
+    req = MagicMock(spec=Request)
+    req.cookies = {} if cookie is None else {"vsession": cookie}
+    return req
+
 
 # ---------------------------------------------------------------------------
 # _public_mode_enabled
 # ---------------------------------------------------------------------------
+
 
 class TestPublicModeEnabled:
     def test_true_when_env_is_true(self, monkeypatch):
@@ -35,107 +45,104 @@ class TestPublicModeEnabled:
 
 
 # ---------------------------------------------------------------------------
-# cookie_user_owns — the five early-return-False exit points
+# cookie_user_owns — every path that denies ownership
 # ---------------------------------------------------------------------------
+
 
 class TestCookieUserOwns:
     """Each test exercises exactly one exit point of ``cookie_user_owns``.
 
     ``cookie_user_owns`` uses lazy imports (``from app.auth import sessions``,
-    ``from app.api import match_archive``, ``from app.api.match_archive``)
-    inside the function body, so we patch the actual source modules rather
-    than ``app.match_report.access``.
+    ``from app.api import match_archive``) inside the function body, so we
+    patch the actual source modules rather than ``app.match_report.access``.
     """
 
-    def _make_request(self, cookie: str | None = None) -> MagicMock:
-        req = MagicMock(spec=Request)
-        req.cookies = {}
-        if cookie is not None:
-            req.cookies["vsession"] = cookie
-        return req
-
-    # Exit 1: match_id is None / falsy — line 29-30
+    # No match id to resolve.
     def test_none_match_id_returns_false(self):
-        assert cookie_user_owns(self._make_request("any"), None) is False
+        assert cookie_user_owns(make_request("any"), None) is False
 
     def test_empty_match_id_returns_false(self):
-        assert cookie_user_owns(self._make_request("any"), "") is False
+        assert cookie_user_owns(make_request("any"), "") is False
 
-    # Exit 2: no session cookie in request — line 35-36
+    # No session cookie on the request.
     def test_no_cookie_returns_false(self):
-        assert cookie_user_owns(self._make_request(None), "match_abc123") is False
+        assert cookie_user_owns(make_request(None), "match_abc123") is False
 
     def test_empty_cookie_returns_false(self):
-        req = self._make_request()
-        req.cookies["vsession"] = ""
-        assert cookie_user_owns(req, "match_abc123") is False
+        assert cookie_user_owns(make_request(""), "match_abc123") is False
 
-    # Exit 3: session cookie does not resolve to a user — line 39-40
+    # Cookie present but does not resolve to a user.
     def test_invalid_session_returns_false(self):
         """A cookie that resolves to no user (e.g. forged)."""
         with patch("app.auth.sessions.resolve_session", return_value=None) as mock_resolve:
-            assert cookie_user_owns(self._make_request("bogus-token"), "match_abc123") is False
+            assert cookie_user_owns(make_request("bogus-token"), "match_abc123") is False
             mock_resolve.assert_called_once()
 
-    # Exit 4: match_id not found in archive — line 44-45
+    # match_id not present in the archive.
     def test_archive_miss_returns_false(self):
         mock_user = MagicMock()
         mock_user.id = 42
 
-        with patch("app.auth.sessions.resolve_session", return_value=mock_user), \
-             patch("app.api.match_archive.load_match", return_value=None):
-            assert cookie_user_owns(self._make_request("valid-session"), "match_missing") is False
+        with (
+            patch("app.auth.sessions.resolve_session", return_value=mock_user),
+            patch("app.api.match_archive.load_match", return_value=None),
+        ):
+            assert cookie_user_owns(make_request("valid-session"), "match_missing") is False
 
-    # Exit 5a: skey missing from payload — line 47-48
+    # Archived payload carries no skey at all.
     def test_payload_without_oid_returns_false(self):
         mock_user = MagicMock()
         mock_user.id = 42
 
-        with patch("app.auth.sessions.resolve_session", return_value=mock_user), \
-             patch("app.api.match_archive.load_match", return_value={"final_state": {}}):
-            assert cookie_user_owns(self._make_request("valid-session"), "match_no_oid") is False
+        with (
+            patch("app.auth.sessions.resolve_session", return_value=mock_user),
+            patch("app.api.match_archive.load_match", return_value={"final_state": {}}),
+        ):
+            assert cookie_user_owns(make_request("valid-session"), "match_no_oid") is False
 
-    # Exit 5b: skey present but invalid — line 47-48
+    # Archived payload carries a skey that does not parse.
     def test_payload_with_invalid_skey_returns_false(self):
         mock_user = MagicMock()
         mock_user.id = 42
 
-        with patch("app.auth.sessions.resolve_session", return_value=mock_user), \
-             patch("app.api.match_archive.load_match",
-                   return_value={"oid": "not-a-valid-skey"}):
-            assert cookie_user_owns(self._make_request("valid-session"), "match_bad_skey") is False
+        with (
+            patch("app.auth.sessions.resolve_session", return_value=mock_user),
+            patch("app.api.match_archive.load_match", return_value={"oid": "not-a-valid-skey"}),
+        ):
+            assert cookie_user_owns(make_request("valid-session"), "match_bad_skey") is False
 
-    # Happy path: owner matches — line 49-50
+    # Happy path: the cookie's user is the skey's owner.
     def test_owner_match_returns_true(self):
-        from app.overlay_key import make_skey
-
         user_id = 42
         skey = make_skey(user_id, "test-oid")
 
         mock_user = MagicMock()
         mock_user.id = user_id
 
-        with patch("app.auth.sessions.resolve_session", return_value=mock_user), \
-             patch("app.api.match_archive.load_match", return_value={"oid": skey}):
-            assert cookie_user_owns(self._make_request("owner-session"), "match_owned") is True
+        with (
+            patch("app.auth.sessions.resolve_session", return_value=mock_user),
+            patch("app.api.match_archive.load_match", return_value={"oid": skey}),
+        ):
+            assert cookie_user_owns(make_request("owner-session"), "match_owned") is True
 
-    # Non-owner user — returns False (owner_id != user.id)
+    # A signed-in user who is not the owner must not read someone else's report.
     def test_non_owner_returns_false(self):
-        from app.overlay_key import make_skey
-
         skey = make_skey(42, "test-oid")  # owner is 42
 
         mock_user = MagicMock()
         mock_user.id = 99  # intruder — not 42
 
-        with patch("app.auth.sessions.resolve_session", return_value=mock_user), \
-             patch("app.api.match_archive.load_match", return_value={"oid": skey}):
-            assert cookie_user_owns(self._make_request("intruder-session"), "match_not_mine") is False
+        with (
+            patch("app.auth.sessions.resolve_session", return_value=mock_user),
+            patch("app.api.match_archive.load_match", return_value={"oid": skey}),
+        ):
+            assert cookie_user_owns(make_request("intruder-session"), "match_not_mine") is False
 
 
 # ---------------------------------------------------------------------------
 # check_read_access — the three-way decision gate
 # ---------------------------------------------------------------------------
+
 
 class TestCheckReadAccess:
     """Test each of the three access paths and the 401 fallback.
@@ -144,69 +151,91 @@ class TestCheckReadAccess:
     ``app.match_report.signing``, so we patch that source module.
     """
 
-    def _make_request(self, cookie: str | None = None) -> MagicMock:
-        req = MagicMock(spec=Request)
-        req.cookies = {}
-        if cookie is not None:
-            req.cookies["vsession"] = cookie
-        return req
-
     # Path 1: public mode — admits anyone
     def test_public_mode_returns_without_raising(self, monkeypatch):
         monkeypatch.setenv("MATCH_REPORT_PUBLIC", "true")
         # Should not raise
-        check_read_access(self._make_request(), "any-match")
+        check_read_access(make_request(), "any-match")
+
+    def test_public_mode_short_circuits_before_any_credential_check(self, monkeypatch):
+        """Public mode must not need — or consult — a cookie or signature."""
+        monkeypatch.setenv("MATCH_REPORT_PUBLIC", "true")
+        with (
+            patch("app.match_report.signing.verify_signed_query") as mock_verify,
+            patch("app.match_report.access.cookie_user_owns") as mock_cookie_owns,
+        ):
+            check_read_access(make_request("some-cookie"), "any-match", exp="1", sig="deadbeef")
+            mock_verify.assert_not_called()
+            mock_cookie_owns.assert_not_called()
 
     # Path 2: signed URL with valid signature
     def test_signed_url_admits_with_valid_signature(self, monkeypatch):
         monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
-        with patch("app.match_report.signing.verify_signed_query", return_value=True):
+        with patch("app.match_report.signing.verify_signed_query", return_value=True) as mock_verify:
             # Should not raise
             check_read_access(
-                self._make_request(),
+                make_request(),
                 "match_signed",
                 exp="1000000000",
                 sig="abcdef123456",
             )
+            # The match id must be bound into the verification, or one valid
+            # signature would unlock every report.
+            mock_verify.assert_called_once_with("match_signed", "1000000000", "abcdef123456")
 
     def test_signed_url_rejects_tampered_signature(self, monkeypatch):
         monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
-        with patch("app.match_report.signing.verify_signed_query", return_value=False), \
-             patch("app.match_report.access.cookie_user_owns", return_value=False):
+        with (
+            patch("app.match_report.signing.verify_signed_query", return_value=False),
+            patch("app.match_report.access.cookie_user_owns", return_value=False),
+        ):
             with pytest.raises(HTTPException) as exc_info:
                 check_read_access(
-                    self._make_request(),
+                    make_request(),
                     "match_signed",
                     exp="1000000000",
                     sig="tampered",
                 )
             assert exc_info.value.status_code == 401
 
+    def test_signed_url_failure_still_falls_back_to_the_owner_cookie(self, monkeypatch):
+        """A stale link must not lock the owner out of their own report."""
+        monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
+        with (
+            patch("app.match_report.signing.verify_signed_query", return_value=False),
+            patch("app.match_report.access.cookie_user_owns", return_value=True),
+        ):
+            # Should not raise
+            check_read_access(make_request("owner"), "match_signed", exp="1", sig="expired")
+
     # Path 3: owner cookie
     def test_owner_cookie_admits(self, monkeypatch):
         monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
         with patch("app.match_report.access.cookie_user_owns", return_value=True):
             # Should not raise
-            check_read_access(self._make_request("owner"), "match_owned")
+            check_read_access(make_request("owner"), "match_owned")
 
     # Fallback: 401 when nothing matches
     def test_raises_401_when_nothing_matches(self, monkeypatch):
         monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
         with patch("app.match_report.access.cookie_user_owns", return_value=False):
             with pytest.raises(HTTPException) as exc_info:
-                check_read_access(self._make_request(), "match_forbidden")
+                check_read_access(make_request(), "match_forbidden")
             assert exc_info.value.status_code == 401
-            assert "WWW-Authenticate" in exc_info.value.headers
+            assert exc_info.value.headers is not None
+            assert exc_info.value.headers["WWW-Authenticate"] == "Cookie"
 
     # Edge: matching both signed URL and cookie — signed takes priority
     def test_signed_url_checked_before_cookie(self, monkeypatch):
         """When both signed params and cookie are present, the signed path
         short-circuits before cookie_user_owns is called."""
         monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
-        with patch("app.match_report.signing.verify_signed_query", return_value=True), \
-             patch("app.match_report.access.cookie_user_owns") as mock_cookie_owns:
+        with (
+            patch("app.match_report.signing.verify_signed_query", return_value=True),
+            patch("app.match_report.access.cookie_user_owns") as mock_cookie_owns,
+        ):
             check_read_access(
-                self._make_request("some-cookie"),
+                make_request("some-cookie"),
                 "match_signed",
                 exp="1000000000",
                 sig="abcdef123456",
@@ -217,14 +246,26 @@ class TestCheckReadAccess:
     # Edge: no match_id together with exp/sig → signed path not entered
     def test_no_match_id_with_exp_sig_skips_signed_path(self, monkeypatch):
         monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
-        with patch("app.match_report.signing.verify_signed_query") as mock_verify, \
-             patch("app.match_report.access.cookie_user_owns", return_value=False):
+        with (
+            patch("app.match_report.signing.verify_signed_query") as mock_verify,
+            patch("app.match_report.access.cookie_user_owns", return_value=False),
+        ):
             with pytest.raises(HTTPException):
                 check_read_access(
-                    self._make_request(),
+                    make_request(),
                     None,  # match_id is None
                     exp="1000000000",
                     sig="abcdef",
                 )
             # verify_signed_query must not be called when match_id is None
+            mock_verify.assert_not_called()
+
+    # Neither exp nor sig present → the signed path is skipped entirely.
+    def test_missing_exp_and_sig_skips_signed_path(self, monkeypatch):
+        monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
+        with (
+            patch("app.match_report.signing.verify_signed_query") as mock_verify,
+            patch("app.match_report.access.cookie_user_owns", return_value=True),
+        ):
+            check_read_access(make_request("owner"), "match_owned")
             mock_verify.assert_not_called()

--- a/tests/test_match_report_access.py
+++ b/tests/test_match_report_access.py
@@ -1,0 +1,230 @@
+"""Direct unit tests for :mod:`app.match_report.access` — the authorization
+gate behind ``/match/{id}/report``.
+
+The integration surface (``TestMatchReportAuth`` in ``test_match_report.py``)
+covers the full HTTP stack; this file focuses on the five early-return exits
+in ``cookie_user_owns`` and the three-way decision in ``check_read_access``
+that the integration suite can only exercise indirectly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, Request
+
+from app.match_report.access import _public_mode_enabled, check_read_access, cookie_user_owns
+
+# ---------------------------------------------------------------------------
+# _public_mode_enabled
+# ---------------------------------------------------------------------------
+
+class TestPublicModeEnabled:
+    def test_true_when_env_is_true(self, monkeypatch):
+        monkeypatch.setenv("MATCH_REPORT_PUBLIC", "true")
+        assert _public_mode_enabled() is True
+
+    def test_false_when_env_is_false(self, monkeypatch):
+        monkeypatch.setenv("MATCH_REPORT_PUBLIC", "false")
+        assert _public_mode_enabled() is False
+
+    def test_false_when_env_is_absent(self, monkeypatch):
+        monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
+        assert _public_mode_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# cookie_user_owns — the five early-return-False exit points
+# ---------------------------------------------------------------------------
+
+class TestCookieUserOwns:
+    """Each test exercises exactly one exit point of ``cookie_user_owns``.
+
+    ``cookie_user_owns`` uses lazy imports (``from app.auth import sessions``,
+    ``from app.api import match_archive``, ``from app.api.match_archive``)
+    inside the function body, so we patch the actual source modules rather
+    than ``app.match_report.access``.
+    """
+
+    def _make_request(self, cookie: str | None = None) -> MagicMock:
+        req = MagicMock(spec=Request)
+        req.cookies = {}
+        if cookie is not None:
+            req.cookies["vsession"] = cookie
+        return req
+
+    # Exit 1: match_id is None / falsy — line 29-30
+    def test_none_match_id_returns_false(self):
+        assert cookie_user_owns(self._make_request("any"), None) is False
+
+    def test_empty_match_id_returns_false(self):
+        assert cookie_user_owns(self._make_request("any"), "") is False
+
+    # Exit 2: no session cookie in request — line 35-36
+    def test_no_cookie_returns_false(self):
+        assert cookie_user_owns(self._make_request(None), "match_abc123") is False
+
+    def test_empty_cookie_returns_false(self):
+        req = self._make_request()
+        req.cookies["vsession"] = ""
+        assert cookie_user_owns(req, "match_abc123") is False
+
+    # Exit 3: session cookie does not resolve to a user — line 39-40
+    def test_invalid_session_returns_false(self):
+        """A cookie that resolves to no user (e.g. forged)."""
+        with patch("app.auth.sessions.resolve_session", return_value=None) as mock_resolve:
+            assert cookie_user_owns(self._make_request("bogus-token"), "match_abc123") is False
+            mock_resolve.assert_called_once()
+
+    # Exit 4: match_id not found in archive — line 44-45
+    def test_archive_miss_returns_false(self):
+        mock_user = MagicMock()
+        mock_user.id = 42
+
+        with patch("app.auth.sessions.resolve_session", return_value=mock_user), \
+             patch("app.api.match_archive.load_match", return_value=None):
+            assert cookie_user_owns(self._make_request("valid-session"), "match_missing") is False
+
+    # Exit 5a: skey missing from payload — line 47-48
+    def test_payload_without_oid_returns_false(self):
+        mock_user = MagicMock()
+        mock_user.id = 42
+
+        with patch("app.auth.sessions.resolve_session", return_value=mock_user), \
+             patch("app.api.match_archive.load_match", return_value={"final_state": {}}):
+            assert cookie_user_owns(self._make_request("valid-session"), "match_no_oid") is False
+
+    # Exit 5b: skey present but invalid — line 47-48
+    def test_payload_with_invalid_skey_returns_false(self):
+        mock_user = MagicMock()
+        mock_user.id = 42
+
+        with patch("app.auth.sessions.resolve_session", return_value=mock_user), \
+             patch("app.api.match_archive.load_match",
+                   return_value={"oid": "not-a-valid-skey"}):
+            assert cookie_user_owns(self._make_request("valid-session"), "match_bad_skey") is False
+
+    # Happy path: owner matches — line 49-50
+    def test_owner_match_returns_true(self):
+        from app.overlay_key import make_skey
+
+        user_id = 42
+        skey = make_skey(user_id, "test-oid")
+
+        mock_user = MagicMock()
+        mock_user.id = user_id
+
+        with patch("app.auth.sessions.resolve_session", return_value=mock_user), \
+             patch("app.api.match_archive.load_match", return_value={"oid": skey}):
+            assert cookie_user_owns(self._make_request("owner-session"), "match_owned") is True
+
+    # Non-owner user — returns False (owner_id != user.id)
+    def test_non_owner_returns_false(self):
+        from app.overlay_key import make_skey
+
+        skey = make_skey(42, "test-oid")  # owner is 42
+
+        mock_user = MagicMock()
+        mock_user.id = 99  # intruder — not 42
+
+        with patch("app.auth.sessions.resolve_session", return_value=mock_user), \
+             patch("app.api.match_archive.load_match", return_value={"oid": skey}):
+            assert cookie_user_owns(self._make_request("intruder-session"), "match_not_mine") is False
+
+
+# ---------------------------------------------------------------------------
+# check_read_access — the three-way decision gate
+# ---------------------------------------------------------------------------
+
+class TestCheckReadAccess:
+    """Test each of the three access paths and the 401 fallback.
+
+    ``check_read_access`` lazy-imports ``verify_signed_query`` from
+    ``app.match_report.signing``, so we patch that source module.
+    """
+
+    def _make_request(self, cookie: str | None = None) -> MagicMock:
+        req = MagicMock(spec=Request)
+        req.cookies = {}
+        if cookie is not None:
+            req.cookies["vsession"] = cookie
+        return req
+
+    # Path 1: public mode — admits anyone
+    def test_public_mode_returns_without_raising(self, monkeypatch):
+        monkeypatch.setenv("MATCH_REPORT_PUBLIC", "true")
+        # Should not raise
+        check_read_access(self._make_request(), "any-match")
+
+    # Path 2: signed URL with valid signature
+    def test_signed_url_admits_with_valid_signature(self, monkeypatch):
+        monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
+        with patch("app.match_report.signing.verify_signed_query", return_value=True):
+            # Should not raise
+            check_read_access(
+                self._make_request(),
+                "match_signed",
+                exp="1000000000",
+                sig="abcdef123456",
+            )
+
+    def test_signed_url_rejects_tampered_signature(self, monkeypatch):
+        monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
+        with patch("app.match_report.signing.verify_signed_query", return_value=False), \
+             patch("app.match_report.access.cookie_user_owns", return_value=False):
+            with pytest.raises(HTTPException) as exc_info:
+                check_read_access(
+                    self._make_request(),
+                    "match_signed",
+                    exp="1000000000",
+                    sig="tampered",
+                )
+            assert exc_info.value.status_code == 401
+
+    # Path 3: owner cookie
+    def test_owner_cookie_admits(self, monkeypatch):
+        monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
+        with patch("app.match_report.access.cookie_user_owns", return_value=True):
+            # Should not raise
+            check_read_access(self._make_request("owner"), "match_owned")
+
+    # Fallback: 401 when nothing matches
+    def test_raises_401_when_nothing_matches(self, monkeypatch):
+        monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
+        with patch("app.match_report.access.cookie_user_owns", return_value=False):
+            with pytest.raises(HTTPException) as exc_info:
+                check_read_access(self._make_request(), "match_forbidden")
+            assert exc_info.value.status_code == 401
+            assert "WWW-Authenticate" in exc_info.value.headers
+
+    # Edge: matching both signed URL and cookie — signed takes priority
+    def test_signed_url_checked_before_cookie(self, monkeypatch):
+        """When both signed params and cookie are present, the signed path
+        short-circuits before cookie_user_owns is called."""
+        monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
+        with patch("app.match_report.signing.verify_signed_query", return_value=True), \
+             patch("app.match_report.access.cookie_user_owns") as mock_cookie_owns:
+            check_read_access(
+                self._make_request("some-cookie"),
+                "match_signed",
+                exp="1000000000",
+                sig="abcdef123456",
+            )
+            # cookie_user_owns must not be called — signed path short-circuits
+            mock_cookie_owns.assert_not_called()
+
+    # Edge: no match_id together with exp/sig → signed path not entered
+    def test_no_match_id_with_exp_sig_skips_signed_path(self, monkeypatch):
+        monkeypatch.delenv("MATCH_REPORT_PUBLIC", raising=False)
+        with patch("app.match_report.signing.verify_signed_query") as mock_verify, \
+             patch("app.match_report.access.cookie_user_owns", return_value=False):
+            with pytest.raises(HTTPException):
+                check_read_access(
+                    self._make_request(),
+                    None,  # match_id is None
+                    exp="1000000000",
+                    sig="abcdef",
+                )
+            # verify_signed_query must not be called when match_id is None
+            mock_verify.assert_not_called()


### PR DESCRIPTION
## Summary

Adds 74 new tests across the three highest-risk test gaps identified in #442.

### Frontend: `useDoubleTap` (27 tests)
Covers the tap/double-tap/long-press state machine behind every score, timeout, and set button.
- Single-tap immediate fire (mouse, touch, Enter, Space)
- Double-tap detection at mousedown within the 280ms window
- Single-tap delay when `onDoubleTap` is provided
- Slow second tap treated as a new first tap
- Keyboard double-tap on Enter
- Long-press fire after 1000ms hold, release-before-threshold no-op, long-press suppressing single and double tap, long-press overriding pending double-tap
- Custom `longPressMs` and `doubleTapMs`
- Gesture priority verification (long-press > double-tap > single-tap)
- Concurrent input guards (touch blocks mouse, 50ms touchActive debounce, keyboard repeat ignored, keyUp without keyDown ignored, non-Enter/Space ignored)
- Cancel press paths (mouseLeave, touchMove clearing touchActive, doubleTapPending reset)
- Cleanup on unmount
- Defensive concurrent press-path clearing

### Frontend: `useScoreActions` (27 tests)
Covers `commitPoint` and the point-type-picker gating for all scoring controls.
- `handleAddPoint`: immediate score, point-type picker gating, matchFinished no-op
- `commitPoint`: tagged scoring (pointType + errorType), autoSimple side-effect
- `handleAddSet`, `handleAddTimeout` (autoSimple + autoSimpleOnTimeout exit), `handleChangeServe`
- `handleDoubleTapScore`/`Timeout` (undo + haptics)
- `pointPickerTeam` state
- inputsRef callback stability across re-renders

### Backend: `match_report_access` (20 tests)
Covers the authorization gate for `/match/{id}/report`.
- `_public_mode_enabled`: true, false, absent env var
- `cookie_user_owns` five early-return-False exits
- Happy path owner match and non-owner rejection
- `check_read_access` three-way gate: public mode, signed URL (valid + tampered), owner cookie, 401 fallback with WWW-Authenticate header
- Edge cases: signed URL short-circuits before cookie check, no match_id with exp/sig skips signed path

Fixes #442.