### PR TITLE
chore(deps): raise the uvicorn floor to 0.52.1 and resync the lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -669,9 +669,24 @@ archive by hand.
 
 ### Dependencies
 
-- **Frontend:** `vite` `8.1.0` → `8.1.5` (patch-level bug fixes; pulls
-  `rolldown` `1.1.3` → `1.1.5`).
-  [#469](https://github.com/JacoboSanchez/volley-overlay-control/pull/469)
+- **Backend runtime:** `sentry-sdk[fastapi]` `>=2.66.0` → `>=2.66.1`
+  (upstream fix for exceptions raised inside `traces_sampler` and other
+  callbacks) and `uvicorn[standard]` `>=0.52.0` → `>=0.52.1`. Only the
+  `uvicorn` floor moved a pin in `requirements.lock` (`0.52.0` →
+  `0.52.1`); the lock already resolved `sentry-sdk` to `2.66.1`.
+  [#483](https://github.com/JacoboSanchez/volley-overlay-control/pull/483),
+  [#484](https://github.com/JacoboSanchez/volley-overlay-control/pull/484)
+- **Frontend:** `vite` `8.1.0` → `8.2.0` (patch-level bug fixes, then the
+  8.2 minor; pulls `rolldown` `1.1.3` → `1.2.3` and `lightningcss`
+  `1.32.0` → `1.33.0`).
+  [#469](https://github.com/JacoboSanchez/volley-overlay-control/pull/469),
+  [#486](https://github.com/JacoboSanchez/volley-overlay-control/pull/486)
+- **Frontend types:** `@types/react` `19.2.17` → `19.2.18` and
+  `@types/react-dom` `19.2.3` → `19.2.4`.
+  [#485](https://github.com/JacoboSanchez/volley-overlay-control/pull/485)
+- **Frontend (transitive, dev-only):** `brace-expansion` `1.1.14` →
+  `1.1.18` and `2.0.3`/`2.1.0` → `2.1.4`.
+  [#481](https://github.com/JacoboSanchez/volley-overlay-control/pull/481)
 - **CI (GitHub Actions):** `docker/login-action` `4.4.0` → `4.6.0`
   (still pinned by commit SHA).
   [#464](https://github.com/JacoboSanchez/volley-overlay-control/pull/464)

--- a/requirements.lock
+++ b/requirements.lock
@@ -76,10 +76,13 @@ starlette==1.3.1
 typing-extensions==4.15.0
     # via
     #   alembic
+    #   anyio
     #   fastapi
+    #   psycopg
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
+    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via
@@ -90,7 +93,7 @@ urllib3==2.7.0
     #   -r requirements.txt
     #   requests
     #   sentry-sdk
-uvicorn==0.52.0
+uvicorn==0.52.1
     # via -r requirements.txt
 uvloop==0.22.1
     # via uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi>=0.141.1
-uvicorn[standard]>=0.52.0
+uvicorn[standard]>=0.52.1
 requests==2.34.2
 # Browser-compatible UTS #46 normalization for CSP frame origins.
 idna>=3.18


### PR DESCRIPTION
## Summary

Unblocks Dependabot's [#484](https://github.com/JacoboSanchez/volley-overlay-control/pull/484) by regenerating `requirements.lock` alongside the `uvicorn` floor it raised, and records the dependency bumps merged today in the changelog.

## Changes

- **Backend runtime:** `uvicorn[standard]` `>=0.52.0` → `>=0.52.1`, with `requirements.lock` resynced (`uvicorn==0.52.0` → `0.52.1`).
- **Changelog:** a `### Dependencies` entry covering this bump plus the four Dependabot PRs already merged to `main` — [#481](https://github.com/JacoboSanchez/volley-overlay-control/pull/481), [#483](https://github.com/JacoboSanchez/volley-overlay-control/pull/483), [#485](https://github.com/JacoboSanchez/volley-overlay-control/pull/485), [#486](https://github.com/JacoboSanchez/volley-overlay-control/pull/486) — which Dependabot PRs do not carry themselves.

Only three files change: `requirements.txt`, `requirements.lock`, `CHANGELOG.md`. The vite, React-types, `sentry-sdk` and `brace-expansion` bumps referenced in the changelog entry are **already on `main`**; this PR documents them, it does not re-apply them. No frontend source or `package-lock.json` change is included.

## Implementation notes

#484 moved `requirements.txt` to `uvicorn[standard]>=0.52.1` but left `requirements.lock` pinning `uvicorn==0.52.0`, so CI's "lockfile satisfies requirements.txt" gate failed the PR outright — uv cannot resolve a floor of `0.52.1` against a `0.52.0` constraint.

That gate exists precisely so a declared CVE floor cannot become fiction while CI and the image keep installing the old pin, so the fix is to regenerate the lock rather than relax the gate. `uv pip compile requirements.txt -o requirements.lock` moves exactly one pin; the remainder of the lock diff is refreshed `# via` attribution comments (`typing-extensions` gaining `anyio`/`psycopg`/`starlette`), with no other version changes.

Merging this should let Dependabot close #484 automatically.

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `mypy` — no issues in 138 source files
- [x] `pytest tests/` — 1391 passed
- [x] Ran CI's lockfile gate locally (`uv pip compile --constraint requirements.lock`, then the pin-set diff) — passes
- [ ] Frontend gates — not applicable, no frontend files touched (CI runs them regardless)

## Checklist

- [x] Added a `CHANGELOG.md` entry under `## [Unreleased]`
- [x] Regenerated screenshots if an operator-facing surface changed — n/a, no visual surface touched
- [x] Updated relevant docs if behaviour changed — n/a, no behaviour change
- [x] No secrets, credentials, or `.env` files committed