### PR TITLE
ci: allow the CI pipeline to be re-run manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,14 @@ on:
     branches: [ "main", "dev" ]
   pull_request:
     branches: [ "main", "dev" ]
+  # Manual re-run. A push-triggered run is the only CI signal main gets, and
+  # that signal can be lost without a single line of code changing: an Actions
+  # capacity incident leaves the jobs queued until they are cancelled, and a
+  # push that lands during one may never spawn a run at all. GitHub cannot
+  # re-run a run that does not exist, so recovering the green build on a
+  # protected branch otherwise means pushing an empty commit. Every other
+  # workflow here already carries this trigger.
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,14 @@ archive by hand.
 
 ### Changed
 
+- **The CI pipeline can be re-run by hand.** `ci.yml` listened only to
+  `push` and `pull_request`, so when an Actions capacity incident left the
+  jobs queued until they were cancelled — or swallowed the push event for a
+  merge outright — `main` was left with no green build and no way to ask for
+  one, because GitHub cannot re-run a run that was never created. The
+  workflow now also accepts `workflow_dispatch`, matching every other
+  workflow in the repository.
+
 - **The config panel's structure now matches its concerns.** The 675-line
   `ConfigPanel.tsx` mixed six of them: the form model, four independent
   remote lookups, history/back interception, save orchestration, the section


### PR DESCRIPTION
The pipeline listened only to push and pull_request. When an Actions
capacity incident holds jobs in the queue until they are cancelled — or
swallows the push event for a merge outright, as happened for the merge
of #490 — main is left with no green build and no way to ask for one:
GitHub cannot re-run a run that was never created, so the only recovery
was an empty commit.

Add workflow_dispatch, which docker-publish.yml, docker-publish-dev.yml
and release.yml already carry. The concurrency group is unchanged, so a
manual run still queues behind an in-flight run on the same ref rather
than cancelling it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MiBeQbbi9Xhps5TMgsDaYp