### PR TITLE
test(audit): one convergence property for the live audit protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,28 @@ archive by hand.
 
 ### Added
 
+- **A property test for the live audit protocol, replacing five one-off
+  regression tests with one invariant.** Review of the audit push protocol
+  found five defects in the seam between the `GET /audit` read, the
+  `audit_append` / `audit_invalidate` frames and the per-OID log lock —
+  including one introduced while fixing another of the same shape. Both
+  halves of that seam are now driven by randomised, seeded interleavings of
+  log mutations (append, undo, rapid-pair tombstone/restore, clear, delete,
+  rotation), transport faults (dropped, duplicated, reordered frames,
+  disconnect/reconnect), transient read failures and board switches, and
+  checked against one property: a client that believes it is current shows
+  exactly what the log holds at the version it holds, and never shows a row
+  the board never logged. `tests/test_audit_convergence_property.py` drives
+  the real `action_log` — lock, tombstone filter, record cache and real
+  rotation included — against a port of the client reducer, and
+  `frontend/src/test/useAuditFeed.property.test.tsx` drives the real
+  `useAuditFeed` hook against a model of the log; only the wire between them
+  is faked. Each of the five reviewed defects is pinned as an injectable
+  regression seed with a test asserting the property fails under it, so the
+  next defect of that shape is caught by the property rather than by
+  remembering to write its one-off test.
+  Fixes [#488](https://github.com/JacoboSanchez/volley-overlay-control/issues/488).
+
 - **Backfilled tests for the three highest-risk untested surfaces.**
   `frontend/src/test/useDoubleTap.test.tsx` covers the press-gesture state
   machine behind every score, timeout and set button — single tap, double

--- a/frontend/src/test/useAuditFeed.property.test.tsx
+++ b/frontend/src/test/useAuditFeed.property.test.tsx
@@ -168,6 +168,15 @@ const DEFECTS: Defect[] = [
   'inconsistent_page_and_version',
 ];
 
+/** The operation that models each defect — see the assertion that uses it. */
+const EXPOSED_BY: Record<Defect, string> = {
+  no_resync_on_open: 'board_open_load_race',
+  frames_from_closed_socket: 'switch_board_mid_flight',
+  // Any read at all: a page and a version that disagree is not tied to a
+  // particular interleaving.
+  inconsistent_page_and_version: 'step',
+};
+
 // ---------------------------------------------------------------------------
 // The walk
 // ---------------------------------------------------------------------------
@@ -200,6 +209,7 @@ const OPS = [
   'reconnect',
   'switch_board',
   'switch_board_mid_flight',
+  'board_open_load_race',
   'read_fault',
   'rotate',
   'clear',
@@ -236,6 +246,10 @@ async function runWalk(seed: number, defect: Defect | null = null): Promise<Walk
   let readFails = false;
   let lastReadOk = false;
   let reads = 0;
+  // Holds the next read's *response* while its page stays sampled at the
+  // moment of the call. See the load-race operation below.
+  let deferNextRead = false;
+  let releaseRead: (() => void) | null = null;
 
   const log = () => logs.get(board)!;
 
@@ -251,7 +265,15 @@ async function runWalk(seed: number, defect: Defect | null = null): Promise<Walk
         throw new Error('Audit log is temporarily unreadable.');
       }
       const source = logs.get(oid)!;
+      // Sampled now, like the server's one lock hold — the response can
+      // land much later, which is what makes a load-time gap possible.
       const { records, version } = source.page(limit);
+      if (deferNextRead) {
+        deferNextRead = false;
+        await new Promise<void>((resolve) => {
+          releaseRead = resolve;
+        });
+      }
       lastReadOk = true;
       pendingLoss = false;
       if (defect === 'inconsistent_page_and_version') {
@@ -303,6 +325,42 @@ async function runWalk(seed: number, defect: Defect | null = null): Promise<Walk
   const openBoard = async (oid: string) => {
     board = oid;
     rerender({ oid });
+    connected = true;
+    pendingLoss = false;
+    if (defect !== 'no_resync_on_open') act(() => result.current.onResync());
+    await settle();
+  };
+
+  /**
+   * Open a board with a mutation landing in the load-time gap.
+   *
+   * The mount read and the socket handshake overlap, so this orders them
+   * the way that hurts: the read samples the log, *then* another client
+   * scores, and only *then* does this socket finish connecting. The frame
+   * for that record is broadcast to a client that is not listening yet,
+   * and the handshake replays the state snapshot, never missed audit rows
+   * — so nothing but the resync on open can close it.
+   *
+   * Without it the board sits on a log one record short while believing it
+   * is current, until the next mutation exposes the gap.
+   */
+  const openBoardWithLoadRace = async (oid: string) => {
+    board = oid;
+    connected = false;
+    deferNextRead = true;
+    rerender({ oid });
+    // The read must be in flight with its page already sampled, or the
+    // mutation below would simply be included and there would be no gap.
+    expect(deferNextRead).toBe(false);
+    logs.get(oid)!.append(1);
+    // Not connected yet: nothing buffers frames for a socket that does not
+    // exist, so this one reaches nobody.
+    queue = [];
+    await act(async () => {
+      releaseRead?.();
+      releaseRead = null;
+    });
+    await settle();
     connected = true;
     pendingLoss = false;
     if (defect !== 'no_resync_on_open') act(() => result.current.onResync());
@@ -366,13 +424,18 @@ async function runWalk(seed: number, defect: Defect | null = null): Promise<Walk
       queue = [];
     },
     reconnect: () => {
+      // Always resyncs, defect or not. #482 (2) was specifically the first
+      // open — reconnects already re-read. Suppressing this one too would
+      // let the defect be caught here, which says nothing about the
+      // load-time gap it is actually about.
       queue = [];
       connected = true;
       pendingLoss = false;
-      if (defect !== 'no_resync_on_open') act(() => result.current.onResync());
+      act(() => result.current.onResync());
     },
     switch_board: () => {},
     switch_board_mid_flight: () => {},
+    board_open_load_race: () => {},
     read_fault: () => {
       readFails = true;
       act(() => result.current.refresh());
@@ -389,6 +452,8 @@ async function runWalk(seed: number, defect: Defect | null = null): Promise<Walk
       const other = board === boards[0] ? boards[1]! : boards[0]!;
       if (op === 'switch_board') {
         await openBoard(other);
+      } else if (op === 'board_open_load_race') {
+        await openBoardWithLoadRace(other);
       } else if (op === 'switch_board_mid_flight') {
         // ``close()`` starts a handshake; it does not drop frames already
         // queued. So the old socket can still fire after the new board's
@@ -476,5 +541,10 @@ describe('useAuditFeed convergence property', () => {
     // Failing here means the property stopped being an instrument for this
     // class of bug — not that the bug is gone.
     expect(caught.length).toBeGreaterThan(0);
+    // …and it has to be caught by the operation that models the race it
+    // names. "Caught" alone is not enough: while the first-open injection
+    // also suppressed the reconnect resync, it was caught there, and the
+    // load-time gap it is actually about went unmodelled.
+    expect(caught[0]).toContain(EXPOSED_BY[defect]);
   });
 });

--- a/frontend/src/test/useAuditFeed.property.test.tsx
+++ b/frontend/src/test/useAuditFeed.property.test.tsx
@@ -1,0 +1,480 @@
+/**
+ * Property test: the audit feed converges to the server's log.
+ *
+ * The client half of ``tests/test_audit_convergence_property.py``. That one
+ * drives the real ``action_log`` against a port of this hook; this one
+ * drives the real hook against a model of the log. Between them, both sides
+ * of the seam #482 found five defects in are exercised by the same
+ * invariant instead of by five one-off tests.
+ *
+ * What is real here: ``useAuditFeed`` itself — its version arithmetic, its
+ * refresh-on-anything-else rule, the abort/replace behaviour of the read
+ * effect, and the board-switch reset. Faked: ``GET /audit`` (served from the
+ * model below) and the socket (frames are handed to the callbacks directly,
+ * which is what lets the walk drop, duplicate, reorder and disconnect).
+ *
+ * The invariant, in the terms this side can observe:
+ *
+ *   1. no phantom rows — every record shown exists in the current board's
+ *      log (this is what a frame from a closed socket violates),
+ *   2. no duplicates and no reordering — timestamps strictly increase,
+ *   3. once caught up, the rows equal ``GET /audit`` exactly, and
+ *   4. once caught up, the *version* held is the log's: probed by pushing
+ *      one contiguous append and requiring it to land without a re-read.
+ *
+ * (4) is the observable form of "the version it holds is the log's
+ * version" — the hook does not expose the counter, but a client holding the
+ * wrong one cannot apply the next push.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { AUDIT_FEED_LIMIT, useAuditFeed } from '../hooks/useAuditFeed';
+import * as apiClient from '../api/board';
+import type { AuditRecord } from '../api/board';
+
+// ---------------------------------------------------------------------------
+// A model of app/api/action_log.py
+// ---------------------------------------------------------------------------
+
+const POP = '_pop';
+const RESTORE = '_restore';
+
+interface Frame {
+  oid: string;
+  event: 'append' | 'invalidate';
+  version: number;
+  record: AuditRecord | null;
+}
+
+/**
+ * The observable contract of the per-OID log: append-only records, pops and
+ * restores as tombstones, a monotonic version bumped by every mutation, and
+ * one frame emitted per mutation — ``append`` only for a plain append, and
+ * ``invalidate`` for everything that changes how records already delivered
+ * should be read (tombstone, restore, clear, delete, rotation).
+ *
+ * Deliberately a model, not a port: the real module is what the pytest half
+ * drives. What has to match is the *protocol*, and that is small enough to
+ * state here in full.
+ */
+class ServerLog {
+  raw: AuditRecord[] = [];
+  version = 0;
+  /** Every ts this board has ever logged. A stale client may still be
+   *  showing a row a later clear/undo/rotation removed — that is ordinary
+   *  staleness. A row this board never logged at all is a phantom. */
+  everLogged = new Set<number>();
+
+  constructor(
+    readonly oid: string,
+    private readonly emit: (frame: Frame) => void,
+    /** Shared across boards: real timestamps are wall-clock, so a record
+     *  from another board can never masquerade as one of ours. */
+    private readonly nextTs: () => number,
+  ) {}
+
+  private bump(event: 'append' | 'invalidate', record: AuditRecord | null) {
+    this.version += 1;
+    this.emit({ oid: this.oid, event, version: this.version, record });
+  }
+
+  append(team: number): AuditRecord {
+    const record = {
+      ts: this.nextTs(),
+      action: 'add_point',
+      params: { team, undo: false },
+    } as unknown as AuditRecord;
+    this.raw.push(record);
+    this.everLogged.add(record.ts);
+    this.bump('append', record);
+    return record;
+  }
+
+  /** Hide the newest visible forward record, as an undo does. */
+  popLastForward(): void {
+    const visible = this.visible();
+    const target = visible[visible.length - 1];
+    if (!target) return;
+    this.raw.push({ ts: this.nextTs(), action: POP, ref_ts: target.ts } as unknown as AuditRecord);
+    this.bump('invalidate', null);
+  }
+
+  tombstone(ts: number): void {
+    this.raw.push({ ts: this.nextTs(), action: POP, ref_ts: ts } as unknown as AuditRecord);
+    this.bump('invalidate', null);
+  }
+
+  restore(ts: number): void {
+    this.raw.push({ ts: this.nextTs(), action: RESTORE, ref_ts: ts } as unknown as AuditRecord);
+    this.bump('invalidate', null);
+  }
+
+  clear(): void {
+    this.raw = [];
+    this.bump('invalidate', null);
+  }
+
+  /** Rotation dropped the oldest slot: history is gone, so this is never
+   *  an append even though the mutation that triggered it was one. */
+  rotate(team: number): void {
+    const record = {
+      ts: this.nextTs(),
+      action: 'add_point',
+      params: { team, undo: false },
+    } as unknown as AuditRecord;
+    this.raw = [...this.raw.slice(Math.ceil(this.raw.length / 2)), record];
+    this.everLogged.add(record.ts);
+    this.bump('invalidate', null);
+  }
+
+  /** Tombstone-filtered view — what ``read_all`` returns. */
+  visible(): AuditRecord[] {
+    const hidden = new Set<number>();
+    for (const r of this.raw) {
+      const action = (r as unknown as { action: string }).action;
+      const ref = (r as unknown as { ref_ts?: number }).ref_ts;
+      if (action === POP && ref !== undefined) hidden.add(ref);
+      else if (action === RESTORE && ref !== undefined) hidden.delete(ref);
+    }
+    return this.raw.filter((r) => {
+      const action = (r as unknown as { action: string }).action;
+      return action !== POP && action !== RESTORE && !hidden.has(r.ts);
+    });
+  }
+
+  /** What ``GET /audit?limit=N`` answers: the newest N records, and the
+   *  version they were read at — sampled together, never separately. */
+  page(limit: number): { records: AuditRecord[]; version: number } {
+    return { records: this.visible().slice(-limit), version: this.version };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Defects
+// ---------------------------------------------------------------------------
+
+/**
+ * The reviewed defects, in the form this side of the seam sees them. The
+ * three read defects (#482 1, 4 and 5) all reach the client as the same
+ * thing — a page and a version that disagree — so they are pinned here as
+ * one, and separately as three in the pytest half where the read is real.
+ */
+type Defect = 'no_resync_on_open' | 'frames_from_closed_socket' | 'inconsistent_page_and_version';
+
+const DEFECTS: Defect[] = [
+  'no_resync_on_open',
+  'frames_from_closed_socket',
+  'inconsistent_page_and_version',
+];
+
+// ---------------------------------------------------------------------------
+// The walk
+// ---------------------------------------------------------------------------
+
+/** Deterministic PRNG — a failing seed reproduces from the test name. */
+function mulberry32(seed: number): () => number {
+  let a = seed + 0x6d2b79f5;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const OPS = [
+  'append',
+  'append',
+  'append',
+  'append',
+  'append',
+  'undo_pop',
+  'undo_pop',
+  'rapid_pair',
+  'drop_frame',
+  'duplicate_frame',
+  'reorder_frames',
+  'disconnect',
+  'reconnect',
+  'switch_board',
+  'switch_board_mid_flight',
+  'read_fault',
+  'rotate',
+  'clear',
+] as const;
+
+type Op = (typeof OPS)[number];
+
+const SEEDS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
+const STEPS = 24;
+
+interface WalkResult {
+  violations: string[];
+  trace: Op[];
+}
+
+async function runWalk(seed: number, defect: Defect | null = null): Promise<WalkResult> {
+  const rand = mulberry32(seed);
+  const violations: string[] = [];
+  const trace: Op[] = [];
+
+  const boards = ['prop-a', 'prop-b'];
+  let queue: Frame[] = [];
+  let tsSeq = 0;
+  const nextTs = () => (tsSeq += 1);
+  const logs = new Map<string, ServerLog>(
+    boards.map((oid) => [oid, new ServerLog(oid, (f) => queue.push(f), nextTs)]),
+  );
+
+  let connected = false;
+  let board = boards[0]!;
+  // A frame lost while connected is only healed by the next frame or the
+  // next read, so liveness is not asserted while this is set.
+  let pendingLoss = false;
+  let readFails = false;
+  let lastReadOk = false;
+  let reads = 0;
+
+  const log = () => logs.get(board)!;
+
+  const getAudit = vi
+    .spyOn(apiClient, 'getAudit')
+    .mockImplementation(async (oid: string, limit: number = AUDIT_FEED_LIMIT) => {
+      reads += 1;
+      if (readFails) {
+        readFails = false;
+        lastReadOk = false;
+        // The route answers an unreadable log with 503 rather than an
+        // empty page at the live version. See app/api/routes/audit.py.
+        throw new Error('Audit log is temporarily unreadable.');
+      }
+      const source = logs.get(oid)!;
+      const { records, version } = source.page(limit);
+      lastReadOk = true;
+      pendingLoss = false;
+      if (defect === 'inconsistent_page_and_version') {
+        // The shape all three read defects present to the client: rows and
+        // counter that do not describe the same moment.
+        return { oid, count: 0, records: [], version } as apiClient.AuditResponse;
+      }
+      return { oid, count: records.length, version, records } as apiClient.AuditResponse;
+    });
+
+  const { result, rerender, unmount } = renderHook(
+    ({ oid }: { oid: string }) => useAuditFeed(oid, true),
+    { initialProps: { oid: board } },
+  );
+
+  /** Let every pending read resolve and every effect it schedules run. */
+  const settle = async () => {
+    let seen = -1;
+    for (let i = 0; i < 25 && seen !== reads; i += 1) {
+      seen = reads;
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    }
+  };
+
+  const dispatch = (frame: Frame) => {
+    if (!connected) return;
+    // The fix for (3) detaches the socket's handlers before closing, so a
+    // frame addressed to a board the client has left never reaches the
+    // callbacks. Under the defect it does.
+    if (frame.oid !== board && defect !== 'frames_from_closed_socket') return;
+    act(() => {
+      if (frame.event === 'append' && frame.record) {
+        result.current.onAppend(frame.version, frame.record);
+      } else {
+        result.current.onInvalidate(frame.version);
+      }
+    });
+  };
+
+  const deliver = () => {
+    const frames = queue;
+    queue = [];
+    frames.forEach(dispatch);
+  };
+
+  const openBoard = async (oid: string) => {
+    board = oid;
+    rerender({ oid });
+    connected = true;
+    pendingLoss = false;
+    if (defect !== 'no_resync_on_open') act(() => result.current.onResync());
+    await settle();
+  };
+
+  const check = (step: number, op: string) => {
+    const rows = result.current.records;
+    const visible = log().visible();
+    const known = log().everLogged;
+    for (const row of rows) {
+      if (!known.has(row.ts)) {
+        violations.push(
+          `step ${step} after ${op}: shows ts=${row.ts}, which board ${board} never logged`,
+        );
+        break;
+      }
+    }
+    for (let i = 1; i < rows.length; i += 1) {
+      if (rows[i]!.ts <= rows[i - 1]!.ts) {
+        violations.push(`step ${step} after ${op}: rows out of order or duplicated at index ${i}`);
+        break;
+      }
+    }
+    const caughtUp = connected && queue.length === 0 && !pendingLoss && lastReadOk;
+    if (!caughtUp) return;
+    const expected = visible.slice(-AUDIT_FEED_LIMIT);
+    if (rows.length !== expected.length || rows.some((r, i) => r.ts !== expected[i]!.ts)) {
+      violations.push(
+        `step ${step} after ${op}: caught up but shows ${rows.length} rows, ` +
+          `GET /audit returns ${expected.length}`,
+      );
+    }
+  };
+
+  const ops: Record<Op, () => void> = {
+    append: () => log().append(rand() < 0.5 ? 1 : 2),
+    undo_pop: () => log().popLastForward(),
+    rapid_pair: () => {
+      const visible = log().visible();
+      if (!visible.length) return;
+      const target = visible[Math.floor(rand() * visible.length)]!;
+      log().tombstone(target.ts);
+      if (rand() < 0.7) log().restore(target.ts);
+    },
+    rotate: () => log().rotate(1),
+    clear: () => log().clear(),
+    drop_frame: () => {
+      if (!queue.length) return;
+      queue.shift();
+      if (connected) pendingLoss = true;
+    },
+    duplicate_frame: () => {
+      if (queue.length) queue.unshift(queue[0]!);
+    },
+    reorder_frames: () => {
+      if (queue.length >= 2) [queue[0], queue[1]] = [queue[1]!, queue[0]!];
+    },
+    disconnect: () => {
+      connected = false;
+      queue = [];
+    },
+    reconnect: () => {
+      queue = [];
+      connected = true;
+      pendingLoss = false;
+      if (defect !== 'no_resync_on_open') act(() => result.current.onResync());
+    },
+    switch_board: () => {},
+    switch_board_mid_flight: () => {},
+    read_fault: () => {
+      readFails = true;
+      act(() => result.current.refresh());
+    },
+  };
+
+  try {
+    await openBoard(board);
+    check(0, 'start');
+
+    for (let step = 1; step <= STEPS; step += 1) {
+      const op = OPS[Math.floor(rand() * OPS.length)]!;
+      trace.push(op);
+      const other = board === boards[0] ? boards[1]! : boards[0]!;
+      if (op === 'switch_board') {
+        await openBoard(other);
+      } else if (op === 'switch_board_mid_flight') {
+        // ``close()`` starts a handshake; it does not drop frames already
+        // queued. So the old socket can still fire after the new board's
+        // read has landed — and with per-board counters that all start at
+        // 0, a stale frame lines up as contiguous often enough to matter.
+        log().append(1);
+        const inFlight = queue;
+        queue = [];
+        await openBoard(other);
+        inFlight.forEach(dispatch);
+      } else {
+        ops[op]();
+      }
+      deliver();
+      await settle();
+      check(step, op);
+    }
+
+    // Eventually: clear every fault, reconnect, and require exact equality.
+    readFails = false;
+    connected = true;
+    queue = [];
+    act(() => result.current.onResync());
+    await settle();
+    const expected = log().visible().slice(-AUDIT_FEED_LIMIT);
+    const rows = result.current.records;
+    if (rows.length !== expected.length || rows.some((r, i) => r.ts !== expected[i]!.ts)) {
+      violations.push(
+        `after a clean reconnect the client shows ${rows.length} rows, ` +
+          `GET /audit returns ${expected.length}`,
+      );
+    }
+
+    // …and holds the log's *version*, not merely its rows: one contiguous
+    // push has to land without a re-read. A client holding a stale counter
+    // would refetch instead, and one holding a counter that has run ahead
+    // would drop the row.
+    const before = reads;
+    const pushed = log().append(1);
+    deliver();
+    await settle();
+    if (reads !== before) {
+      violations.push('a contiguous push forced a re-read: the held version is not the log’s');
+    }
+    if (!result.current.records.some((r) => r.ts === pushed.ts)) {
+      violations.push('a contiguous push was not applied: the held version is not the log’s');
+    }
+  } finally {
+    unmount();
+    getAudit.mockRestore();
+  }
+
+  return { violations, trace };
+}
+
+describe('useAuditFeed convergence property', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(SEEDS)('converges to the log for seed %i', async (seed) => {
+    const { violations } = await runWalk(seed);
+    expect(violations).toEqual([]);
+  });
+
+  it('visits every operation the walk can generate', async () => {
+    // A property that never reaches the interesting states proves nothing.
+    const seen = new Set<Op>();
+    for (const seed of SEEDS.slice(0, 8)) {
+      const { trace } = await runWalk(seed);
+      trace.forEach((op) => seen.add(op));
+    }
+    expect([...seen].sort()).toEqual([...new Set(OPS)].sort());
+  });
+
+  it.each(DEFECTS)('catches the %s defect', async (defect) => {
+    let caught: string[] = [];
+    for (const seed of SEEDS) {
+      const { violations } = await runWalk(seed, defect);
+      if (violations.length) {
+        caught = violations;
+        break;
+      }
+    }
+    // Failing here means the property stopped being an instrument for this
+    // class of bug — not that the bug is gone.
+    expect(caught.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/test_audit_convergence_property.py
+++ b/tests/test_audit_convergence_property.py
@@ -39,9 +39,9 @@ than by remembering to write the matching one-off test.
 
 from __future__ import annotations
 
+import itertools
 import random
 import threading
-import time
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -68,6 +68,9 @@ SEEDS = tuple(range(120))
 # Walk length. Long enough for the log to be cleared, re-grown, rotated and
 # switched away from several times within one walk.
 STEPS = 50
+
+# Hands every walk in the session its own pair of board ids. See ``Walk.run``.
+_WALK_IDS = itertools.count()
 
 
 class Defect(str, Enum):
@@ -296,13 +299,26 @@ def _real_read_page(oid: str, limit: int) -> tuple:
     return action_log.read_page(oid, limit=limit)
 
 
-def _yield_to_writer() -> None:
-    """Widen the window a defect leaves open so a racing writer hits it.
+# Set for exactly one read by ``Walk._op_race_read``; fired by a defective
+# reader at the point where its window is open. A thread cannot be used for
+# this: nothing makes the OS schedule it between the two samples, so a
+# writer that happens to finish first produces no inconsistency and the
+# defect goes uncaught on that run. Firing the mutation *at* the seam, on
+# this thread, is exact — the defective reader is not holding the lock
+# there, which is the whole bug, so the append proceeds normally.
+#
+# The real reader has no seam to fire: its version and page come out of one
+# lock hold. ``_op_race_read`` therefore also runs a genuine writer thread,
+# which is what puts concurrency against the shipped implementation.
+_seam_hook: Callable[[], None] | None = None
 
-    Only the defective copies call this. The real read has no window to
-    widen: the version and the page come out of one lock hold.
-    """
-    time.sleep(0.005)
+
+def _fire_seam() -> None:
+    """Land the armed mutation in the window this defect leaves open."""
+    global _seam_hook
+    hook, _seam_hook = _seam_hook, None
+    if hook is not None:
+        hook()
 
 
 def _read_page_version_outside_lock(oid: str, limit: int) -> tuple:
@@ -311,7 +327,7 @@ def _read_page_version_outside_lock(oid: str, limit: int) -> tuple:
     if path is None:
         return [], None, action_log.version(oid)
     log_version = action_log.version(oid)
-    _yield_to_writer()
+    _fire_seam()
     try:
         with action_log._lock_for(oid):
             records = (
@@ -330,7 +346,7 @@ def _read_page_empty_fast_path_outside_lock(oid: str, limit: int) -> tuple:
     if path is None:
         return [], None, action_log.version(oid)
     if not action_log._has_any_log_file(path):
-        _yield_to_writer()
+        _fire_seam()
         return [], None, action_log.version(oid)
     return _real_read_page(oid, limit)
 
@@ -398,11 +414,21 @@ class Walk:
 
     def run(self) -> list[Violation]:
         rng = random.Random(self.seed)
-        # Fresh OIDs per walk: ``action_log``'s per-OID version counter,
-        # timestamp tracker and record cache are module state that outlives
-        # a single walk. Both boards still start at version 0, which is the
-        # overlap that made defect (3) ordinary rather than exotic.
-        self.boards = (f"walk{self.seed}-a", f"walk{self.seed}-b")
+        # Fresh OIDs per walk, unique across the whole session rather than
+        # only across seeds. ``action_log``'s version counter and timestamp
+        # tracker are module state that ``delete`` bumps rather than
+        # removes, so re-running a seed on the same names would start it
+        # part-way up a counter — and the two boards at *different* points,
+        # destroying the from-zero overlap that makes a stale cross-board
+        # frame line up (defect 3) and making a failing seed behave
+        # differently alone than in the suite. The assertion below keeps
+        # that from silently coming back.
+        uid = next(_WALK_IDS)
+        self.boards = (f"walk{self.seed}n{uid}-a", f"walk{self.seed}n{uid}-b")
+        assert all(action_log.version(b) == 0 for b in self.boards), (
+            "a walk must start from an untouched log: the oracle assumes "
+            "both boards begin at version 0"
+        )
         # version -> what a client reading at that version should be showing.
         # Filled by ``_snapshot`` before every check, so every version the
         # client can legitimately hold has an entry.
@@ -558,18 +584,37 @@ class Walk:
     def _op_race_read(self, rng: random.Random) -> None:
         """A writer landing while the client is re-reading.
 
-        The real ``read_page`` samples the version and builds the page
-        under one lock hold, so this append is ordered entirely before or
-        entirely after the pair — never between them.
+        Two mechanisms, because the two implementations need different
+        things put against them. The real ``read_page`` samples the version
+        and builds the page under one lock hold, so the only meaningful
+        test is a genuine thread: whenever it lands, it must land entirely
+        before or entirely after that hold. A defective reader has a window
+        between its samples, and a thread is not a reliable way to hit a
+        window — so there the mutation is fired *at* the seam, on this
+        thread, which is exact and independent of the scheduler.
         """
+        global _seam_hook
         self.client.refresh()
         oid = self._oid()
-        writer = threading.Thread(target=self._append, args=(oid, rng))
-        writer.start()
+        if self.defect is None:
+            writer = threading.Thread(target=self._append, args=(oid, rng))
+            writer.start()
+            try:
+                self._client_settle()
+            finally:
+                writer.join()
+            return
+        # No thread here on purpose. A defect walk decides whether the
+        # property catches the defect, and a thread would let the scheduler
+        # decide that instead — which seed reports first would move between
+        # runs, and a walk could miss the window entirely.
+        _seam_hook = lambda: self._append(oid, rng)  # noqa: E731
         try:
             self._client_settle()
         finally:
-            writer.join()
+            # A defect with no window to fire into still gets its mutation,
+            # so every walk performs the same operations either way.
+            _fire_seam()
 
     # -- settling and checking -------------------------------------------
 
@@ -762,6 +807,37 @@ class TestPropertyCatchesTheReviewedDefects:
             if walk.violations:
                 return walk
         return None
+
+    @pytest.mark.parametrize(
+        ("defect", "seed"),
+        [
+            (Defect.PAGE_VERSION_OUTSIDE_LOCK, 0),
+            (Defect.EMPTY_FAST_PATH_OUTSIDE_LOCK, 1),
+        ],
+    )
+    def test_a_seam_defect_is_caught_by_the_walk_not_by_the_scheduler(
+        self, defect, seed,
+    ):
+        """The two read defects must be caught identically on every run.
+
+        Both are only visible when a mutation lands *between* the two
+        samples the defective read takes. Leaving that to a writer thread
+        would leave it to the OS: a run where the append finished first
+        produces no inconsistency, so the walk could miss the window
+        entirely and the property would look like it had stopped detecting
+        the defect. The mutation is fired at the seam instead, so the same
+        seed reports the same violations every time.
+
+        Running the same seed twice also pins the other half of that: each
+        walk gets its own board ids, so the second one starts from an
+        untouched log rather than part-way up the first one's counters.
+        """
+        first = _run(seed, defect=defect)
+        second = _run(seed, defect=defect)
+        assert first.violations
+        assert [str(v) for v in first.violations] == [
+            str(v) for v in second.violations
+        ]
 
     @pytest.mark.parametrize("defect", list(Defect))
     def test_defect_is_caught(self, defect):

--- a/tests/test_audit_convergence_property.py
+++ b/tests/test_audit_convergence_property.py
@@ -1,0 +1,799 @@
+"""Property test: the control client's audit view converges to the server's log.
+
+The push protocol (#446 §5) has three moving parts — the ``GET /audit`` read,
+the ``audit_append`` / ``audit_invalidate`` frames on the control socket, and
+the per-OID log lock that orders them. Review of #482 found five defects
+living in the seams *between* those parts, none of which the per-case unit
+tests caught, because each test drove one piece's happy path in isolation.
+Fixing one of them (the empty-log fast path) opened another of the same
+shape, which is the evidence that a per-case instrument is the wrong tool
+here.
+
+This module replaces the per-case instrument with one invariant checked over
+randomised interleavings::
+
+    Safety   — whenever the client holds version V, its records are exactly
+               what the log looked like at version V.
+    Liveness — whenever the client is connected, has heard every frame the
+               log emitted since it connected, and its last read succeeded,
+               it holds the log's current version and the log's records.
+
+Safety is the property that makes a stale view harmless: a client that has
+fallen behind is fine, a client that *believes* it is current while showing
+something the server never had is not. Liveness is what forbids "fell behind
+and never noticed".
+
+**The log is real.** Every mutation goes through ``app.api.action_log`` and
+every read through ``action_log.read_page`` — including the lock, the
+tombstone filter, the parsed-record cache and real rotation. The client is a
+port of ``frontend/src/hooks/useAuditFeed.ts`` (see :class:`ClientFeed`;
+``frontend/src/test/useAuditFeed.property.test.tsx`` runs the same walk
+against the real hook). Only the wire between them is faked, which is what
+lets the walk drop, duplicate, reorder and disconnect at will.
+
+Each of the five reviewed defects is pinned as a :class:`Defect` the harness
+can inject, and each has a test asserting the property *fails* under it —
+so a future regression of that shape is caught by this one property rather
+than by remembering to write the matching one-off test.
+"""
+
+from __future__ import annotations
+
+import random
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from unittest.mock import patch
+
+import pytest
+
+from app.api import action_log
+
+pytestmark = pytest.mark.usefixtures("clean_sessions")
+
+# Mirrors ``AUDIT_FEED_LIMIT`` in frontend/src/hooks/useAuditFeed.ts — the
+# client holds one bounded window, so "equal to the server" means equal to
+# the server's newest ``FEED_LIMIT`` records.
+FEED_LIMIT = 60
+
+# Seeds for the main property. Fixed rather than random so a failure is
+# reproducible from the test name alone, and wide enough that the rarer
+# interleavings (a read fault landing between a board switch and its first
+# frame, say) are actually visited.
+SEEDS = tuple(range(120))
+
+# Walk length. Long enough for the log to be cleared, re-grown, rotated and
+# switched away from several times within one walk.
+STEPS = 50
+
+
+class Defect(str, Enum):
+    """The five defects review of #482 found in this seam.
+
+    Injected by the harness so the property can be shown to catch each one.
+    The names are the bug, not the fix.
+    """
+
+    #: (1) ``read_page`` sampled the version outside the lock that built the
+    #: page, so a concurrent append landed between them: the page carried a
+    #: record the version did not account for, and the client applied that
+    #: record's ``audit_append`` on top of it — twice in the list.
+    PAGE_VERSION_OUTSIDE_LOCK = "page_version_outside_lock"
+
+    #: (2) No resync on the *first* socket open. The mount read and the
+    #: handshake overlap, and a mutation in that window is broadcast to a
+    #: client that is not listening yet.
+    NO_RESYNC_ON_OPEN = "no_resync_on_open"
+
+    #: (3) A closed socket still delivered queued frames, and the audit
+    #: callbacks carry no board identity — so another board's action landed
+    #: in this board's history. Per-board counters all start at 0, which is
+    #: what makes the version line up often enough to matter.
+    FRAMES_FROM_CLOSED_SOCKET = "frames_from_closed_socket"
+
+    #: (4) The empty-log fast path tested for the file outside the lock —
+    #: the same defect as (1) in smaller print, introduced while fixing it.
+    EMPTY_FAST_PATH_OUTSIDE_LOCK = "empty_fast_path_outside_lock"
+
+    #: (5) A failed read answered with an empty page at the *live* version.
+    #: The counter accounts for every record the caller did not get, so the
+    #: client builds on nothing and never sees a gap. Unlike the others this
+    #: one never self-heals.
+    FAILED_READ_KEEPS_LIVE_VERSION = "failed_read_keeps_live_version"
+
+
+# ---------------------------------------------------------------------------
+# The wire — the only faked component
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Frame:
+    """One ``audit_append`` / ``audit_invalidate`` message in flight."""
+
+    oid: str
+    event: str
+    version: int
+    record: dict | None
+
+
+class Wire:
+    """The control socket between ``action_log``'s observer and the client.
+
+    Faked so the walk can inject the transport faults a real socket produces
+    on its own schedule: a dropped frame, a duplicated one, a reordered
+    pair, and a disconnect at an arbitrary point. Nothing buffers frames
+    across a closed socket — a client that was not listening never hears
+    them, which is precisely why the reconnect has to re-read.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.queue: list[Frame] = []
+        self.connected = False
+        self.board: str | None = None
+        # Set when a frame is lost while connected. The protocol only
+        # promises to heal that on the *next* frame or read, so liveness is
+        # not asserted while it is set.
+        self.pending_loss = False
+        # Defect (3): deliver frames regardless of which board they belong to.
+        self.deliver_foreign = False
+
+    def emit(self, frame: Frame) -> None:
+        """Observer callback — may run on any thread, like the real fan-out."""
+        with self._lock:
+            self.queue.append(frame)
+
+    def connect(self, oid: str) -> None:
+        with self._lock:
+            if not self.deliver_foreign:
+                self.queue.clear()
+            self.connected = True
+            self.board = oid
+            # A reconnect is a recovery point: the client re-reads on open,
+            # so whatever was missed while the socket was down is healed.
+            self.pending_loss = False
+
+    def disconnect(self) -> None:
+        with self._lock:
+            self.connected = False
+            if not self.deliver_foreign:
+                self.queue.clear()
+
+    def take(self) -> list[Frame]:
+        with self._lock:
+            frames, self.queue = self.queue, []
+            return frames
+
+    def drop_one(self) -> bool:
+        """Lose the oldest queued frame, as a flaky socket would."""
+        with self._lock:
+            if not self.queue:
+                return False
+            self.queue.pop(0)
+            if self.connected:
+                self.pending_loss = True
+            return True
+
+    def duplicate_one(self) -> bool:
+        with self._lock:
+            if not self.queue:
+                return False
+            self.queue.insert(0, self.queue[0])
+            return True
+
+    def reorder_pair(self) -> bool:
+        with self._lock:
+            if len(self.queue) < 2:
+                return False
+            self.queue[0], self.queue[1] = self.queue[1], self.queue[0]
+            return True
+
+
+# ---------------------------------------------------------------------------
+# The client — a port of useAuditFeed
+# ---------------------------------------------------------------------------
+
+
+class ClientFeed:
+    """Port of ``frontend/src/hooks/useAuditFeed.ts``.
+
+    Same three rules, same order:
+
+    * a pushed record is applied only when its version is exactly one ahead
+      of the version held; anything else re-reads,
+    * an invalidate and a reconnect always re-read,
+    * a failed read clears the records and the held version, because a
+      stale window that silently stops tracking play is worse than an
+      empty one.
+
+    ``refresh`` drops the held version *before* re-reading so a push racing
+    the in-flight read cannot be mistaken for contiguous with the records it
+    is about to replace. The React hook's other asynchrony (an abandoned
+    read resolving after a later one) is not modelled here — that is what
+    the vitest property test drives, against the real hook.
+    """
+
+    def __init__(self, read_page: Callable[[str, int], tuple]) -> None:
+        self._read_page = read_page
+        self.oid: str | None = None
+        self.records: list[dict] = []
+        self.version: int | None = None
+        self.error: str | None = None
+        self.last_read_ok = False
+        self._pending_read = False
+
+    def open_board(self, oid: str) -> None:
+        """Mount on a new board: the previous board's rows leave with it."""
+        self.oid = oid
+        self.records = []
+        self.version = None
+        self.error = None
+        self.last_read_ok = False
+        self._pending_read = True
+
+    def refresh(self) -> None:
+        self.version = None
+        self._pending_read = True
+
+    def on_append(self, version: int, record: dict) -> None:
+        held = self.version
+        if held is None or version != held + 1:
+            self.refresh()
+            return
+        self.version = version
+        records = [*self.records, record]
+        self.records = records[-FEED_LIMIT:] if len(records) > FEED_LIMIT else records
+
+    def on_invalidate(self, _version: int) -> None:
+        self.refresh()
+
+    def on_resync(self) -> None:
+        self.refresh()
+
+    def settle(self) -> None:
+        """Resolve the pending read, if any. One read is enough: nothing
+        mutates while it runs except a deliberately raced writer."""
+        while self._pending_read:
+            self._pending_read = False
+            assert self.oid is not None
+            records, _cursor, version = self._read_page(self.oid, FEED_LIMIT)
+            if version is None:
+                # The route answers a failed read with 503 (see
+                # ``app/api/routes/audit.py``); the hook's catch path clears.
+                self.records = []
+                self.version = None
+                self.error = "unreadable"
+                self.last_read_ok = False
+                continue
+            self.records = list(records)
+            self.version = version
+            self.error = None
+            self.last_read_ok = True
+
+
+# ---------------------------------------------------------------------------
+# Read variants — the real one, and the defective ones being pinned
+# ---------------------------------------------------------------------------
+
+
+def _real_read_page(oid: str, limit: int) -> tuple:
+    return action_log.read_page(oid, limit=limit)
+
+
+def _yield_to_writer() -> None:
+    """Widen the window a defect leaves open so a racing writer hits it.
+
+    Only the defective copies call this. The real read has no window to
+    widen: the version and the page come out of one lock hold.
+    """
+    time.sleep(0.005)
+
+
+def _read_page_version_outside_lock(oid: str, limit: int) -> tuple:
+    """Defect (1): sample the counter, *then* build the page."""
+    path = action_log._path(oid)
+    if path is None:
+        return [], None, action_log.version(oid)
+    log_version = action_log.version(oid)
+    _yield_to_writer()
+    try:
+        with action_log._lock_for(oid):
+            records = (
+                action_log._read_visible_locked(path, oid)
+                if limit > 0 and action_log._has_any_log_file(path)
+                else []
+            )
+    except Exception:
+        return [], None, None
+    return records[-limit:] if limit > 0 else [], None, log_version
+
+
+def _read_page_empty_fast_path_outside_lock(oid: str, limit: int) -> tuple:
+    """Defect (4): test for "no file yet" before taking the lock."""
+    path = action_log._path(oid)
+    if path is None:
+        return [], None, action_log.version(oid)
+    if not action_log._has_any_log_file(path):
+        _yield_to_writer()
+        return [], None, action_log.version(oid)
+    return _real_read_page(oid, limit)
+
+
+def _read_page_failed_read_keeps_live_version(oid: str, limit: int) -> tuple:
+    """Defect (5): answer a failed read with an empty page at the live version."""
+    records, cursor, log_version = _real_read_page(oid, limit)
+    if log_version is None:
+        return [], None, action_log.version(oid)
+    return records, cursor, log_version
+
+
+_READ_VARIANTS: dict[Defect | None, Callable[[str, int], tuple]] = {
+    None: _real_read_page,
+    Defect.PAGE_VERSION_OUTSIDE_LOCK: _read_page_version_outside_lock,
+    Defect.EMPTY_FAST_PATH_OUTSIDE_LOCK: _read_page_empty_fast_path_outside_lock,
+    Defect.FAILED_READ_KEEPS_LIVE_VERSION: _read_page_failed_read_keeps_live_version,
+}
+
+
+# ---------------------------------------------------------------------------
+# The walk
+# ---------------------------------------------------------------------------
+
+# Weighted by how often each happens in a live match: points dominate,
+# undos are common, everything else is occasional. Listed rather than
+# weighted-tupled so a failing seed's op trace reads as plain names.
+OPS: tuple[str, ...] = (
+    "append", "append", "append", "append", "append", "append",
+    "undo_pop", "undo_pop",
+    "rapid_pair",
+    "race_read", "race_read",
+    "drop_frame", "duplicate_frame", "reorder_frames",
+    "disconnect", "reconnect",
+    "switch_board", "switch_board_mid_flight",
+    "read_fault",
+    "rotate",
+    "clear",
+    "delete",
+)
+
+
+@dataclass
+class Violation:
+    step: int
+    op: str
+    kind: str
+    detail: str
+
+    def __str__(self) -> str:  # pragma: no cover - only rendered on failure
+        return f"step {self.step} after {self.op!r}: {self.kind} — {self.detail}"
+
+
+@dataclass
+class Walk:
+    """One randomised interleaving of log mutations, faults and reads."""
+
+    seed: int
+    defect: Defect | None = None
+    steps: int = STEPS
+    violations: list[Violation] = field(default_factory=list)
+    trace: list[str] = field(default_factory=list)
+
+    def run(self) -> list[Violation]:
+        rng = random.Random(self.seed)
+        # Fresh OIDs per walk: ``action_log``'s per-OID version counter,
+        # timestamp tracker and record cache are module state that outlives
+        # a single walk. Both boards still start at version 0, which is the
+        # overlap that made defect (3) ordinary rather than exotic.
+        self.boards = (f"walk{self.seed}-a", f"walk{self.seed}-b")
+        # version -> what a client reading at that version should be showing.
+        # Filled by ``_snapshot`` before every check, so every version the
+        # client can legitimately hold has an entry.
+        self.snapshots: dict[str, dict[int, tuple]] = {b: {} for b in self.boards}
+        self.wire = Wire()
+        self.wire.deliver_foreign = self.defect is Defect.FRAMES_FROM_CLOSED_SOCKET
+        self.client = ClientFeed(_READ_VARIANTS.get(self.defect, _real_read_page))
+        self.next_read_fails = False
+
+        action_log.set_observer(
+            lambda oid, event, version, record: self.wire.emit(
+                Frame(oid, event, version, record),
+            ),
+        )
+        try:
+            self._board_open(self.boards[0])
+            self._settle_and_check(0, "start")
+            for step in range(1, self.steps + 1):
+                op = rng.choice(OPS)
+                self.trace.append(op)
+                getattr(self, f"_op_{op}")(rng)
+                self._settle_and_check(step, op)
+            self._final_convergence_check()
+        finally:
+            action_log.set_observer(None)
+            for board in self.boards:
+                action_log.delete(board)
+        return self.violations
+
+    # -- server-side operations ------------------------------------------
+
+    def _oid(self) -> str:
+        assert self.client.oid is not None
+        return self.client.oid
+
+    def _append(self, oid: str, rng: random.Random | None = None) -> dict | None:
+        team = 1 if rng is None else rng.choice((1, 2))
+        return action_log.append(
+            oid, "add_point", {"team": team, "undo": False}, {"n": team},
+        )
+
+    def _op_append(self, rng: random.Random) -> None:
+        self._append(self._oid(), rng)
+
+    def _op_undo_pop(self, _rng: random.Random) -> None:
+        action_log.pop_last_forward(self._oid(), action_log.UNDOABLE_ACTIONS)
+
+    def _op_rapid_pair(self, rng: random.Random) -> None:
+        """Undo-then-revert inside the 5 s window: tombstone, then restore."""
+        oid = self._oid()
+        visible = action_log.read_all(oid)
+        if not visible:
+            return
+        ref_ts = rng.choice(visible).get("ts")
+        if ref_ts is None:
+            return
+        action_log.tombstone_ts(oid, ref_ts)
+        if rng.random() < 0.7:
+            action_log.restore_popped(oid, ref_ts)
+
+    def _op_clear(self, _rng: random.Random) -> None:
+        action_log.clear(self._oid())
+
+    def _op_delete(self, _rng: random.Random) -> None:
+        action_log.delete(self._oid())
+
+    def _op_rotate(self, rng: random.Random) -> None:
+        """Force a real rotation on the next append.
+
+        Rotation can discard the oldest slot, so the log downgrades the
+        append to an invalidate — a client whose window reaches into the
+        dropped file cannot simply extend it.
+        """
+        with patch.object(action_log, "AUDIT_LOG_MAX_BYTES", 1):
+            self._append(self._oid(), rng)
+
+    # -- transport / client-side operations ------------------------------
+
+    def _board_open(self, oid: str) -> None:
+        self.client.open_board(oid)
+        self.wire.connect(oid)
+        if self.defect is not Defect.NO_RESYNC_ON_OPEN:
+            self.client.on_resync()
+
+    def _op_switch_board(self, _rng: random.Random) -> None:
+        other = self.boards[1] if self.client.oid == self.boards[0] else self.boards[0]
+        self._board_open(other)
+
+    def _op_switch_board_mid_flight(self, rng: random.Random) -> None:
+        """Switch boards with a frame for the old board still in flight.
+
+        ``close()`` starts a handshake; it does not drop frames already
+        queued for delivery. So the old socket can fire *after* the new
+        board's read has landed — and the audit callbacks carry no board
+        identity, so with per-board counters that all start at 0 the stale
+        frame lines up as contiguous often enough to matter. The fix
+        detaches the handlers before closing; here that shows up as the
+        frame being addressed to a board the client is no longer on.
+        """
+        self._append(self._oid(), rng)
+        in_flight = self.wire.take()
+        self._op_switch_board(rng)
+        self._deliver()
+        self._client_settle()
+        for frame in in_flight:
+            self._dispatch(frame)
+
+    def _op_disconnect(self, _rng: random.Random) -> None:
+        self.wire.disconnect()
+
+    def _op_reconnect(self, _rng: random.Random) -> None:
+        if self.wire.connected:
+            self.wire.disconnect()
+        self.wire.connect(self._oid())
+        if self.defect is not Defect.NO_RESYNC_ON_OPEN:
+            self.client.on_resync()
+
+    def _op_drop_frame(self, _rng: random.Random) -> None:
+        self.wire.drop_one()
+
+    def _op_duplicate_frame(self, _rng: random.Random) -> None:
+        self.wire.duplicate_one()
+
+    def _op_reorder_frames(self, _rng: random.Random) -> None:
+        self.wire.reorder_pair()
+
+    def _op_read_fault(self, _rng: random.Random) -> None:
+        """Make the client's next ``GET /audit`` fail transiently."""
+        self.next_read_fails = True
+        self.client.refresh()
+
+    def _op_race_read(self, rng: random.Random) -> None:
+        """A writer landing while the client is re-reading.
+
+        The real ``read_page`` samples the version and builds the page
+        under one lock hold, so this append is ordered entirely before or
+        entirely after the pair — never between them.
+        """
+        self.client.refresh()
+        oid = self._oid()
+        writer = threading.Thread(target=self._append, args=(oid, rng))
+        writer.start()
+        try:
+            self._client_settle()
+        finally:
+            writer.join()
+
+    # -- settling and checking -------------------------------------------
+
+    def _client_settle(self) -> None:
+        if self.next_read_fails:
+            self.next_read_fails = False
+            with patch.object(
+                action_log, "_read_visible_locked", side_effect=OSError("disk gone"),
+            ):
+                self.client.settle()
+            return
+        self.client.settle()
+
+    def _snapshot(self) -> None:
+        """Record what each board's log looks like at its current version."""
+        for board in self.boards:
+            self.snapshots[board][action_log.version(board)] = tuple(
+                action_log.read_all(board)[-FEED_LIMIT:],
+            )
+
+    def _dispatch(self, frame: Frame) -> None:
+        if not self.wire.connected:
+            return
+        if frame.oid != self.client.oid and not self.wire.deliver_foreign:
+            return
+        if frame.event == action_log.EVENT_APPEND and frame.record is not None:
+            self.client.on_append(frame.version, frame.record)
+        else:
+            self.client.on_invalidate(frame.version)
+
+    def _deliver(self) -> None:
+        for frame in self.wire.take():
+            self._dispatch(frame)
+
+    def _settle_and_check(self, step: int, op: str) -> None:
+        self._snapshot()
+        self._deliver()
+        self._client_settle()
+        if self.client.last_read_ok:
+            self.wire.pending_loss = False
+        self._check(step, op)
+
+    def _check(self, step: int, op: str) -> None:
+        client = self.client
+        oid = self._oid()
+        if client.version is not None:
+            expected = self.snapshots[oid].get(client.version)
+            if expected is not None and tuple(client.records) != expected:
+                self.violations.append(Violation(
+                    step, op, "safety",
+                    f"holds version {client.version} with "
+                    f"{len(client.records)} records, but the log at that "
+                    f"version had {len(expected)}",
+                ))
+        caught_up = (
+            self.wire.connected
+            and not self.wire.queue
+            and not self.wire.pending_loss
+            and client.last_read_ok
+        )
+        if not caught_up:
+            return
+        live_version = action_log.version(oid)
+        if client.version != live_version:
+            self.violations.append(Violation(
+                step, op, "liveness",
+                f"caught up but holds version {client.version}, log is at "
+                f"{live_version}",
+            ))
+        live_records = tuple(action_log.read_all(oid)[-FEED_LIMIT:])
+        if tuple(client.records) != live_records:
+            self.violations.append(Violation(
+                step, op, "liveness",
+                f"caught up but shows {len(client.records)} records, "
+                f"GET /audit returns {len(live_records)}",
+            ))
+
+    def _final_convergence_check(self) -> None:
+        """Heal every fault, reconnect, and require the client to be current.
+
+        This is the "eventually" half. A client left empty by a failed read
+        holds no version, so the per-step check cannot judge it — but it
+        must not stay that way once the fault clears and it re-reads.
+        """
+        self.next_read_fails = False
+        self.wire.deliver_foreign = False
+        self._board_open(self._oid())
+        self._deliver()
+        self._client_settle()
+        oid = self._oid()
+        expected = tuple(action_log.read_all(oid)[-FEED_LIMIT:])
+        if tuple(self.client.records) != expected:
+            self.violations.append(Violation(
+                self.steps, "final", "convergence",
+                f"after a clean reconnect the client shows "
+                f"{len(self.client.records)} records, GET /audit returns "
+                f"{len(expected)}",
+            ))
+        if self.client.version != action_log.version(oid):
+            self.violations.append(Violation(
+                self.steps, "final", "convergence",
+                f"after a clean reconnect the client holds version "
+                f"{self.client.version}, log is at {action_log.version(oid)}",
+            ))
+
+
+def _run(seed: int, defect: Defect | None = None, steps: int = STEPS) -> Walk:
+    walk = Walk(seed=seed, defect=defect, steps=steps)
+    walk.run()
+    return walk
+
+
+# ---------------------------------------------------------------------------
+# The property
+# ---------------------------------------------------------------------------
+
+
+class TestAuditConvergenceProperty:
+    @pytest.mark.parametrize("seed", SEEDS)
+    def test_client_converges_to_the_log(self, seed):
+        walk = _run(seed)
+        assert not walk.violations, (
+            f"seed {seed} violated the invariant:\n  "
+            + "\n  ".join(str(v) for v in walk.violations)
+            + f"\n  ops: {walk.trace}"
+        )
+
+    def test_the_walk_actually_exercises_every_operation(self):
+        """A property that never reaches the interesting states proves nothing.
+
+        Cheap insurance against a future edit to ``OPS`` (or to an op that
+        silently becomes a no-op) quietly reducing this file to a very slow
+        way of asserting that appends work.
+        """
+        seen: set[str] = set()
+        for seed in SEEDS[:20]:
+            seen.update(_run(seed).trace)
+        assert seen == set(OPS)
+
+    def test_the_log_is_the_real_one(self):
+        """Guard against the harness drifting into a mock of the thing.
+
+        The walk is only worth its runtime if the reads and mutations it
+        drives are the shipped implementation.
+        """
+        assert _READ_VARIANTS[None] is _real_read_page
+        walk = Walk(seed=0)
+        with patch.object(
+            action_log, "read_page", wraps=action_log.read_page,
+        ) as spy_read, patch.object(
+            action_log, "append", wraps=action_log.append,
+        ) as spy_append:
+            walk.run()
+        assert spy_read.called
+        assert spy_append.called
+
+
+class TestPropertyCatchesTheReviewedDefects:
+    """Each reviewed defect, re-injected, must break the property.
+
+    These are the regression seeds asked for in #488: they pin the five
+    findings of #482 to the one invariant, so the next defect of the same
+    shape is caught by the property instead of by whoever remembers to
+    write its one-off test.
+    """
+
+    @staticmethod
+    def _first_violating_seed(defect: Defect) -> Walk | None:
+        for seed in SEEDS:
+            walk = _run(seed, defect=defect)
+            if walk.violations:
+                return walk
+        return None
+
+    @pytest.mark.parametrize("defect", list(Defect))
+    def test_defect_is_caught(self, defect):
+        walk = self._first_violating_seed(defect)
+        assert walk is not None, (
+            f"the property did not catch {defect.value} in {len(SEEDS)} walks "
+            f"— it is no longer an instrument for this class of bug"
+        )
+
+    def test_a_duplicated_or_reordered_frame_is_not_a_defect(self):
+        """The counter-check: the property must not fire on healthy faults.
+
+        Duplication and reordering are resolved by the version check (one
+        extra read each). A property that flagged them would be measuring
+        the wire, not the protocol, and its failures would carry no signal.
+        """
+        healthy = {"duplicate_frame", "reorder_frames"}
+        seen: set[str] = set()
+        for seed in SEEDS[:20]:
+            walk = _run(seed)
+            assert not walk.violations, f"seed {seed}: {walk.violations[0]}"
+            seen.update(healthy & set(walk.trace))
+        assert seen == healthy
+
+
+class TestConcurrentWriterConvergence:
+    """The same invariant with a real writer thread, not a scripted race.
+
+    ``TestPageVersionAtomicity`` in ``test_audit_broadcast.py`` hammers
+    ``read_page`` against a writer and asserts the page and version agree.
+    This generalises that to the whole loop: the client applies what the
+    reads and frames tell it, and must still land exactly on the log.
+    """
+
+    def test_client_lands_on_the_log_after_a_concurrent_writer(self):
+        oid = "oid-concurrent"
+        wire = Wire()
+        action_log.set_observer(
+            lambda o, e, v, r: wire.emit(Frame(o, e, v, r)),
+        )
+        client = ClientFeed(_real_read_page)
+        try:
+            client.open_board(oid)
+            wire.connect(oid)
+            client.on_resync()
+            client.settle()
+
+            stop = threading.Event()
+
+            def _writer():
+                for i in range(120):
+                    if stop.is_set():
+                        return
+                    action_log.append(
+                        oid, "add_point", {"team": 1, "undo": False}, {"n": i},
+                    )
+
+            writer = threading.Thread(target=_writer)
+            writer.start()
+            try:
+                for _ in range(200):
+                    for frame in wire.take():
+                        if frame.event == action_log.EVENT_APPEND and frame.record:
+                            client.on_append(frame.version, frame.record)
+                        else:
+                            client.on_invalidate(frame.version)
+                    client.settle()
+                    # Safety mid-flight: the client may be behind, but every
+                    # record it holds must be a prefix-consistent tail of the
+                    # log — never a record the log does not have, and never
+                    # one twice.
+                    held = [r["ts"] for r in client.records]
+                    assert held == sorted(set(held))
+            finally:
+                stop.set()
+                writer.join()
+
+            # Quiescent: drain, re-read, and require exact equality.
+            for frame in wire.take():
+                if frame.event == action_log.EVENT_APPEND and frame.record:
+                    client.on_append(frame.version, frame.record)
+                else:
+                    client.on_invalidate(frame.version)
+            client.on_resync()
+            client.settle()
+            assert client.records == action_log.read_all(oid)[-FEED_LIMIT:]
+            assert client.version == action_log.version(oid)
+        finally:
+            action_log.set_observer(None)
+            action_log.delete(oid)

--- a/tests/test_audit_convergence_property.py
+++ b/tests/test_audit_convergence_property.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import random
 import threading
 import time
+from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
@@ -223,7 +224,16 @@ class ClientFeed:
         self.version: int | None = None
         self.error: str | None = None
         self.last_read_ok = False
+        #: Successful reads so far. A dropped frame is healed by the next
+        #: read, so the walk has to tell "a read just landed" from "the
+        #: last read, whenever it was, succeeded".
+        self.reads_ok = 0
         self._pending_read = False
+        # Pushes that arrived non-contiguous with the version held, i.e.
+        # gaps the client actually detected. The walk asserts this is
+        # non-zero, so a transport fault that quietly stops producing gaps
+        # cannot leave the property looking healthy.
+        self.gaps_detected = 0
 
     def open_board(self, oid: str) -> None:
         """Mount on a new board: the previous board's rows leave with it."""
@@ -241,6 +251,8 @@ class ClientFeed:
     def on_append(self, version: int, record: dict) -> None:
         held = self.version
         if held is None or version != held + 1:
+            if held is not None:
+                self.gaps_detected += 1
             self.refresh()
             return
         self.version = version
@@ -272,6 +284,7 @@ class ClientFeed:
             self.version = version
             self.error = None
             self.last_read_ok = True
+            self.reads_ok += 1
 
 
 # ---------------------------------------------------------------------------
@@ -380,6 +393,8 @@ class Walk:
     steps: int = STEPS
     violations: list[Violation] = field(default_factory=list)
     trace: list[str] = field(default_factory=list)
+    #: How many frames each transport fault actually perturbed.
+    faults: Counter = field(default_factory=Counter)
 
     def run(self) -> list[Violation]:
         rng = random.Random(self.seed)
@@ -505,14 +520,35 @@ class Walk:
         if self.defect is not Defect.NO_RESYNC_ON_OPEN:
             self.client.on_resync()
 
-    def _op_drop_frame(self, _rng: random.Random) -> None:
-        self.wire.drop_one()
+    # Every step drains the wire, so a fault operation has to produce the
+    # frames it perturbs — otherwise it acts on an empty queue and is a
+    # silent no-op, which is how a transport fault stops being tested
+    # without any test going red. ``faults`` counts what was actually
+    # perturbed and is asserted non-zero, so that cannot come back.
 
-    def _op_duplicate_frame(self, _rng: random.Random) -> None:
-        self.wire.duplicate_one()
+    def _op_drop_frame(self, rng: random.Random) -> None:
+        """A mutation whose frame is lost in flight.
 
-    def _op_reorder_frames(self, _rng: random.Random) -> None:
-        self.wire.reorder_pair()
+        The log moved; the client is never told. Only the next frame or the
+        next read can heal that, which is why liveness is not asserted
+        until one of them happens.
+        """
+        self._append(self._oid(), rng)
+        if self.wire.drop_one():
+            self.faults["dropped"] += 1
+
+    def _op_duplicate_frame(self, rng: random.Random) -> None:
+        """The same frame delivered twice — the record must not land twice."""
+        self._append(self._oid(), rng)
+        if self.wire.duplicate_one():
+            self.faults["duplicated"] += 1
+
+    def _op_reorder_frames(self, rng: random.Random) -> None:
+        """Two frames delivered newest-first."""
+        self._append(self._oid(), rng)
+        self._append(self._oid(), rng)
+        if self.wire.reorder_pair():
+            self.faults["reordered"] += 1
 
     def _op_read_fault(self, _rng: random.Random) -> None:
         """Make the client's next ``GET /audit`` fail transiently."""
@@ -570,9 +606,13 @@ class Walk:
 
     def _settle_and_check(self, step: int, op: str) -> None:
         self._snapshot()
+        reads_before = self.client.reads_ok
         self._deliver()
         self._client_settle()
-        if self.client.last_read_ok:
+        # A lost frame is healed by the next *read*, not by the memory of an
+        # earlier one — clearing this on ``last_read_ok`` would assert
+        # liveness against a client nothing has re-read for.
+        if self.client.reads_ok > reads_before:
             self.wire.pending_loss = False
         self._check(step, op)
 
@@ -664,14 +704,29 @@ class TestAuditConvergenceProperty:
     def test_the_walk_actually_exercises_every_operation(self):
         """A property that never reaches the interesting states proves nothing.
 
-        Cheap insurance against a future edit to ``OPS`` (or to an op that
-        silently becomes a no-op) quietly reducing this file to a very slow
-        way of asserting that appends work.
+        Appearing in the trace is not enough — an operation can be selected
+        and still do nothing, which is exactly what happened to the three
+        transport faults when they were written to perturb a queue the
+        previous step had already drained. So this also counts the frames
+        each fault really perturbed, and the gaps the client really saw as
+        a result.
         """
         seen: set[str] = set()
+        faults: Counter = Counter()
+        gaps = 0
         for seed in SEEDS[:20]:
-            seen.update(_run(seed).trace)
+            walk = _run(seed)
+            seen.update(walk.trace)
+            faults.update(walk.faults)
+            gaps += walk.client.gaps_detected
         assert seen == set(OPS)
+        assert faults["dropped"] > 0
+        assert faults["duplicated"] > 0
+        assert faults["reordered"] > 0
+        # A fault the client never notices is a fault that tests nothing:
+        # the duplicated and reordered frames must actually be landing on a
+        # client that holds a version to compare them against.
+        assert gaps > 0
 
     def test_the_log_is_the_real_one(self):
         """Guard against the harness drifting into a mock of the thing.

--- a/tests/test_audit_convergence_property.py
+++ b/tests/test_audit_convergence_property.py
@@ -88,7 +88,8 @@ class Defect(str, Enum):
 
     #: (2) No resync on the *first* socket open. The mount read and the
     #: handshake overlap, and a mutation in that window is broadcast to a
-    #: client that is not listening yet.
+    #: client that is not listening yet. Reconnects always re-read, so
+    #: this is only observable through ``_op_board_open_load_race``.
     NO_RESYNC_ON_OPEN = "no_resync_on_open"
 
     #: (3) A closed socket still delivered queued frames, and the audit
@@ -381,7 +382,7 @@ OPS: tuple[str, ...] = (
     "race_read", "race_read",
     "drop_frame", "duplicate_frame", "reorder_frames",
     "disconnect", "reconnect",
-    "switch_board", "switch_board_mid_flight",
+    "switch_board", "switch_board_mid_flight", "board_open_load_race",
     "read_fault",
     "rotate",
     "clear",
@@ -540,9 +541,38 @@ class Walk:
         self.wire.disconnect()
 
     def _op_reconnect(self, _rng: random.Random) -> None:
+        # Always resyncs, defect or not. #482 (2) was specifically the
+        # *first* open: reconnects already re-read. Suppressing this one
+        # too would let the defect be caught here, which would say nothing
+        # about the load-time gap it is actually about — see
+        # ``_op_board_open_load_race``.
         if self.wire.connected:
             self.wire.disconnect()
         self.wire.connect(self._oid())
+        self.client.on_resync()
+
+    def _op_board_open_load_race(self, rng: random.Random) -> None:
+        """Open a board with a mutation landing in the load-time gap.
+
+        The mount read and the socket handshake overlap. This orders them
+        the way that hurts: the read samples the log, *then* another client
+        scores, and only *then* does this socket finish connecting. The
+        frame for that record is broadcast to a client that is not
+        listening yet, and the handshake replays the state snapshot, never
+        missed audit rows — so nothing but the resync on open can close it.
+
+        Without that resync the board sits on a log one record short while
+        believing it is current, until the next mutation exposes the gap.
+        """
+        other = self.boards[1] if self.client.oid == self.boards[0] else self.boards[0]
+        self.client.open_board(other)
+        # The mount read lands before the mutation, which is what makes the
+        # page stale rather than merely early.
+        self._client_settle()
+        self._append(other, rng)
+        # Not connected yet: ``Wire.connect`` drops what was queued, because
+        # nothing buffers frames for a socket that does not exist.
+        self.wire.connect(other)
         if self.defect is not Defect.NO_RESYNC_ON_OPEN:
             self.client.on_resync()
 
@@ -839,12 +869,32 @@ class TestPropertyCatchesTheReviewedDefects:
             str(v) for v in second.violations
         ]
 
+    # The operation that models each defect. Asserted, because "caught" is
+    # not enough on its own: a defect injected in a way that also breaks
+    # some unrelated path gets caught there instead, and then the walk is
+    # not pinning the race it names. #482 (2) is the case in point — while
+    # the injection also suppressed the reconnect resync, it was caught
+    # there, and the load-time gap it is actually about went unmodelled.
+    EXPOSED_BY = {
+        Defect.PAGE_VERSION_OUTSIDE_LOCK: "race_read",
+        Defect.NO_RESYNC_ON_OPEN: "board_open_load_race",
+        Defect.FRAMES_FROM_CLOSED_SOCKET: "switch_board_mid_flight",
+        Defect.EMPTY_FAST_PATH_OUTSIDE_LOCK: "race_read",
+        Defect.FAILED_READ_KEEPS_LIVE_VERSION: "read_fault",
+    }
+
     @pytest.mark.parametrize("defect", list(Defect))
     def test_defect_is_caught(self, defect):
         walk = self._first_violating_seed(defect)
         assert walk is not None, (
             f"the property did not catch {defect.value} in {len(SEEDS)} walks "
             f"— it is no longer an instrument for this class of bug"
+        )
+        assert walk.violations[0].op == self.EXPOSED_BY[defect], (
+            f"{defect.value} was first caught after "
+            f"{walk.violations[0].op!r}, not after "
+            f"{self.EXPOSED_BY[defect]!r} — the walk is catching it "
+            f"somewhere other than the race it is supposed to model"
         )
 
     def test_a_duplicated_or_reordered_frame_is_not_a_defect(self):


### PR DESCRIPTION
Review of #482 found five defects in the seam between the GET /audit
read, the audit_append/audit_invalidate frames and the per-OID log lock.
None was caught by the unit tests or by an end-to-end run, because both
drove each piece's happy path in isolation — and fixing the empty-log
fast path opened another hole of the same shape, which is the evidence
that a per-case instrument is the wrong tool for a combinatorial problem.

Replace it with one invariant, checked over seeded random interleavings
of log mutations (append, undo, rapid-pair tombstone/restore, clear,
delete, rotation), transport faults (drop, duplicate, reorder,
disconnect/reconnect), transient read failures and board switches:

  Safety   — whenever the client holds version V, its records are
             exactly what the log looked like at version V.
  Liveness — whenever it is connected, has heard every frame since it
             connected and its last read succeeded, it holds the log's
             version and the log's records.

tests/test_audit_convergence_property.py drives the real action_log —
lock, tombstone filter, parsed-record cache and real rotation included —
against a port of the useAuditFeed reducer, plus a concurrent-writer walk
that generalises TestPageVersionAtomicity to the whole loop.
frontend/src/test/useAuditFeed.property.test.tsx drives the real hook
against a model of the log, checking the same property in the terms that
side can observe (no phantom rows, no duplicates or reordering, equality
once caught up, and a contiguous-push probe for the held version). Only
the wire between log and client is faked.

Each reviewed defect is pinned as an injectable regression seed with a
test asserting the property fails under it, so a future defect of the
same shape is caught by the property instead of by remembering to write
its one-off test.

Fixes #488

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0139Mr3hv2Wy6J1K6MEgGMYn